### PR TITLE
Improvements to the performance of SCF.member and SCF.not_member

### DIFF
--- a/choco-solver/src/main/java/solver/constraints/set/PropIntMemberSet.java
+++ b/choco-solver/src/main/java/solver/constraints/set/PropIntMemberSet.java
@@ -196,7 +196,7 @@ public class PropIntMemberSet extends Propagator<Variable> {
             if (!set.envelopeContains(iv.getValue())) {
                 return ESat.FALSE;
             } else {
-                if (set.isInstantiated()) {
+                if (set.kernelContains(iv.getValue())) {
                     return ESat.TRUE;
                 } else {
                     return ESat.UNDEFINED;

--- a/choco-solver/src/main/java/solver/constraints/set/PropNotMemberIntSet.java
+++ b/choco-solver/src/main/java/solver/constraints/set/PropNotMemberIntSet.java
@@ -72,6 +72,7 @@ public class PropNotMemberIntSet extends Propagator<IntVar> {
 	public void propagate(int evtmask) throws ContradictionException {
 		if(iv.isInstantiated()){
 			sv.removeFromEnvelope(iv.getValue(),aCause);
+			setPassive();
 		}
 	}
 
@@ -79,6 +80,7 @@ public class PropNotMemberIntSet extends Propagator<IntVar> {
 	public void propagate(int vidx, int evtmask) throws ContradictionException {
 		assert iv.isInstantiated();
 		sv.removeFromEnvelope(iv.getValue(),aCause);
+		setPassive();
 	}
 
 	@Override


### PR DESCRIPTION
1. Reduce the number of ESat.Undefined cases for PropIntMemberSet.isEntailed.
2. PropNotMemberSetInt's constructor specifies to react on fine events yet it did not implement an incremental propagation.
3. Set to passive when PropNotMemberSetInt or PropNotMemberIntSet can guarantee that the domain of the integer variable does not overlap with the envelope of the set variable.
