### PR TITLE
Fix ScaleView::doRemoveValueFromVar to not remove values it does not contain

### DIFF
--- a/src/main/java/org/chocosolver/solver/variables/view/ScaleView.java
+++ b/src/main/java/org/chocosolver/solver/variables/view/ScaleView.java
@@ -96,7 +96,7 @@ public final class ScaleView extends IntView {
 
     @Override
     protected boolean doRemoveValueFromVar(int value) throws ContradictionException {
-        return var.removeValue(value / cste, this);
+        return value % cste == 0 && var.removeValue(value / cste, this);
     }
 
     @Override


### PR DESCRIPTION


For example, consider the following program:

```java
    public static void main(String[] args) {
        Model m = new Model();
        IntVar y = m.intVar("y", -3, 1);
        IntVar z = m.intVar("z", new int[]{-4, 4});
        m.arithm(m.intScaleView(y, 3), "!=", z).post();
        System.out.println(m);
        Solver s = m.getSolver();

        while (s.solve()) {
            System.out.println("3 * " + y.getValue() + " != " + z);
        }
    }
```

This will fail to find the solution 3 * -1 != -4
