### PR TITLE
Fixed PropDivXYZ isEntailed.

### DIFF
--- a/choco-solver/src/main/java/solver/constraints/ternary/PropDivXYZ.java
+++ b/choco-solver/src/main/java/solver/constraints/ternary/PropDivXYZ.java
@@ -173,7 +173,7 @@ public class PropDivXYZ extends Propagator<IntVar> {
         if (Y.isInstantiated() && Z.isInstantiatedTo(0)) {
             int xx = Math.max(Math.abs(X.getLB()), Math.abs(X.getUB()));
             int yy = Math.abs(Y.getValue());
-            return ESat.eval(xx < yy);
+            if (xx < yy) return ESat.TRUE;
         }
         return ESat.UNDEFINED;
     }


### PR DESCRIPTION
Fixed the isEntailed method. For example, the following code will return one incorrect solution.

``` java
public static void main(String[] args) {
    Solver solver = new Solver();
    IntVar i = VF.enumerated("i", 0, 2, solver);
    solver.post(ICF.eucl_div(i, VF.one(solver), VF.zero(solver)).getOpposite());
    if (solver.findSolution()) {
        do {
            System.out.println(i + " / 1 != 0");
            System.out.println(solver.isSatisfied());
        } while (solver.nextSolution());
    }
}
```
