### PR TITLE
Creating a bit set would create an array instead due to a missing return...

### DIFF
--- a/choco-solver/src/main/java/util/objects/setDataStructures/SetFactory.java
+++ b/choco-solver/src/main/java/util/objects/setDataStructures/SetFactory.java
@@ -84,7 +84,7 @@ public class SetFactory {
                 case DOUBLE_LINKED_LIST:
                     return new Set_Std_2LinkedList(environment);
                 case BITSET:
-                    new Set_Std_BitSet(environment, maximumSize);
+                    return new Set_Std_BitSet(environment, maximumSize);
                 case BOOL_ARRAY:
                     return new Set_Std_Array(environment, maximumSize);
             }


### PR DESCRIPTION
It's impossible to create a SetVariable with bit set envelope/kernel without this fix.
