### PR TITLE
Fixed all different propogator for sets.

### DIFF
--- a/choco-solver/src/main/java/solver/constraints/propagators/set/PropAllDiff.java
+++ b/choco-solver/src/main/java/solver/constraints/propagators/set/PropAllDiff.java
@@ -98,7 +98,7 @@ public class PropAllDiff extends Propagator<SetVar> {
                         int nbSameInKer = 0;
                         int diff = -1;
                         for (int j=vars[idx].getKernelFirst(); j!=SetVar.END; j=vars[idx].getKernelNext())
-                            if (!vars[i].envelopeContains(j)){
+                            if (vars[i].kernelContains(j)){
                                 nbSameInKer++;
 							}else{
                                 diff = j;


### PR DESCRIPTION
The propagator produces incorrect results. Here's a snippet of code that displays the bug.

``` java
public static void main(String[] args) {
    Solver solver = new Solver();

    SetVar[] children = new SetVar[2];
    for (int i = 0; i < children.length; i++) {
        children[i] = VariableFactory.set("child" + i, new int[]{0, 1, 2, 3, 4}, solver);
    }
    solver.post(SetConstraintsFactory.all_different(children));
    solver.set(SetStrategyFactory.setLex(children));

    int solutions = 0;
    int wrong = 0;
    if (solver.findSolution()) {
        do {
            if (!ESat.TRUE.equals(solver.isEntailed())) {
                wrong++;
                System.out.println(solver);
            }
            solutions++;
        } while (solver.nextSolution());
    }

    System.out.println(wrong + "/" + solutions);
}
```

The last print statement outputs "26/878". The expected output is "0/992".
