### PR TITLE
Generalize the set variable selection strategy

### DIFF
--- a/choco-solver/src/main/java/solver/search/strategy/SetStrategyFactory.java
+++ b/choco-solver/src/main/java/solver/search/strategy/SetStrategyFactory.java
@@ -27,6 +27,8 @@
 
 package solver.search.strategy;
 
+import solver.search.strategy.selectors.VariableSelector;
+import solver.search.strategy.selectors.variables.InputOrder;
 import solver.search.strategy.strategy.set.SetSearchStrategy;
 import solver.search.strategy.strategy.set.SetValSelector;
 import solver.search.strategy.strategy.set.SetVarSelector;
@@ -53,8 +55,8 @@ public final class SetStrategyFactory {
 	 * @param enforceFirst	branching order true = enforce first; false = remove first
 	 * @return a strategy to instantiate sets
 	 */
-	public static SetSearchStrategy generic(SetVar[] sets, SetVarSelector varS, SetValSelector valS, boolean enforceFirst){
-		return new SetSearchStrategy(sets,varS,valS, enforceFirst);
+	public static SetSearchStrategy generic(SetVar[] sets, VariableSelector<SetVar> varS, SetValSelector valS, boolean enforceFirst){
+		return new SetSearchStrategy(varS,valS, enforceFirst);
 	}
 
 	/**
@@ -63,7 +65,7 @@ public final class SetStrategyFactory {
 	 * @return a strategy to instantiate sets
 	 */
 	public static SetSearchStrategy force_first(SetVar[] sets){
-		return new SetSearchStrategy(sets,new SetVarSelector.FirstVar(), new SetValSelector.FirstVal(),true);
+		return new SetSearchStrategy(new InputOrder<>(sets), new SetValSelector.FirstVal(),true);
 	}
 
 	/**
@@ -72,7 +74,7 @@ public final class SetStrategyFactory {
 	 * @return a strategy to instantiate sets
 	 */
 	public static SetSearchStrategy remove_first(SetVar[] sets){
-		return new SetSearchStrategy(sets,new SetVarSelector.FirstVar(), new SetValSelector.FirstVal(),false);
+		return new SetSearchStrategy(new InputOrder<>(sets), new SetValSelector.FirstVal(),false);
 	}
 
 	/**
@@ -83,7 +85,7 @@ public final class SetStrategyFactory {
 	 * @return a strategy to instantiate sets
 	 */
 	public static SetSearchStrategy force_minDelta_first(SetVar[] sets){
-		return new SetSearchStrategy(sets,new SetVarSelector.MinDelta(), new SetValSelector.FirstVal(),true);
+		return new SetSearchStrategy(new SetVarSelector.MinDelta(sets), new SetValSelector.FirstVal(),true);
 	}
 
 	/**
@@ -94,6 +96,6 @@ public final class SetStrategyFactory {
 	 * @return a strategy to instantiate sets
 	 */
 	public static SetSearchStrategy force_maxDelta_first(SetVar[] sets){
-		return new SetSearchStrategy(sets,new SetVarSelector.MaxDelta(), new SetValSelector.FirstVal(),true);
+		return new SetSearchStrategy(new SetVarSelector.MaxDelta(sets), new SetValSelector.FirstVal(),true);
 	}
 }

--- a/choco-solver/src/main/java/solver/search/strategy/selectors/variables/InputOrder.java
+++ b/choco-solver/src/main/java/solver/search/strategy/selectors/variables/InputOrder.java
@@ -29,7 +29,7 @@ package solver.search.strategy.selectors.variables;
 
 import memory.IStateInt;
 import solver.search.strategy.selectors.VariableSelector;
-import solver.variables.IntVar;
+import solver.variables.Variable;
 
 /**
  * <b>Input order</b> variable selector.
@@ -39,26 +39,26 @@ import solver.variables.IntVar;
  * @author Charles Prud'homme
  * @since 2 juil. 2010
  */
-public class InputOrder implements VariableSelector<IntVar> {
+public class InputOrder<V extends Variable> implements VariableSelector<V> {
 
-    IntVar[] variables;
+    V[] variables;
 
     IStateInt index;
 
-    public InputOrder(IntVar[] variables) {
+    public InputOrder(V[] variables) {
         this.variables = variables.clone();
         this.index = variables[0].getSolver().getEnvironment().makeInt();
     }
 
     @Override
-    public IntVar[] getScope() {
+    public V[] getScope() {
         return variables;
     }
 
     @Override
     public boolean hasNext() {
         int idx = index.get();
-        for (; idx < variables.length && variables[idx].getDomainSize() == 1; idx++) {
+        for (; idx < variables.length && variables[idx].instantiated(); idx++) {
         }
         return idx < variables.length;
     }
@@ -67,7 +67,7 @@ public class InputOrder implements VariableSelector<IntVar> {
     public void advance() {
         int idx = index.get();
         for (; idx < variables.length; idx++) {
-            if (variables[idx].getDomainSize() > 1) {
+            if (!variables[idx].instantiated()) {
                 return;
             }
             index.add(1);
@@ -75,7 +75,7 @@ public class InputOrder implements VariableSelector<IntVar> {
     }
 
     @Override
-    public IntVar getVariable() {
+    public V getVariable() {
         return variables[index.get()];
     }
 }

--- a/choco-solver/src/main/java/solver/search/strategy/selectors/variables/Occurrence.java
+++ b/choco-solver/src/main/java/solver/search/strategy/selectors/variables/Occurrence.java
@@ -29,6 +29,7 @@ package solver.search.strategy.selectors.variables;
 
 import solver.search.strategy.selectors.VariableSelector;
 import solver.variables.IntVar;
+import solver.variables.Variable;
 
 /**
  * <b>Occurrence</b> variable selector.
@@ -39,29 +40,29 @@ import solver.variables.IntVar;
  * @author Charles Prud'homme
  * @since 2 juil. 2010
  */
-public class Occurrence implements VariableSelector<IntVar> {
+public class Occurrence<V extends Variable> implements VariableSelector<V> {
 
     /* list of variables */
-    IntVar[] variables;
+    V[] variables;
 
     /* index of the smallest domain variable */
     int large_idx;
 
-    public Occurrence(IntVar[] variables) {
+    public Occurrence(V[] variables) {
         this.variables = variables.clone();
         large_idx = 0;
 
     }
 
     @Override
-    public IntVar[] getScope() {
+    public V[] getScope() {
         return variables;
     }
 
     @Override
     public boolean hasNext() {
         int idx = 0;
-        for (; idx < variables.length && variables[idx].getDomainSize() == 1; idx++) {
+        for (; idx < variables.length && variables[idx].instantiated(); idx++) {
         }
         return idx < variables.length;
     }
@@ -71,9 +72,8 @@ public class Occurrence implements VariableSelector<IntVar> {
         int large_idx = 0;
         int large_nb_cstrs = Integer.MIN_VALUE;
         for (int idx = 0; idx < variables.length; idx++) {
-            int dsize = variables[idx].getDomainSize();
             int nb_cstrs = variables[idx].nbConstraints();
-            if (dsize > 1 && nb_cstrs > large_nb_cstrs) {
+            if (!variables[idx].instantiated() && nb_cstrs > large_nb_cstrs) {
                 large_nb_cstrs = nb_cstrs;
                 large_idx = idx;
             }
@@ -82,7 +82,7 @@ public class Occurrence implements VariableSelector<IntVar> {
     }
 
     @Override
-    public IntVar getVariable() {
+    public V getVariable() {
         return variables[large_idx];
     }
 }

--- a/choco-solver/src/main/java/solver/search/strategy/selectors/variables/Random.java
+++ b/choco-solver/src/main/java/solver/search/strategy/selectors/variables/Random.java
@@ -29,7 +29,7 @@ package solver.search.strategy.selectors.variables;
 
 import gnu.trove.list.array.TIntArrayList;
 import solver.search.strategy.selectors.VariableSelector;
-import solver.variables.IntVar;
+import solver.variables.Variable;
 
 /**
  * <b>Random</b> variable selector.
@@ -39,9 +39,9 @@ import solver.variables.IntVar;
  * @author Charles Prud'homme
  * @since 2 juil. 2010
  */
-public class Random implements VariableSelector<IntVar> {
+public class Random<T extends Variable> implements VariableSelector<T> {
 
-    IntVar[] variables;
+    T[] variables;
 
     int rand_idx;
 
@@ -49,21 +49,21 @@ public class Random implements VariableSelector<IntVar> {
 
     java.util.Random random;
 
-    public Random(IntVar[] variables, long seed) {
+    public Random(T[] variables, long seed) {
         this.variables = variables.clone();
         sets = new TIntArrayList(variables.length);
         random = new java.util.Random(seed);
     }
 
     @Override
-    public IntVar[] getScope() {
+    public T[] getScope() {
         return variables;
     }
 
     @Override
     public boolean hasNext() {
         int idx = 0;
-        for (; idx < variables.length && variables[idx].getDomainSize() == 1; idx++) {
+        for (; idx < variables.length && variables[idx].instantiated(); idx++) {
         }
         return idx < variables.length;
     }
@@ -73,8 +73,7 @@ public class Random implements VariableSelector<IntVar> {
         sets.clear();
         rand_idx = 0;
         for (int idx = 0; idx < variables.length; idx++) {
-            int dsize = variables[idx].getDomainSize();
-            if (dsize > 1) {
+            if (!variables[idx].instantiated()) {
                 sets.add(idx);
             }
         }
@@ -82,7 +81,7 @@ public class Random implements VariableSelector<IntVar> {
     }
 
     @Override
-    public IntVar getVariable() {
+    public T getVariable() {
         return variables[rand_idx];
     }
 }


### PR DESCRIPTION
A few changes.
1. Previously a set search strategy required two parts, a SetVarSelector and a SetValSelector. SetVarSelector did not inherit from VariableSelector which made it impossible to use strategies that are generalized to work with many types of variables. I've changed it so that set search strategy now requires a VariableSelector<SetVar> and a SetValSelector. This is an improvement because it accepts generalized VariableSelectors as well as specialized set variable selectors.
2. Generalized the InputOrder, Random, and Occurrence selection strategies to work with any type of variables.
3. Removed SetVarSelector.FirstVar since it is a redundant specialized reimplementation of InputOrder. In fact, SetVarSelector.FirstVar was less performant than InputOrder because InputOrder maintains an "IStateInt index" of all the instantiated variables it has already seen, whereas SetVarSelector.FirstVar would re-examine all the instantiated variables again at every selection.
