### PR TITLE
Fixed PropIntMemberSet

### DIFF
--- a/choco-solver/src/main/java/solver/constraints/propagators/set/PropIntMemberSet.java
+++ b/choco-solver/src/main/java/solver/constraints/propagators/set/PropIntMemberSet.java
@@ -172,10 +172,10 @@ public class PropIntMemberSet extends Propagator<Variable> {
 					}
 				}
 			}
-			if(w1 != def){
+			if(w1 != def && w2 == def){
 				set.addToKernel(w1,aCause);
 				iv.instantiateTo(w1,aCause);
-			}else{
+			}else if (w1 == def) {
 				contradiction(iv,"");
 			}
 		}


### PR DESCRIPTION
PropIntMemberSet is incorrect when there are exactly two values in the set's envelope that are also in the integer's domain. For example, the following program should have 2 solutions, but currently only has 1.

``` java
public static void main(String[] args) {
    Solver solver = new Solver();
    IntVar i = VF.enumerated("i", 0, 1, solver);
    SetVar s = VF.set("s", new int[]{0, 1}, new int[]{0, 1}, solver);
    solver.post(SCF.member(i, s));
    solver.set(
            new StrategiesSequencer(solver.getEnvironment(),
            SetStrategyFactory.setLex(new SetVar[]{s}),
            IntStrategyFactory.firstFail_InDomainMax(new IntVar[]{i})));
    if (solver.findSolution()) {
        do {
            System.out.println(solver);
        } while (solver.nextSolution());
    }
}
```
