### PR TITLE
Record all variables in a solution by default.

### DIFF
--- a/src/main/java/org/chocosolver/solver/Solution.java
+++ b/src/main/java/org/chocosolver/solver/Solution.java
@@ -102,7 +102,7 @@ public class Solution implements ICause {
         empty = false;
         boolean warn = false;
         if (varsToStore.length == 0) {
-            varsToStore = model.getSolver().getSearch().getVariables();
+            varsToStore = model.getVars();
         }
         assert varsToStore.length > 0;
         if (intmap != null) {


### PR DESCRIPTION
I use a lot of channeling constraints and only use one of the variables in the search strategy, but I would still like to query the values of the other variable.

For example:

```java
    public static void main(String[] args) {
        Model model = new Model();
        BoolVar[] bools = model.boolVarArray("bool", 2);
        SetVar set = model.setVar("set", new int[]{}, new int[]{0,1});
        model.setBoolsChanneling(bools, set).post();
        Solver solver = model.getSolver();
        solver.setSearch(Search.minDomLBSearch(bools));
        
        Solution solution = solver.findSolution();
        System.out.println(Arrays.toString(solution.getSetVal(set)));
    }    
```

This will throw a null pointer exception because the value for "set" was never recorded.