### PR TITLE
Change ISet::toString implementations to use newIterator(), rather than iterator()

### DIFF
--- a/src/main/java/org/chocosolver/util/objects/setDataStructures/bitset/Set_BitSet.java
+++ b/src/main/java/org/chocosolver/util/objects/setDataStructures/bitset/Set_BitSet.java
@@ -160,8 +160,9 @@ public class Set_BitSet implements ISet {
 	@Override
 	public String toString() {
 		String st = "{";
-		for(int i:this){
-			st+=i+", ";
+                ISetIterator iter = newIterator();
+                while (iter.hasNext()) {
+			st+=iter.nextInt()+", ";
 		}
 		st+="}";
 		return st.replace(", }","}");

--- a/src/main/java/org/chocosolver/util/objects/setDataStructures/bitset/Set_Std_BitSet.java
+++ b/src/main/java/org/chocosolver/util/objects/setDataStructures/bitset/Set_Std_BitSet.java
@@ -132,8 +132,9 @@ public class Set_Std_BitSet implements ISet {
 	@Override
 	public String toString() {
 		String st = "{";
-		for(int i:this){
-			st+=i+", ";
+                ISetIterator iter = newIterator();
+                while (iter.hasNext()) {
+			st+=iter.nextInt()+", ";
 		}
 		st+="}";
 		return st.replace(", }","}");

--- a/src/main/java/org/chocosolver/util/objects/setDataStructures/constant/Set_FixedArray.java
+++ b/src/main/java/org/chocosolver/util/objects/setDataStructures/constant/Set_FixedArray.java
@@ -100,8 +100,9 @@ public class Set_FixedArray implements ISet {
 	@Override
 	public String toString() {
 		String st = "{";
-		for(int i:this){
-			st+=i+", ";
+                ISetIterator iter = newIterator();
+                while (iter.hasNext()) {
+			st+=iter.nextInt()+", ";
 		}
 		st+="}";
 		return st.replace(", }","}");

--- a/src/main/java/org/chocosolver/util/objects/setDataStructures/linkedlist/Set_LinkedList.java
+++ b/src/main/java/org/chocosolver/util/objects/setDataStructures/linkedlist/Set_LinkedList.java
@@ -168,8 +168,9 @@ public class Set_LinkedList implements ISet {
 	@Override
 	public String toString() {
 		String st = "{";
-		for(int i:this){
-			st+=i+", ";
+                ISetIterator iter = newIterator();
+                while (iter.hasNext()) {
+			st+=iter.nextInt()+", ";
 		}
 		st+="}";
 		return st.replace(", }","}");

--- a/src/main/java/org/chocosolver/util/objects/setDataStructures/swapList/Set_Swap.java
+++ b/src/main/java/org/chocosolver/util/objects/setDataStructures/swapList/Set_Swap.java
@@ -176,8 +176,9 @@ public class Set_Swap implements ISet {
 	@Override
 	public String toString() {
 		String st = "{";
-		for(int i:this){
-			st+=i+", ";
+                ISetIterator iter = newIterator();
+                while (iter.hasNext()) {
+			st+=iter.nextInt()+", ";
 		}
 		st+="}";
 		return st.replace(", }","}");


### PR DESCRIPTION
The current implementation of toString calls iterator() which reuses the internal iterator. This means that toString cannot be used inside a loop of the set. For example:

```java
for (int i : set.getUB()) {
  // Do not call set.toString nor set.getUB().toString(), otherwise it messes with the for loop.
  // In addition, my preferred debugger uses toString to give human readable information, hence
  // I cannot debug inside this loop.
}
```

Since toString is typically used for debugging, I think this PR is useful.