### PR TITLE
update the way propagator are informed of value removals

### DIFF
--- a/solver/src/main/java/solver/constraints/propagators/binary/PropAbsolute.java
+++ b/solver/src/main/java/solver/constraints/propagators/binary/PropAbsolute.java
@@ -37,7 +37,6 @@ import solver.exception.ContradictionException;
 import solver.requests.IRequest;
 import solver.variables.EventType;
 import solver.variables.IntVar;
-import solver.variables.delta.IntDelta;
 
 /**
  * Enforces X = |Y|
@@ -86,10 +85,7 @@ public class PropAbsolute extends Propagator<IntVar> {
                 updateUpperBoundofY();
                 updateHolesinY();
             } else {
-                IntDelta delta = vars[idxVarInProp].getDelta();
-                int f = intVarIRequest.fromDelta();
-                int l = intVarIRequest.toDelta();
-                delta.forEach(rem_proc.set(idxVarInProp), f, l);
+                intVarIRequest.forEach(rem_proc.set(idxVarInProp));
 //                updateHolesinY();
             }
         } else { // filter from Y to X
@@ -102,10 +98,7 @@ public class PropAbsolute extends Propagator<IntVar> {
                 updateUpperBoundofX();
                 updateHolesinX();
             } else {
-                IntDelta delta = vars[idxVarInProp].getDelta();
-                int f = intVarIRequest.fromDelta();
-                int l = intVarIRequest.toDelta();
-                delta.forEach(rem_proc.set(idxVarInProp), f, l);
+                intVarIRequest.forEach(rem_proc.set(idxVarInProp));
 //                updateHolesinX();
             }
         }

--- a/solver/src/main/java/solver/constraints/propagators/binary/PropEqualXY_C.java
+++ b/solver/src/main/java/solver/constraints/propagators/binary/PropEqualXY_C.java
@@ -135,9 +135,7 @@ public final class PropEqualXY_C extends Propagator<IntVar> {
                     }
                 }
                 if (EventType.isRemove(mask)) {
-                    int f = request.fromDelta();
-                    int l = request.toDelta();
-                    delta.forEach(rem_proc.set(varIdx), f, l);
+                    request.forEach(rem_proc.set(varIdx));
                 }
             }
         }

--- a/solver/src/main/java/solver/constraints/propagators/binary/PropEqualX_YC.java
+++ b/solver/src/main/java/solver/constraints/propagators/binary/PropEqualX_YC.java
@@ -42,7 +42,6 @@ import solver.explanations.VariableState;
 import solver.requests.IRequest;
 import solver.variables.EventType;
 import solver.variables.IntVar;
-import solver.variables.delta.IntDelta;
 
 /**
  * X = Y + C
@@ -119,10 +118,6 @@ public final class PropEqualX_YC extends Propagator<IntVar> {
     public void propagateOnRequest
             (IRequest<IntVar> request, int varIdx,
              int mask) throws ContradictionException {
-        IntDelta delta = request.getVariable().getDelta();
-        int f = request.fromDelta();
-        int l = request.toDelta();
-
         if (EventType.isInstantiate(mask)) {
             this.awakeOnInst(varIdx);
         } else {
@@ -133,7 +128,7 @@ public final class PropEqualX_YC extends Propagator<IntVar> {
                 this.awakeOnUpp(varIdx);
             }
             if (EventType.isRemove(mask)) {
-                delta.forEach(rem_proc.set(varIdx), f, l);
+                request.forEach(rem_proc.set(varIdx));
             }
         }
     }

--- a/solver/src/main/java/solver/constraints/propagators/gary/PropIntVarsGraphChanneling.java
+++ b/solver/src/main/java/solver/constraints/propagators/gary/PropIntVarsGraphChanneling.java
@@ -126,10 +126,8 @@ public class PropIntVarsGraphChanneling<V extends Variable> extends GraphPropaga
 				g.enforceArc(idxVarInProp, valuesHash.get(intVars[idxVarInProp].getValue()), this, false);
 			}
 			if((mask & (EventType.REMOVE.mask | EventType.INCLOW.mask | EventType.DECUPP.mask)) !=0){
-				IntVar var = (IntVar) request.getVariable();
-				IntDelta d = var.getDelta();
 				valRemoved.set(idxVarInProp);
-				d.forEach(valRemoved, request.fromDelta(), request.toDelta());
+                request.forEach(valRemoved);
 			}
 		}
 	}

--- a/solver/src/main/java/solver/constraints/propagators/nary/PropAllDiffAC.java
+++ b/solver/src/main/java/solver/constraints/propagators/nary/PropAllDiffAC.java
@@ -97,9 +97,7 @@ public class PropAllDiffAC extends Propagator<IntVar> {
         if (EventType.isInstantiate(mask)) {
             struct.updateMatchingOnInstantiation(varIdx, var.getValue(), this);
         } else {
-            int f = request.fromDelta();
-            int l = request.toDelta();
-            delta.forEach(rem_proc.set(varIdx), f, l);
+            request.forEach(rem_proc.set(varIdx));
         }
         forcePropagate();
     }

--- a/solver/src/main/java/solver/constraints/propagators/nary/PropCount.java
+++ b/solver/src/main/java/solver/constraints/propagators/nary/PropCount.java
@@ -37,7 +37,6 @@ import solver.exception.ContradictionException;
 import solver.requests.IRequest;
 import solver.variables.EventType;
 import solver.variables.IntVar;
-import solver.variables.delta.IntDelta;
 
 /**
  * Define a COUNT constraint setting size{forall v in lvars | v = occval} <= or >= or = occVar
@@ -164,11 +163,7 @@ public class PropCount extends Propagator<IntVar> {
                 }
             }
             //assumption : we only get the inst events on all variables except the occurrence variable
-            IntVar var = request.getVariable();
-            IntDelta delta = var.getDelta();
-            int f = request.fromDelta();
-            int l = request.toDelta();
-            delta.forEach(rem_proc.set(vIdx), f, l);
+            request.forEach(rem_proc.set(vIdx));
             checkNbPossible();
         }
 

--- a/solver/src/main/java/solver/constraints/propagators/nary/PropInverseChanneling.java
+++ b/solver/src/main/java/solver/constraints/propagators/nary/PropInverseChanneling.java
@@ -130,9 +130,7 @@ public class PropInverseChanneling extends Propagator<IntVar> {
         if (EventType.isInstantiate(mask)) {
             this.awakeOnInst(varIdx);
         } else {
-            int f = request.fromDelta();
-            int l = request.toDelta();
-            delta.forEach(rem_proc.set(varIdx), f, l);
+            request.forEach(rem_proc.set(varIdx));
         }
     }
 

--- a/solver/src/main/java/solver/constraints/propagators/nary/automaton/PropCostRegular.java
+++ b/solver/src/main/java/solver/constraints/propagators/nary/automaton/PropCostRegular.java
@@ -43,7 +43,6 @@ import solver.exception.ContradictionException;
 import solver.requests.IRequest;
 import solver.variables.EventType;
 import solver.variables.IntVar;
-import solver.variables.delta.IntDelta;
 
 /**
  * <br/>
@@ -105,12 +104,7 @@ public class PropCostRegular extends Propagator<IntVar> {
         if (idxVarInProp == zIdx) { // z only deals with bound events
             boundChange.set(true);
         } else { // other variables only deals with removal events
-            IntVar var = intVarIRequest.getVariable();
-            IntDelta delta = var.getDelta();
-
-            int f = intVarIRequest.fromDelta();
-            int l = intVarIRequest.toDelta();
-            delta.forEach(rem_proc.set(idxVarInProp), f, l);
+            intVarIRequest.forEach(rem_proc.set(idxVarInProp));
         }
         forcePropagate();
     }

--- a/solver/src/main/java/solver/constraints/propagators/nary/automaton/PropMultiCostRegular.java
+++ b/solver/src/main/java/solver/constraints/propagators/nary/automaton/PropMultiCostRegular.java
@@ -55,7 +55,6 @@ import solver.exception.ContradictionException;
 import solver.requests.IRequest;
 import solver.variables.EventType;
 import solver.variables.IntVar;
-import solver.variables.delta.IntDelta;
 
 import java.util.ArrayList;
 import java.util.BitSet;
@@ -288,11 +287,7 @@ public final class PropMultiCostRegular extends Propagator<IntVar> {
     public void propagateOnRequest(IRequest<IntVar> request, int vIdx, int mask) throws ContradictionException {
         if (vIdx < offset) {
             checkWorld();
-            IntVar var = request.getVariable();
-            IntDelta delta = var.getDelta();
-            int f = request.fromDelta();
-            int l = request.toDelta();
-            delta.forEach(rem_proc.set(vIdx), f, l);
+            request.forEach(rem_proc.set(vIdx));
         } else if (EventType.isInstantiate(mask) || EventType.isBound(mask)) {
             boundUpdate.add(vIdx - offset);
             computed = false;

--- a/solver/src/main/java/solver/constraints/propagators/nary/automaton/PropRegular.java
+++ b/solver/src/main/java/solver/constraints/propagators/nary/automaton/PropRegular.java
@@ -41,7 +41,6 @@ import solver.exception.ContradictionException;
 import solver.requests.IRequest;
 import solver.variables.EventType;
 import solver.variables.IntVar;
-import solver.variables.delta.IntDelta;
 
 /**
  * <br/>
@@ -92,12 +91,7 @@ public class PropRegular extends Propagator<IntVar> {
     @Override
     public void propagateOnRequest(IRequest<IntVar> intVarIRequest, int idxVarInProp,
                                    int mask) throws ContradictionException {
-        IntVar var = intVarIRequest.getVariable();
-        IntDelta delta = var.getDelta();
-
-        int f = intVarIRequest.fromDelta();
-        int l = intVarIRequest.toDelta();
-        delta.forEach(rem_proc.set(idxVarInProp), f, l);
+        intVarIRequest.forEach(rem_proc.set(idxVarInProp));
     }
 
     @Override

--- a/solver/src/main/java/solver/constraints/propagators/nary/channeling/PropDomainChanneling.java
+++ b/solver/src/main/java/solver/constraints/propagators/nary/channeling/PropDomainChanneling.java
@@ -39,7 +39,6 @@ import solver.requests.IRequest;
 import solver.variables.BoolVar;
 import solver.variables.EventType;
 import solver.variables.IntVar;
-import solver.variables.delta.IntDelta;
 
 /**
  * Constraints that map the boolean assignments variables (bvars) with the standard assignment variables (var).
@@ -163,11 +162,7 @@ public class PropDomainChanneling extends Propagator<IntVar> {
                 oldsup.set(vars[idxVarInProp].getUB());
             }
             if (EventType.isRemove(mask)) {
-                IntVar var = request.getVariable();
-                IntDelta delta = var.getDelta();
-                int f = request.fromDelta();
-                int l = request.toDelta();
-                delta.forEach(rem_proc, f, l);
+                request.forEach(rem_proc);
             }
         }
 

--- a/solver/src/main/java/solver/constraints/propagators/nary/channeling/PropElementV.java
+++ b/solver/src/main/java/solver/constraints/propagators/nary/channeling/PropElementV.java
@@ -39,7 +39,6 @@ import solver.exception.ContradictionException;
 import solver.requests.IRequest;
 import solver.variables.EventType;
 import solver.variables.IntVar;
-import solver.variables.delta.IntDelta;
 
 /**
  * A class implementing the constraint VALUE = TABLE[INDEX],
@@ -101,11 +100,7 @@ public class PropElementV extends Propagator<IntVar> {
             awakeOnSup(vIdx);
         }
         if (EventType.isRemove(mask)) {
-            IntVar var = request.getVariable();
-            IntDelta delta = var.getDelta();
-            int f = request.fromDelta();
-            int l = request.toDelta();
-            delta.forEach(rem_proc.set(vIdx), f, l);
+            request.forEach(rem_proc.set(vIdx));
         }
     }
 

--- a/solver/src/main/java/solver/constraints/propagators/nary/globalcardinality/PropBoundGlobalCardinality.java
+++ b/solver/src/main/java/solver/constraints/propagators/nary/globalcardinality/PropBoundGlobalCardinality.java
@@ -37,7 +37,6 @@ import solver.exception.ContradictionException;
 import solver.requests.IRequest;
 import solver.variables.EventType;
 import solver.variables.IntVar;
-import solver.variables.delta.IntDelta;
 
 import java.util.Arrays;
 import java.util.Comparator;
@@ -255,11 +254,7 @@ public class PropBoundGlobalCardinality extends Propagator<IntVar> {
             }
         }
         if (idx < nbVars) {
-            IntVar var = request.getVariable();
-            IntDelta delta = var.getDelta();
-            int f = request.fromDelta();
-            int l = request.toDelta();
-            delta.forEach(rem_proc, f, l);
+            request.forEach(rem_proc);
         }
     }
 

--- a/solver/src/main/java/solver/constraints/propagators/nary/globalcardinality/PropBoundGlobalCardinaltyLowUp.java
+++ b/solver/src/main/java/solver/constraints/propagators/nary/globalcardinality/PropBoundGlobalCardinaltyLowUp.java
@@ -34,7 +34,6 @@ import solver.exception.ContradictionException;
 import solver.requests.IRequest;
 import solver.variables.EventType;
 import solver.variables.IntVar;
-import solver.variables.delta.IntDelta;
 
 /**
  * A constraint to enforce BoundConsistency on a global cardinality
@@ -121,11 +120,7 @@ public class PropBoundGlobalCardinaltyLowUp extends PropBoundGlobalCardinality {
             }
             if (EventType.isRemove(mask)) {
                 if (idx < nbVars) {
-                    IntVar var = request.getVariable();
-                    IntDelta delta = var.getDelta();
-                    int f = request.fromDelta();
-                    int l = request.toDelta();
-                    delta.forEach(rem_proc, f, l);
+                    request.forEach(rem_proc);
                 }
             }
         }

--- a/solver/src/main/java/solver/constraints/propagators/nary/globalcardinality/PropGlobalCardinalityAC.java
+++ b/solver/src/main/java/solver/constraints/propagators/nary/globalcardinality/PropGlobalCardinalityAC.java
@@ -117,9 +117,7 @@ public class PropGlobalCardinalityAC extends Propagator<IntVar> {
         if (EventType.isInstantiate(mask)) {
             struct.setMatch(varIdx, var.getValue());
         } else {
-            int f = request.fromDelta();
-            int l = request.toDelta();
-            delta.forEach(rem_proc.set(varIdx), f, l);
+            request.forEach(rem_proc.set(varIdx));
         }
 //        if (getNbRequestEnqued() == 0) {
 //            struct.removeUselessEdges(this);

--- a/solver/src/main/java/solver/constraints/propagators/nary/matching/AbstractBipartiteGraph.java
+++ b/solver/src/main/java/solver/constraints/propagators/nary/matching/AbstractBipartiteGraph.java
@@ -40,7 +40,6 @@ import solver.exception.ContradictionException;
 import solver.requests.IRequest;
 import solver.variables.EventType;
 import solver.variables.IntVar;
-import solver.variables.delta.IntDelta;
 
 import java.text.MessageFormat;
 
@@ -618,16 +617,11 @@ public abstract class AbstractBipartiteGraph extends Propagator<IntVar> {
 
     @Override
     public void propagateOnRequest(IRequest<IntVar> request, int varIdx, int mask) throws ContradictionException {
-        IntDelta delta = request.getVariable().getDelta();
-        int f = request.fromDelta();
-        int l = request.toDelta();
 
         if (EventType.isInstantiate(mask)) {
             this.awakeOnInst(varIdx);
-            delta.forEach(rem_proc.set(varIdx), f, l);
-        } else {
-            delta.forEach(rem_proc.set(varIdx), f, l);
         }
+        request.forEach(rem_proc.set(varIdx));
     }
 
 

--- a/solver/src/main/java/solver/constraints/propagators/ternary/PropMax.java
+++ b/solver/src/main/java/solver/constraints/propagators/ternary/PropMax.java
@@ -37,7 +37,6 @@ import solver.exception.ContradictionException;
 import solver.requests.IRequest;
 import solver.variables.EventType;
 import solver.variables.IntVar;
-import solver.variables.delta.IntDelta;
 
 /**
  * X = MAX(Y,Z)
@@ -84,11 +83,7 @@ public class PropMax extends Propagator<IntVar> {
         } else if (EventType.isDecupp(mask)) {
             this.awakeOnUpp(varIdx);
         } else if (EventType.isRemove(mask)) {
-            IntVar var = request.getVariable();
-            IntDelta delta = var.getDelta();
-            int f = request.fromDelta();
-            int l = request.toDelta();
-            delta.forEach(rem_proc.set(varIdx), f, l);
+            request.forEach(rem_proc.set(varIdx));
         }
     }
 
@@ -141,26 +136,26 @@ public class PropMax extends Propagator<IntVar> {
             val = v0.getValue();
             v1.updateUpperBound(val, this, false);
             v2.updateUpperBound(val, this, false);
-            if (!v1.contains(val)){
+            if (!v1.contains(val)) {
                 v2.instantiateTo(val, this, false);
             }
-            if (!v2.contains(val)){
+            if (!v2.contains(val)) {
                 v1.instantiateTo(val, this, false);
             }
         } else if (idx == 1) {
             val = v1.getValue();
-            if (val > v2.getUB()){
+            if (val > v2.getUB()) {
                 v0.instantiateTo(val, this, false);
                 setPassive();
-            } else{
+            } else {
                 v0.updateUpperBound(Math.max(val, v2.getUB()), this, false);
             }
         } else if (idx == 2) {
             val = v2.getValue();
-            if (val > v1.getUB()){
+            if (val > v1.getUB()) {
                 v0.instantiateTo(val, this, false);
                 setPassive();
-            } else{
+            } else {
                 v0.updateUpperBound(Math.max(val, v1.getUB()), this, false);
             }
         }

--- a/solver/src/main/java/solver/requests/ConditionnalRequest.java
+++ b/solver/src/main/java/solver/requests/ConditionnalRequest.java
@@ -27,6 +27,7 @@
 
 package solver.requests;
 
+import choco.kernel.common.util.procedure.IntProcedure;
 import choco.kernel.memory.IEnvironment;
 import choco.kernel.memory.IStateInt;
 import solver.constraints.propagators.Propagator;
@@ -73,14 +74,15 @@ public class ConditionnalRequest<P extends Propagator<IntVar>> extends AbstractR
         dLast = 0;
     }
 
+
     @Override
-    public int fromDelta() {
-        return frozenFirst;
+    public void forEach(IntProcedure proc) throws ContradictionException {
+        variable.getDelta().forEach(proc, first.get(), last.get());
     }
 
     @Override
-    public int toDelta() {
-        return frozenLast;
+    public void forEach(IntProcedure proc, int from, int to) throws ContradictionException {
+        variable.getDelta().forEach(proc, from, to);
     }
 
     @Override

--- a/solver/src/main/java/solver/requests/EventRequest.java
+++ b/solver/src/main/java/solver/requests/EventRequest.java
@@ -27,6 +27,7 @@
 
 package solver.requests;
 
+import choco.kernel.common.util.procedure.IntProcedure;
 import solver.constraints.propagators.Propagator;
 import solver.exception.ContradictionException;
 import solver.search.loop.AbstractSearchLoop;
@@ -64,13 +65,13 @@ public class EventRequest<V extends Variable, P extends Propagator<V>> extends A
     }
 
     @Override
-    public int fromDelta() {
-        return frozenFirst;
+    public void forEach(IntProcedure proc) throws ContradictionException {
+        variable.getDelta().forEach(proc, frozenFirst, frozenLast);
     }
 
     @Override
-    public int toDelta() {
-        return frozenLast;
+    public void forEach(IntProcedure proc, int from, int to) throws ContradictionException {
+        variable.getDelta().forEach(proc, from, to);
     }
 
     @Override

--- a/solver/src/main/java/solver/requests/GraphRequest.java
+++ b/solver/src/main/java/solver/requests/GraphRequest.java
@@ -27,6 +27,7 @@
 
 package solver.requests;
 
+import choco.kernel.common.util.procedure.IntProcedure;
 import solver.constraints.propagators.Propagator;
 import solver.exception.ContradictionException;
 import solver.search.loop.AbstractSearchLoop;
@@ -60,14 +61,12 @@ public class GraphRequest<V extends GraphVar, P extends Propagator<V>> extends A
     }
 
     @Override
-    @Deprecated
-    public int fromDelta() {
+    public void forEach(IntProcedure proc) throws ContradictionException {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    @Deprecated
-    public int toDelta() {
+    public void forEach(IntProcedure proc, int from, int to) throws ContradictionException {
         throw new UnsupportedOperationException();
     }
 

--- a/solver/src/main/java/solver/requests/IRequest.java
+++ b/solver/src/main/java/solver/requests/IRequest.java
@@ -27,6 +27,7 @@
 
 package solver.requests;
 
+import choco.kernel.common.util.procedure.IntProcedure;
 import solver.constraints.propagators.Propagator;
 import solver.exception.ContradictionException;
 import solver.propagation.IQueable;
@@ -51,12 +52,14 @@ public interface IRequest<V extends Variable> extends Serializable, IQueable {
 
     /**
      * Return the propagator declared in <code>this</code>
+     *
      * @return the propagator
      */
     Propagator<V> getPropagator();
 
     /**
      * Returns the variable declared in <code>this</code>
+     *
      * @return the variable
      */
     V getVariable();
