### PR TITLE
Int Channeling always throws NullPointerException in constructor.

### DIFF
--- a/choco-solver/src/main/java/solver/constraints/propagators/set/PropIntChannel.java
+++ b/choco-solver/src/main/java/solver/constraints/propagators/set/PropIntChannel.java
@@ -90,8 +90,8 @@ public class PropIntChannel extends Propagator<Variable> {
             this.idm[i] = this.ints[i].monitorDelta(this);
         }
         for (int i = 0; i < nSets; i++) {
-            this.sdm[i] = this.sets[i].monitorDelta(this);
             this.sets[i] = (SetVar) vars[i];
+            this.sdm[i] = this.sets[i].monitorDelta(this);
         }
         // procedures
         elementForced = new IntProcedure() {
@@ -175,9 +175,9 @@ public class PropIntChannel extends Propagator<Variable> {
                 sets[ints[idx].getValue() - offSet1].addToKernel(idx + offSet2, aCause);
             }
             idx += offSet2;
-            idm[idxVarInProp].freeze();
-            idm[idxVarInProp].forEach(valRem, EventType.REMOVE);
-            idm[idxVarInProp].unfreeze();
+            idm[idxVarInProp - nSets].freeze();
+            idm[idxVarInProp - nSets].forEach(valRem, EventType.REMOVE);
+            idm[idxVarInProp - nSets].unfreeze();
         }
     }
 


### PR DESCRIPTION
The constructor always fails with a NullPointerException due to wrong order of initialization.

Propogation on the integer variables are using the wrong variable ids.

My Choco3 knowledge is not very good so hopefully these changes are correct.
