### PR TITLE
Fixed BoolNotView not conforming to its interface.

### DIFF
--- a/choco-solver/src/main/java/solver/variables/view/BoolNotView.java
+++ b/choco-solver/src/main/java/solver/variables/view/BoolNotView.java
@@ -164,12 +164,18 @@ public final class BoolNotView extends IntView<IEnumDelta, BoolVar<IEnumDelta>> 
 
     @Override
     public int nextValue(int v) {
-        return var.previousValue(1 - v);
+        if(v < 0 && contains(0)) {
+            return 0;
+        }
+        return v <= 0 && contains(1) ? 1 : Integer.MAX_VALUE;
     }
 
     @Override
     public int previousValue(int v) {
-        return var.nextValue(1 - v);
+        if(v > 1 && contains(1)) {
+            return 1;
+        }
+        return v >= 1 && contains(0) ? 0 : Integer.MIN_VALUE;
     }
 
     @Override


### PR DESCRIPTION
BoolNotView's nextValue and previousValue do not conform to its interface. nextValue should return Integer.MAX_VALUE when it is out of values, but currently it is returning Integer.MIN_VALUE for such cases. Likewise, prevValue is returning the wrong value. As a result, the following program will be stuck in an infinite loop.

``` java
public static void main(String[] args) {
    Solver solver = new Solver();
    BoolVar a = VF.bool("a", solver);
    BoolVar b = VF.bool("b", solver);
    solver.post(ICF.arithm(a, "+", VF.not(b), "=", 2));
    System.out.println(solver.findSolution());
}
```
