### PR TITLE
Fixed if-then-else not activating its propagators.

### DIFF
--- a/choco-solver/src/main/java/solver/constraints/propagators/reified/PropImplied.java
+++ b/choco-solver/src/main/java/solver/constraints/propagators/reified/PropImplied.java
@@ -82,11 +82,13 @@ public class PropImplied extends Propagator<Variable> {
             ESat sat = trueCons.isEntailed();
             if (sat == ESat.FALSE) {
                 bVar.setToFalse(aCause);
+                reifCons.activate(1);
                 setPassive();
             }
             sat = falseCons.isEntailed();
             if (sat == ESat.FALSE) {
                 bVar.setToTrue(aCause);
+                reifCons.activate(0);
                 setPassive();
             }
         }


### PR DESCRIPTION
IfThenElse is bugged because it is not activating the "then" or "else" propagators when the other is not entailed. For example:

``` java
public static void main(String[] args) {
    Solver solver = new Solver();
    BoolVar v = VariableFactory.bool("v", solver);
    IntVar i1 = VariableFactory.enumerated("i1", 0, 10, solver);
    IntVar i2 = VariableFactory.enumerated("i2", 0, 10, solver);
    solver.post(LogicalConstraintFactory.ifThenElse(v,
            IntConstraintFactory.arithm(i1, "=", 3),
            IntConstraintFactory.arithm(i2, "=", 3)));
    solver.post(LogicalConstraintFactory.ifThenElse(v,
            IntConstraintFactory.arithm(i2, "=", 0),
            IntConstraintFactory.arithm(i1, "=", 0)));

    solver.set(IntStrategyFactory.firstFail_InDomainMin(new IntVar[]{i1, i2}));

    if (solver.findSolution()) {
        do {
            System.out.println(solver);
        } while (solver.nextSolution());
    }
}
```

Should have exactly two solutions: (i1=3, i2=0) and (i1=0, i2=3). The current implementation has a ton of solutions.
