### PR TITLE
Improve FirstFail

### DIFF
--- a/src/main/java/org/chocosolver/solver/search/strategy/SearchStrategyFactory.java
+++ b/src/main/java/org/chocosolver/solver/search/strategy/SearchStrategyFactory.java
@@ -261,7 +261,7 @@ public class SearchStrategyFactory {
      * @return assignment strategy
      */
     public static IntStrategy minDomLBSearch(IntVar... vars) {
-        return intVarSearch(minDomIntVar(), minIntVal(), vars);
+        return intVarSearch(minDomIntVar(vars[0].getModel()), minIntVal(), vars);
     }
 
     /**
@@ -270,7 +270,7 @@ public class SearchStrategyFactory {
      * @return assignment strategy
      */
     public static IntStrategy minDomUBSearch(IntVar... vars) {
-        return intVarSearch(minDomIntVar(), maxIntVal(), vars);
+        return intVarSearch(minDomIntVar(vars[0].getModel()), maxIntVal(), vars);
     }
 
     // ************************************************************************************

--- a/src/main/java/org/chocosolver/solver/search/strategy/selectors/VarSelectorFactory.java
+++ b/src/main/java/org/chocosolver/solver/search/strategy/selectors/VarSelectorFactory.java
@@ -117,8 +117,8 @@ public class VarSelectorFactory {
      * Only for integer variables
      * @return a variable selector choosing the variable with the smallest domain
      */
-    public static VariableSelector<IntVar> minDomIntVar(){
-        return new FirstFail();
+    public static VariableSelector<IntVar> minDomIntVar(Model model){
+        return new FirstFail(model);
     }
 
     /**

--- a/src/test/java/org/chocosolver/samples/todo/problems/integer/KnightTourProblem_Circuit.java
+++ b/src/test/java/org/chocosolver/samples/todo/problems/integer/KnightTourProblem_Circuit.java
@@ -89,7 +89,7 @@ public class KnightTourProblem_Circuit extends AbstractProblem {
         Solver r = model.getSolver();
 		r.limitTime(limit);
 		r.set(intVarSearch(
-				minDomIntVar(),
+				minDomIntVar(r.getModel()),
                 var -> {
                     int ub = var.getUB();
                     int size = succ.length + 1;

--- a/src/test/java/org/chocosolver/solver/explanations/ExplanationEngineTest.java
+++ b/src/test/java/org/chocosolver/solver/explanations/ExplanationEngineTest.java
@@ -602,7 +602,7 @@ public class ExplanationEngineTest {
         model.arithm(matrix[0][0], "<", matrix[n - 1][0]).post();
 
         Solver r = model.getSolver();
-        r.set(intVarSearch(minDomIntVar(), midIntVal(true), vars));
+        r.set(intVarSearch(minDomIntVar(r.getModel()), midIntVal(true), vars));
 
         configure(model, a);
         model.getSolver().showShortStatistics();

--- a/src/test/java/org/chocosolver/solver/search/StrategyTest.java
+++ b/src/test/java/org/chocosolver/solver/search/StrategyTest.java
@@ -169,7 +169,7 @@ public class StrategyTest {
         IntVar v1 = model.intVar("v1", 1, 5, false);
         IntVar v2 = model.intVar("v2", 3, 4, false);
         IntVar[] vs = new IntVar[]{v1, v2};
-        VariableSelector<IntVar> eval = new FirstFail();
+        VariableSelector<IntVar> eval = new FirstFail(model);
         IntVar va = eval.getVariable(vs);
         Assert.assertEquals(v2, va);
     }
@@ -264,7 +264,7 @@ public class StrategyTest {
     public void testFirstFail2() {
         Model model = new Model();
         IntVar v1 = model.intVar("v1", 1, 5, false);
-        VariableEvaluator<IntVar> eval = new FirstFail();
+        VariableEvaluator<IntVar> eval = new FirstFail(model);
         double va = eval.evaluate(v1);
         Assert.assertEquals(5.0, va);
     }
@@ -339,7 +339,7 @@ public class StrategyTest {
         Model model = new Model();
         IntVar[] X = model.intVarArray("X", 2, 0, 2, false);
         Solver r = model.getSolver();
-        r.set(intVarSearch(minDomIntVar(), midIntVal(true), int_split, X));
+        r.set(intVarSearch(minDomIntVar(r.getModel()), midIntVal(true), int_split, X));
         model.getSolver().showDecisions();
         while (model.solve()) ;
         assertEquals(model.getSolver().getSolutionCount(), 9);
@@ -350,7 +350,7 @@ public class StrategyTest {
         Model model = new Model();
         IntVar[] X = model.intVarArray("X", 2, 0, 2, false);
         Solver r = model.getSolver();
-        r.set(intVarSearch(minDomIntVar(), midIntVal(false), int_reverse_split, X));
+        r.set(intVarSearch(minDomIntVar(r.getModel()), midIntVal(false), int_reverse_split, X));
         model.getSolver().showDecisions();
         while (model.solve()) ;
         assertEquals(model.getSolver().getSolutionCount(), 9);
@@ -362,7 +362,7 @@ public class StrategyTest {
         Model model = new Model();
         IntVar[] X = model.intVarArray("X", 2, 0, 2, false);
         Solver r = model.getSolver();
-        r.set(intVarSearch(minDomIntVar(), midIntVal(true), int_split, X));
+        r.set(intVarSearch(minDomIntVar(r.getModel()), midIntVal(true), int_split, X));
         model.getSolver().showDecisions();
         while (model.solve()) ;
         assertEquals(model.getSolver().getSolutionCount(), 9);
@@ -373,7 +373,7 @@ public class StrategyTest {
         Model model = new Model();
         IntVar[] X = model.intVarArray("X", 2, 0, 2, false);
         Solver r = model.getSolver();
-        r.set(intVarSearch(minDomIntVar(), midIntVal(false), int_reverse_split, X));
+        r.set(intVarSearch(minDomIntVar(r.getModel()), midIntVal(false), int_reverse_split, X));
         model.getSolver().showDecisions();
         while (model.solve()) ;
         assertEquals(model.getSolver().getSolutionCount(), 9);


### PR DESCRIPTION
I got some performance issues when having tons of variables.
This is a port of my own FirstFail that provided the following optimisations:

- Add a shortcut to stop at the moment we have a variable with a domain size of 2
- store the loop offset

Performance  improvement on my code:
```
Vanilla FirstFail: After 66897ms of search (terminated): 6439 opened search node(s), 1817 backtrack(s), 1 solution(s):
New FirstFail: After 55937ms of search (terminated): 6439 opened search node(s), 1817 backtrack(s), 1 solution(s):
```
