### PR TITLE
Fix reset

### DIFF
--- a/choco-solver/src/main/java/solver/search/loop/AbstractSearchLoop.java
+++ b/choco-solver/src/main/java/solver/search/loop/AbstractSearchLoop.java
@@ -41,6 +41,7 @@ import solver.search.strategy.decision.Decision;
 import solver.search.strategy.decision.RootDecision;
 import solver.search.strategy.strategy.AbstractStrategy;
 import solver.variables.Variable;
+import solver.variables.delta.IDelta;
 import util.ESat;
 
 /**
@@ -184,7 +185,10 @@ public abstract class AbstractSearchLoop implements ISearchLoop {
                 tmp.free();
             }
             for(Variable var : solver.getVars()) {
-                var.getDelta().lazyClear();
+                IDelta delta = var.getDelta();
+                if (delta != null) {
+                    delta.lazyClear();
+                }
             }
         }
     }


### PR DESCRIPTION
Deltas are not clearing on reset. For example, the following code find an incorrect solution the second time.

``` java
public static void main(String[] args) {
    Solver solver = new Solver();
    final SetVar s0 = VF.set("s0", 0, 1, solver);
    final BoolVar b0 = VF.bool("b0", solver);
    final BoolVar b1 = VF.bool("b1", solver);
    final IntVar i0 = VF.bool("i0", solver);
    solver.set(ISF.lexico_LB(i0));
    solver.post(SCF.bool_channel(new BoolVar[]{b0, b1}, s0, 0));
    solver.post(SCF.cardinality(s0, VF.fixed(0, solver)));

    solver.findSolution();
    System.out.println(solver.isSatisfied());
    System.out.println(s0 + ", " + b0 + ", " + b1 + ", " + i0);

    solver.getEngine().flush();
    solver.getSearchLoop().reset();

    solver.findSolution();
    System.out.println(solver.isSatisfied());
    System.out.println(s0 + ", " + b0 + ", " + b1 + ", " + i0);
}
```

I added code to clear the deltas on the search loop reset, although I'm not sure if this is the right place to do it.
