### PR TITLE
Some set propagators do not accept ISetDeltaMonitors that are not of the...

### DIFF
--- a/choco-solver/src/main/java/solver/constraints/set/PropAllDisjoint.java
+++ b/choco-solver/src/main/java/solver/constraints/set/PropAllDisjoint.java
@@ -74,7 +74,7 @@ public class PropAllDisjoint extends Propagator<SetVar> {
         super(sets, PropagatorPriority.LINEAR, true);
         n = sets.length;
         // delta monitors
-        sdm = new SetDeltaMonitor[n];
+        sdm = new ISetDeltaMonitor[n];
         for (int i = 0; i < n; i++) {
             sdm[i] = this.vars[i].monitorDelta(this);
         }

--- a/choco-solver/src/main/java/solver/constraints/set/PropAllEqual.java
+++ b/choco-solver/src/main/java/solver/constraints/set/PropAllEqual.java
@@ -72,7 +72,7 @@ public class PropAllEqual extends Propagator<SetVar> {
         super(sets, PropagatorPriority.LINEAR, true);
         n = sets.length;
         // delta monitors
-        sdm = new SetDeltaMonitor[n];
+        sdm = new ISetDeltaMonitor[n];
         for (int i = 0; i < n; i++) {
             sdm[i] = this.vars[i].monitorDelta(this);
         }

--- a/choco-solver/src/main/java/solver/constraints/set/PropGraphChannel.java
+++ b/choco-solver/src/main/java/solver/constraints/set/PropGraphChannel.java
@@ -90,7 +90,7 @@ public class PropGraphChannel extends Propagator<Variable> {
         n = sets.length;
         this.g = (GraphVar) vars[n];
         assert (n == g.getEnvelopGraph().getNbNodes());
-        sdm = new SetDeltaMonitor[n];
+        sdm = new ISetDeltaMonitor[n];
         for (int i = 0; i < n; i++) {
             sdm[i] = sets[i].monitorDelta(this);
         }

--- a/choco-solver/src/main/java/solver/constraints/set/PropIntChannel.java
+++ b/choco-solver/src/main/java/solver/constraints/set/PropIntChannel.java
@@ -83,7 +83,7 @@ public class PropIntChannel extends Propagator<Variable> {
         this.sets = new SetVar[nSets];
         this.ints = new IntVar[nInts];
         this.idm = new IIntDeltaMonitor[nInts];
-        this.sdm = new SetDeltaMonitor[nSets];
+        this.sdm = new ISetDeltaMonitor[nSets];
         this.offSet1 = offSet1;
         this.offSet2 = offSet2;
         for (int i = 0; i < nInts; i++) {

--- a/choco-solver/src/main/java/solver/constraints/set/PropIntersection.java
+++ b/choco-solver/src/main/java/solver/constraints/set/PropIntersection.java
@@ -62,7 +62,7 @@ public class PropIntersection extends Propagator<SetVar> {
     public PropIntersection(SetVar[] sets, SetVar intersection) {
         super(ArrayUtils.append(sets, new SetVar[]{intersection}), PropagatorPriority.LINEAR, true);
         k = sets.length;
-        sdm = new SetDeltaMonitor[k + 1];
+        sdm = new ISetDeltaMonitor[k + 1];
         for (int i = 0; i <= k; i++) {
             sdm[i] = this.vars[i].monitorDelta(this);
         }

--- a/choco-solver/src/main/java/solver/constraints/set/PropInverse.java
+++ b/choco-solver/src/main/java/solver/constraints/set/PropInverse.java
@@ -82,7 +82,7 @@ public class PropInverse extends Propagator<SetVar> {
         this.sets = Arrays.copyOfRange(vars, 0, sets.length);
         this.invsets = Arrays.copyOfRange(vars, sets.length, vars.length);
         // delta monitors
-        sdm = new SetDeltaMonitor[n + n2];
+        sdm = new ISetDeltaMonitor[n + n2];
         for (int i = 0; i < n + n2; i++) {
             sdm[i] = this.vars[i].monitorDelta(this);
         }

--- a/choco-solver/src/main/java/solver/constraints/set/PropOffSet.java
+++ b/choco-solver/src/main/java/solver/constraints/set/PropOffSet.java
@@ -61,7 +61,7 @@ public class PropOffSet extends Propagator<SetVar> {
     public PropOffSet(SetVar set1, SetVar set2, int offSet) {
         super(new SetVar[]{set1, set2}, PropagatorPriority.UNARY, true);
         this.offSet = offSet;
-        sdm = new SetDeltaMonitor[2];
+        sdm = new ISetDeltaMonitor[2];
         sdm[0] = vars[0].monitorDelta(this);
         sdm[1] = vars[1].monitorDelta(this);
         this.forced = new IntProcedure() {

--- a/choco-solver/src/main/java/solver/constraints/set/PropSubsetEq.java
+++ b/choco-solver/src/main/java/solver/constraints/set/PropSubsetEq.java
@@ -71,7 +71,7 @@ public class PropSubsetEq extends Propagator<SetVar> {
     public PropSubsetEq(SetVar X, SetVar Y) {
         super(new SetVar[]{X, Y}, PropagatorPriority.LINEAR, true);
         // delta monitors
-        sdm = new SetDeltaMonitor[2];
+        sdm = new ISetDeltaMonitor[2];
         for (int i = 0; i < 2; i++) {
             sdm[i] = this.vars[i].monitorDelta(this);
         }

--- a/choco-solver/src/main/java/solver/constraints/set/PropSymmetric.java
+++ b/choco-solver/src/main/java/solver/constraints/set/PropSymmetric.java
@@ -72,7 +72,7 @@ public class PropSymmetric extends Propagator<SetVar> {
         super(sets, PropagatorPriority.LINEAR, true);
         n = sets.length;
         this.offSet = offSet;
-        sdm = new SetDeltaMonitor[n];
+        sdm = new ISetDeltaMonitor[n];
         for (int i = 0; i < n; i++) {
             sdm[i] = this.vars[i].monitorDelta(this);
         }

--- a/choco-solver/src/main/java/solver/constraints/set/PropUnion.java
+++ b/choco-solver/src/main/java/solver/constraints/set/PropUnion.java
@@ -68,7 +68,7 @@ public class PropUnion extends Propagator<SetVar> {
     public PropUnion(SetVar[] sets, SetVar union) {
         super(ArrayUtils.append(sets, new SetVar[]{union}), PropagatorPriority.LINEAR, true);
         k = sets.length;
-        sdm = new SetDeltaMonitor[k + 1];
+        sdm = new ISetDeltaMonitor[k + 1];
         for (int i = 0; i <= k; i++) {
             sdm[i] = this.vars[i].monitorDelta(this);
         }


### PR DESCRIPTION
... type SetDeltaMonitor.

For example, the following code will throw an ArrayStoreException:

``` java
    Solver solver = new Solver();
    SetVar v1 = VF.fixed("{0,1}", new int[]{0, 1}, solver);
    SetVar v2 = VF.set("v2", 0, 3, solver);
    solver.post(SCF.subsetEq(new SetVar[]{v1, v2}));
    solver.set(SetStrategyFactory.force_first(new SetVar[]{v1, v2}));
    if (solver.findSolution()) {
        do {
            System.out.println(v1 + " subseteq " + v2);
        } while (solver.nextSolution());
    }
```
