### PR TITLE
Constants zero and one do not raise contradictions

### DIFF
--- a/choco-solver/src/main/java/solver/variables/view/BoolConstantView.java
+++ b/choco-solver/src/main/java/solver/variables/view/BoolConstantView.java
@@ -65,12 +65,12 @@ public class BoolConstantView extends ConstantView implements BoolVar<IntDelta> 
 
     @Override
     public boolean setToTrue(ICause cause) throws ContradictionException {
-        return false;
+        return instantiateTo(1, cause);
     }
 
     @Override
     public boolean setToFalse(ICause cause) throws ContradictionException {
-        return false;
+        return instantiateTo(0, cause);
     }
 
     @Override


### PR DESCRIPTION
For example:

``` java
public static void main(String[] args) {
    Solver solver = new Solver();
    UndirectedGraphVar g = new UndirectedGraphVar("g", solver, 2, true);
    BoolVar b0 = VF.one(solver);
    BoolVar b1 = VF.zero(solver);
    BoolVar b2 = VF.zero(solver);
    BoolVar b3 = VF.one(solver);
    g.getEnvelopGraph().addEdge(0, 1);

    // Forbid the edge (0, 1)
    Constraint c = new Constraint(new Variable[]{g, b0, b1, b2, b3}, solver);
    c.setPropagators(new PropGraphBool(g, new BoolVar[][]{
        new BoolVar[]{b0, b1},
        new BoolVar[]{b2, b3}
    }));
    solver.post(c);

    solver.set(GraphStrategyFactory.graphLexico(g));
    if (solver.findSolution()) {
        System.out.println("Found a solution! Entailed? " + solver.isEntailed());
    } else {
        System.out.println("No solution!");
    }
}
```

Currently it prints: "Found a solution! Entailed? FALSE".
After the fix it prints: "No solution!"