@@ -71,20 +74,24 @@ public interface IRequest<V extends Variable> extends Serializable, IQueable {
 
     /**
      * Return the index of <code>this</code> in the requests list of the variable
+     *
      * @return index of <code>this</code> in the list of requests of the variable
      */
     int getIdxInVar();
 
     /**
      * Update the index of <code>this</code> in the list of requests of the variable to <code>idx</code>
+     *
      * @param idx new index
      */
     void setIdxInVar(int idx);
 
 
     int getIdxVarInProp();
+
     /**
      * Return the propagation conditions mask of the declared propagator
+     *
      * @return propagation conditions maks of the propagator
      */
     int getMask();
@@ -92,14 +99,15 @@ public interface IRequest<V extends Variable> extends Serializable, IQueable {
     /**
      * Call the filtering algorithm of the declared propagator.
      * Must prepare the propagator to be called.
+     *
      * @throws ContradictionException if a contradiction occurs during call to filtering algorithm
      */
     void filter() throws ContradictionException;
 
     /**
      * Inform <code>this</code> on its variable modification
-     * @param e event occured on the variable
      *
+     * @param e event occured on the variable
      */
     void update(EventType e);
 
@@ -114,16 +122,22 @@ public interface IRequest<V extends Variable> extends Serializable, IQueable {
     void desactivate();
 
     /**
-     * Return the index, in the delta of the variable, of the first element removed but not propagated
-     * @return index, in the delta of the variable, of the first element removed but not propagated
+     * Execute a given procedure <code>proc</code> for every value removed from the variable and not yet propagated
+     * @param proc procedure to execute
+     * @throws ContradictionException if a contradiction occurs.
      */
-    int fromDelta();
+    void forEach(IntProcedure proc) throws ContradictionException;
 
     /**
-     * Return the index, in the delta of the variable, of the last element removed but not propagated
-     * @return index, in the delta of the variable, of the last element removed but not propagated
+     * Execute a given procedure <code>proc</code> for every value removed from the variable between the index <code>from</code>
+     * to the index <code>to</code>.
+     * <br/> <b>For advanced users only!</b>
+     * @param proc procedure to execute
+     * @param from from index (inclusive) regarding values already propagated by the propagator
+     * @param to   from index (exclusive) regarding values already propagated by the propagator
+     * @throws ContradictionException if a contradiction occurs.
      */
-    int toDelta();
+    void forEach(IntProcedure proc, int from, int to) throws ContradictionException;
 
     IPropagationEngine getPropagationEngine();
 

--- a/solver/src/main/java/solver/requests/PropRequest.java
+++ b/solver/src/main/java/solver/requests/PropRequest.java
@@ -27,6 +27,7 @@
 
 package solver.requests;
 
+import choco.kernel.common.util.procedure.IntProcedure;
 import solver.constraints.propagators.Propagator;
 import solver.exception.ContradictionException;
 import solver.propagation.engines.IPropagationEngine;
@@ -72,12 +73,12 @@ public final class PropRequest<V extends Variable, P extends Propagator<V>> impl
     }
 
     @Override
-    public int fromDelta() {
+    public void forEach(IntProcedure proc) throws ContradictionException {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public int toDelta() {
+    public void forEach(IntProcedure proc, int from, int to) throws ContradictionException {
         throw new UnsupportedOperationException();
     }
 

--- a/solver/src/main/java/solver/requests/ViewRequestWrapper.java
+++ b/solver/src/main/java/solver/requests/ViewRequestWrapper.java
@@ -26,6 +26,7 @@
  */
 package solver.requests;
 
+import choco.kernel.common.util.procedure.IntProcedure;
 import solver.constraints.propagators.Propagator;
 import solver.exception.ContradictionException;
 import solver.propagation.engines.IPropagationEngine;
@@ -119,13 +120,13 @@ public class ViewRequestWrapper implements IRequest<IntVar> {
     }
 
     @Override
-    public int fromDelta() {
-        return original.fromDelta();
+    public void forEach(IntProcedure proc) throws ContradictionException {
+        original.forEach(proc);
     }
 
     @Override
-    public int toDelta() {
-        return original.toDelta();
+    public void forEach(IntProcedure proc, int from, int to) throws ContradictionException {
+        original.forEach(proc, from, to);
     }
 
     @Override

--- a/solver/src/main/java/solver/requests/conditions/CondAllDiffBC.java
+++ b/solver/src/main/java/solver/requests/conditions/CondAllDiffBC.java
@@ -40,9 +40,9 @@ public class CondAllDiffBC extends AbstractCondition {
     @Override
     void update(ConditionnalRequest request, int evtMask) {
         if(EventType.isRemove(evtMask)){
-            for (int i = request.fromDelta(); i <= request.toDelta(); i++) {
-                unionset.remove(i);
-            }
+//            for (int i = request.fromDelta(); i <= request.toDelta(); i++) {
+//                unionset.remove(i);
+//            }
         }
     }
 

--- a/solver/src/main/java/solver/variables/delta/GraphDelta.java
+++ b/solver/src/main/java/solver/variables/delta/GraphDelta.java
@@ -27,55 +27,63 @@
 
 package solver.variables.delta;
 
-public class GraphDelta implements IGraphDelta{
+import choco.kernel.common.util.procedure.IntProcedure;
+import solver.exception.ContradictionException;
 
-	//***********************************************************************************
-	// VARIABLES
-	//***********************************************************************************
+public class GraphDelta implements IGraphDelta {
 
-	private IntDelta nodeEnf,nodeRem,arcEnf,arcRem;
-	
-	//***********************************************************************************
-	// CONSTRUCTORS
-	//***********************************************************************************
+    //***********************************************************************************
+    // VARIABLES
+    //***********************************************************************************
 
-	public GraphDelta(){
-		nodeEnf = new Delta();
-		nodeRem = new Delta();
-		arcEnf = new Delta();
-		arcRem = new Delta();
-	}
-	
-	//***********************************************************************************
-	// METHODS
-	//***********************************************************************************
+    private IntDelta nodeEnf, nodeRem, arcEnf, arcRem;
 
-	@Override
-	public int size() {
-		throw new UnsupportedOperationException();
-	}
+    //***********************************************************************************
+    // CONSTRUCTORS
+    //***********************************************************************************
 
-	//***********************************************************************************
-	// ACCESSORS
-	//***********************************************************************************
+    public GraphDelta() {
+        nodeEnf = new Delta();
+        nodeRem = new Delta();
+        arcEnf = new Delta();
+        arcRem = new Delta();
+    }
 
-	@Override
-	public IntDelta getNodeRemovalDelta() {
-		return nodeRem;
-	}
+    //***********************************************************************************
+    // METHODS
+    //***********************************************************************************
 
-	@Override
-	public IntDelta getNodeEnforcingDelta() {
-		return nodeEnf;
-	}
+    @Override
+    public int size() {
+        throw new UnsupportedOperationException();
+    }
 
-	@Override
-	public IntDelta getArcRemovalDelta() {
-		return arcRem;
-	}
+    @Override
+    public void forEach(IntProcedure proc, int from, int to) throws ContradictionException {
+        throw new UnsupportedOperationException();
+    }
 
-	@Override
-	public IntDelta getArcEnforcingDelta() {
-		return arcEnf;
-	}
+    //***********************************************************************************
+    // ACCESSORS
+    //***********************************************************************************
+
+    @Override
+    public IntDelta getNodeRemovalDelta() {
+        return nodeRem;
+    }
+
+    @Override
+    public IntDelta getNodeEnforcingDelta() {
+        return nodeEnf;
+    }
+
+    @Override
+    public IntDelta getArcRemovalDelta() {
+        return arcRem;
+    }
+
+    @Override
+    public IntDelta getArcEnforcingDelta() {
+        return arcEnf;
+    }
 }

--- a/solver/src/main/java/solver/variables/delta/IDelta.java
+++ b/solver/src/main/java/solver/variables/delta/IDelta.java
@@ -27,6 +27,9 @@
 
 package solver.variables.delta;
 
+import choco.kernel.common.util.procedure.IntProcedure;
+import solver.exception.ContradictionException;
+
 import java.io.Serializable;
 
 /**
@@ -43,4 +46,14 @@ public interface IDelta extends Serializable{
      */
     int size();
 
+    /**
+     * Execute a given procedure <code>proc</code> for every value removed from the variable between the index <code>from</code>
+     * to the index <code>to</code>.
+     * <br/> <b>For advanced users only!</b>
+     * @param proc procedure to execute
+     * @param from from index (inclusive) regarding values already propagated by the propagator
+     * @param to   from index (exclusive) regarding values already propagated by the propagator
+     * @throws ContradictionException if a contradiction occurs.
+     */
+    void forEach(IntProcedure proc, int from, int to) throws ContradictionException;
 }

--- a/solver/src/test/java/solver/requests/RequestListTest.java
+++ b/solver/src/test/java/solver/requests/RequestListTest.java
@@ -28,6 +28,7 @@
 package solver.requests;
 
 import choco.kernel.ESat;
+import choco.kernel.common.util.procedure.IntProcedure;
 import choco.kernel.memory.IEnvironment;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -71,13 +72,13 @@ public class RequestListTest {
         }
 
         @Override
-        public int fromDelta() {
-            return 0;
+        public void forEach(IntProcedure proc) throws ContradictionException {
+            throw new UnsupportedOperationException();
         }
 
         @Override
-        public int toDelta() {
-            return 0;
+        public void forEach(IntProcedure proc, int from, int to) throws ContradictionException {
+            throw new UnsupportedOperationException();
         }
     }
 


### PR DESCRIPTION
remove getters fromDelta and toDelta from requests.
Action on value removed should be done using #forEach(proc).
Advanced uses can be done using #forEach(proc, from, to) (eg. for
ConditionnalRequest)

GraphRequest throws exception! (a refactoring should be considered).
