### PR TITLE
Fixed match method.

### DIFF
--- a/choco-solver/src/main/java/solver/constraints/binary/PropEqualXY_C.java
+++ b/choco-solver/src/main/java/solver/constraints/binary/PropEqualXY_C.java
@@ -145,7 +145,7 @@ public final class PropEqualXY_C extends Propagator<IntVar> {
 
     private boolean match() {
         int lb = x.getLB();
-        int ub = y.getUB();
+        int ub = x.getUB();
         for (; lb <= ub; lb = x.nextValue(lb)) {
             if (y.contains(cste - lb)) return true;
         }

--- a/choco-solver/src/main/java/solver/constraints/binary/PropEqualX_YC.java
+++ b/choco-solver/src/main/java/solver/constraints/binary/PropEqualX_YC.java
@@ -153,7 +153,7 @@ public final class PropEqualX_YC extends Propagator<IntVar> {
 
     private boolean match() {
         int lb = x.getLB();
-        int ub = y.getUB();
+        int ub = x.getUB();
         for (; lb <= ub; lb = x.nextValue(lb)) {
             if (y.contains(lb - cste)) return true;
         }


### PR DESCRIPTION
isEntailed returns the wrong value. For example:

``` java
public static void main(String[] args) {
    Solver s = new Solver();
    IntVar three = VF.fixed(3, s);
    IntVar two = VF.fixed(2, s);
    s.post(ICF.arithm(three, "-", two, "=", 1));
    System.out.println(s.findSolution());
    System.out.println(s.isEntailed());
}
```

Prints "true \n false". It should print "true \n true".
