### PR TITLE
Fixed entailment of PropBoolChannel when elements in the set is negative...

### DIFF
--- a/choco-solver/src/main/java/solver/constraints/set/PropBoolChannel.java
+++ b/choco-solver/src/main/java/solver/constraints/set/PropBoolChannel.java
@@ -152,7 +152,8 @@ public class PropBoolChannel extends Propagator<Variable> {
     @Override
     public ESat isEntailed() {
         for (int j=set.getKernelFirst(); j!=SetVar.END; j=set.getKernelNext()) {
-            if (bools[j - offSet].isInstantiatedTo(0)) {
+            int i = j - offSet;
+            if (i < 0  || i >= bools.length || bools[i].isInstantiatedTo(0)) {
                 return ESat.FALSE;
             }
         }


### PR DESCRIPTION
... or larger than the length of the boolean array.

For example, the following code will throw an array out of index exception.

``` java
public static void main(String[] args) {
    Solver solver = new Solver();
    BoolVar[] bs = VF.boolArray("bs", 3, solver);
    SetVar s1 = VF.set("s1", -3, 3, solver);
    SetVar s2 = VF.set("s2", -3, 3, solver);
    solver.post(LCF.or(SCF.all_equal(new SetVar[]{s1, s2}), SCF.bool_channel(bs, s1, 0)));
    if (solver.findSolution()) {
        do {
            System.out.println(s1 + " : " + s2);
        } while (solver.nextSolution());
    }
}
```
