### PR TITLE
Fixed PropTimesNaive failing idempotency check.

### DIFF
--- a/choco-solver/src/main/java/solver/constraints/ternary/PropTimesNaive.java
+++ b/choco-solver/src/main/java/solver/constraints/ternary/PropTimesNaive.java
@@ -70,11 +70,6 @@ public class PropTimesNaive extends Propagator<IntVar> {
     }
 
     @Override
-    public final void propagate(int varIdx, int mask) throws ContradictionException {
-        propagate(0);
-    }
-
-    @Override
     public final ESat isEntailed() {
         if (isCompletelyInstantiated()) {
             return ESat.eval(v0.getValue() * v1.getValue() == v2.getValue());
@@ -88,13 +83,13 @@ public class PropTimesNaive extends Propagator<IntVar> {
         if (a <= 0 && b >= 0 && c <= 0 && d >= 0) { // case 1
             min = MIN;
             max = MAX;
-            return var.updateLowerBound(min, this) & var.updateUpperBound(max, this);
+            return var.updateLowerBound(min, this) | var.updateUpperBound(max, this);
         } else if (c == 0 && d == 0 && (a > 0 || b < 0)) // case 2
             this.contradiction(var, "");
         else if (c < 0 && d > 0 && (a > 0 || b < 0)) { // case 3
             max = Math.max(Math.abs(a), Math.abs(b));
             min = -max;
-            return var.updateLowerBound(min, this) & var.updateUpperBound(max, this);
+            return var.updateLowerBound(min, this) | var.updateUpperBound(max, this);
         } else if (c == 0 && d != 0 && (a > 0 || b < 0)) // case 4 a
             return div(var, a, b, 1, d);
         else if (c != 0 && d == 0 && (a > 0 || b < 0)) // case 4 b
@@ -107,7 +102,7 @@ public class PropTimesNaive extends Propagator<IntVar> {
             min = (int) Math.round(Math.ceil(low));
             max = (int) Math.round(Math.floor(high));
             if (min > max) this.contradiction(var, "");
-            return var.updateLowerBound(min, this) & var.updateUpperBound(max, this);
+            return var.updateLowerBound(min, this) | var.updateUpperBound(max, this);
         }
         return false;
     }
@@ -115,7 +110,7 @@ public class PropTimesNaive extends Propagator<IntVar> {
     private boolean mul(IntVar var, int a, int b, int c, int d) throws ContradictionException {
         int min = Math.min(Math.min(multiply(a, c), multiply(a, d)), Math.min(multiply(b, c), multiply(b, d)));
         int max = Math.max(Math.max(multiply(a, c), multiply(a, d)), Math.max(multiply(b, c), multiply(b, d)));
-        return var.updateLowerBound(min, this) & var.updateUpperBound(max, this);
+        return var.updateLowerBound(min, this) | var.updateUpperBound(max, this);
     }
 
     public final static int multiply(int a, int b) {


### PR DESCRIPTION
_times_ constraint is not idempotent. The following code will demonstrate this.

``` java
public static void main(String[] args) throws Exception {
    Solver s = new Solver();
    IntVar a = VF.enumerated("a", 0, 3, s);
    IntVar b = VF.enumerated("b", -3, 3, s);
    Constraint c = ICF.times(a, b, VF.fixed(3, s));
    s.post(c);
    s.propagate();
    System.out.println(a.contains(0));
    for(Propagator p : c.getPropagators()) {
        p.propagate(EventType.FULL_PROPAGATION.mask);
    }
    System.out.println(a.contains(0));
}
```

It will print "true, false" meaning the first propagation did not reach a fixed point.

The bug is because of the following code:

``` java
return var.updateLowerBound(min, this) & var.updateUpperBound(max, this);
```

The "&" means that changes will be notified if both the upper and lower bound were altered.
