### PR TITLE
Fixed remove-from-env events not propagating when instantiating set vars

### DIFF
--- a/choco-solver/src/main/java/solver/variables/SetVarImpl.java
+++ b/choco-solver/src/main/java/solver/variables/SetVarImpl.java
@@ -174,9 +174,9 @@ public class SetVarImpl extends AbstractVariable<SetDelta, SetVar> implements Se
             contradiction(cause, null, "");
         }
         if (envelope.getSize() != value.length) {
-            for (int i = envelope.getFirstElement(); i >= 0; i = envelope.getNextElement()) {
-                if (!kernel.contain(i)) {
-                    envelope.remove(i);
+            for (int i = getEnvelopeFirst(); i != END; i = getEnvelopeNext()) {
+                if (!kernelContains(i)) {
+                    removeFromEnvelope(i, cause);
                 }
             }
         }


### PR DESCRIPTION
The issue is that elements removed from the envelope are not propagated. The instaniateTo method in SetVarImpl uses envelope.remove which does not propagate the events. The fix I provided uses the removeFromEnvelope method which does propagate properly. The smallest example I can think of showing this problem:

``` java
public static void main(String[] args) {
    Solver solver = new Solver();

    SetVar svar1 = VariableFactory.set("svar1", new int[]{0, 1, 2, 3, 4, 5}, new int[]{3, 4}, solver);
    SetVar svar2 = VariableFactory.set("svar2", new int[]{0, 1, 2, 3, 4, 5}, new int[]{3, 4}, solver);
    SetVar svar3 = VariableFactory.set("svar3", new int[]{0, 1, 2, 3, 4, 5}, new int[]{5}, solver);

    Constraint con = new Constraint(new Variable[]{svar1, svar2}, solver);
    Dud dud = new Dud(svar1, svar2);
    con.setPropagators(dud);
    solver.post(SetConstraintsFactory.union(new SetVar[]{svar1, svar2}, svar3));
    solver.post(con);
    // svar3 is not a decision variable
    solver.set(SetStrategyFactory.setLex(new SetVar[]{svar1, svar2}));

    // Should say no solution because svar1 = svar2 = {3, 4} and svar3 contains 5 hence
    // svar3 cannot be the union of svar1 and svar2
    System.out.println(solver.findSolution() ? "Found solution" : "No solution");
    System.out.println(solver);
}

/**
 * Instantiates the variables to {3, 4}
 */
private static class Dud extends Propagator<SetVar> {

    public Dud(SetVar... vars) {
        super(vars, PropagatorPriority.UNARY);
    }

    @Override
    public int getPropagationConditions(int vIdx) {
        return EventType.ALL_FINE_EVENTS.strengthened_mask;
    }

    @Override
    public void propagate(int evtmask) throws ContradictionException {
        System.out.println("propagate : " + evtmask);

        for (SetVar var : vars) {
            var.instantiateTo(new int[]{3, 4}, aCause);
        }
    }

    @Override
    public void propagate(int idxVarInProp, int mask) throws ContradictionException {
        System.out.println("propagateVar : " + idxVarInProp + " : " + mask);
    }

    @Override
    public ESat isEntailed() {
        return ESat.TRUE;
    }
}
```

The program will find a solution even though there isn't one.

The fix I provided is the most obvious solution although inefficient since removeFromEnvelope also does an unecessary kernelContains check (we've already checked that in the if statement).
