### PR TITLE
Fixed scale view instantiateTo, nextValue, and previousValue.

### DIFF
--- a/choco-solver/src/main/java/solver/variables/view/ScaleView.java
+++ b/choco-solver/src/main/java/solver/variables/view/ScaleView.java
@@ -122,6 +122,9 @@ public final class ScaleView extends IntView {
     @Override
     public boolean instantiateTo(int value, ICause cause) throws ContradictionException {
         assert cause != null;
+        if (value % cste != 0) {
+            contradiction(cause, EventType.INSTANTIATE, "Not a multiple of " + cste);
+        }
         boolean done = var.instantiateTo(value / cste, this);
         if (done) {
             notifyPropagators(EventType.INSTANTIATE, cause);
@@ -198,7 +201,7 @@ public final class ScaleView extends IntView {
 
     @Override
     public int nextValue(int v) {
-        int value = var.nextValue(v / cste);
+        int value = var.nextValue(MathUtils.divFloor(v , cste));
         if (value == Integer.MAX_VALUE) {
             return value;
         }
@@ -207,7 +210,7 @@ public final class ScaleView extends IntView {
 
     @Override
     public int previousValue(int v) {
-        int value = var.previousValue(v / cste);
+        int value = var.previousValue(MathUtils.divCeil(v, cste));
         if (value == Integer.MIN_VALUE) {
             return Integer.MIN_VALUE;
         }


### PR DESCRIPTION
For example, the following code will find an incorrect solution, assuming views are **enabled**.

``` java
public static void main(String[] args) {
    Solver solver = new Solver();
    IntVar i = VF.enumerated("i", -2, 2, solver);
    solver.post(ICF.arithm(
            VF.scale(i, 3),
            "=",
            2));
    if(solver.findSolution()) {
        do{
            System.out.println(solver);
            System.out.println(solver.isSatisfied());
        }while(solver.nextSolution());
    }
}
```

The is due to this code in ScaleView.java

``` java
public boolean instantiateTo(int value, ICause cause) throws ContradictionException {
    assert cause != null;
    boolean done = var.instantiateTo(value / cste, this);
    if (done) {
        notifyPropagators(EventType.INSTANTIATE, cause);
        return true;
    }
    return false;
}
```

So when "value=2", then the inner variable is instantiated to 0, which is the case for the example above. The bug has to do with the division by cste.

Likewise, nextValue and previousValue are bugged for a similar reason. For example, the following code will print "0" and "0" but the expected values are "-3" and "3".

``` java
public static void main(String[] args) {
    Solver solver = new Solver();
    IntVar i = VF.enumerated("i", -2, 2, solver);
    System.out.println(VF.scale(i, 3).nextValue(-5));
    System.out.println(VF.scale(i, 3).previousValue(5));
}
```
