### PR TITLE
when a thread used by choco solver is interrupted by Thread.interrupt() method, the solver should be stopped

### DIFF
--- a/src/main/java/org/chocosolver/solver/Solver.java
+++ b/src/main/java/org/chocosolver/solver/Solver.java
@@ -282,7 +282,7 @@ public final class Solver implements ISolver, IMeasures, IOutputFactory {
         kill = true;
         boolean left = true;
         while(!stop){
-            if (isStopCriterionMet()) {
+            if (isStopCriterionMet() || Thread.currentThread().isInterrupted()) {
                 stop = true;
             }
             switch (action) {


### PR DESCRIPTION
Minimal change in develop branch to support Thread.interrupt() method used by thread pools to end a thread since method Thread.stop() is deprecated.

Maybe extra property of Solver class may be created to know whether a solver was stopped thanks to interrupted thread or some stop criteria was met.