### PR TITLE
A complementary intersection propagator for filtering the sets.

### DIFF
--- a/src/main/java/org/chocosolver/solver/constraints/ISetConstraintFactory.java
+++ b/src/main/java/org/chocosolver/solver/constraints/ISetConstraintFactory.java
@@ -83,7 +83,30 @@ public interface ISetConstraintFactory {
 	 * @return A constraint ensuring that the intersection of <i>sets</i> is equal to <i>intersectionSet</i>
 	 */
 	default Constraint intersection(SetVar[] sets, SetVar intersectionSet) {
-		return new Constraint("SetIntersection", new PropIntersection(sets, intersectionSet), new PropIntersection(sets, intersectionSet));
+		return intersection(sets, intersectionSet, false);
+	}
+
+	/**
+	 * Creates a constraint which ensures that the intersection of <i>sets</i> is equal to <i>intersectionSet</i>
+	 *
+	 * @param sets an array of set variables
+	 * @param intersectionSet a set variable representing the intersection of <i>sets</i>
+         * @param boundConsistent adds an additional propagator to guarantee BC
+	 * @return A constraint ensuring that the intersection of <i>sets</i> is equal to <i>intersectionSet</i>
+	 */
+	default Constraint intersection(SetVar[] sets, SetVar intersectionSet, boolean boundConsistent) {
+		if (sets.length == 0) {
+			throw new IllegalArgumentException("The intersection of zero sets is undefined.");
+		}
+		if (boundConsistent) {
+			return new Constraint("SetIntersection",
+				new PropIntersection(sets, intersectionSet),
+				sets.length == 1
+					? new PropAllEqual(new SetVar[]{sets[0], intersectionSet})
+					: new PropIntersectionFilterSets(sets, intersectionSet));
+		} else {
+			return new Constraint("SetIntersection", new PropIntersection(sets, intersectionSet));
+		}
 	}
 
 	/**

--- a/src/main/java/org/chocosolver/solver/constraints/set/PropIntersectionFilterSets.java
+++ b/src/main/java/org/chocosolver/solver/constraints/set/PropIntersectionFilterSets.java
@@ -92,12 +92,11 @@ public class PropIntersectionFilterSets extends Propagator<SetVar> {
             ISetIterator iter = vars[i].getLB().iterator();
             while (iter.hasNext()) {
                 int j = iter.nextInt();
-                if (!intersection.getUB().contains(j)) {
-                    if (count.adjustOrPutValue(j, 1, 1) >= k - 1) {
-                        // intersection does not contain j but k - 1 sets
-                        // contains j, hence the last set must not contain j.
-                        findSetThatDoesNotContainJInLB(j).remove(j, this);
-                    }
+                if (!intersection.getUB().contains(j) &&
+                    count.adjustOrPutValue(j, 1, 1) >= k - 1) {
+                    // intersection does not contain j but k - 1 sets contains
+                    // j, hence the last set must not contain j.
+                    findSetThatDoesNotContainJInLB(j).remove(j, this);
                 }
             }
         }

--- a/src/main/java/org/chocosolver/solver/constraints/set/PropIntersectionFilterSets.java
+++ b/src/main/java/org/chocosolver/solver/constraints/set/PropIntersectionFilterSets.java
@@ -1,3 +1,30 @@
+/**
+ * Copyright (c) 2016, Ecole des Mines de Nantes All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer. 2. Redistributions in
+ * binary form must reproduce the above copyright notice, this list of
+ * conditions and the following disclaimer in the documentation and/or other
+ * materials provided with the distribution. 3. All advertising materials
+ * mentioning features or use of this software must display the following
+ * acknowledgement: This product includes software developed by the
+ * <organization>. 4. Neither the name of the <organization> nor the names of
+ * its contributors may be used to endorse or promote products derived from this
+ * software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY <COPYRIGHT HOLDER> ''AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL <COPYRIGHT HOLDER> BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 package org.chocosolver.solver.constraints.set;
 
 import gnu.trove.map.hash.TIntIntHashMap;

--- a/src/main/java/org/chocosolver/solver/constraints/set/PropIntersectionFilterSets.java
+++ b/src/main/java/org/chocosolver/solver/constraints/set/PropIntersectionFilterSets.java
@@ -1,0 +1,122 @@
+package org.chocosolver.solver.constraints.set;
+
+import gnu.trove.map.hash.TIntIntHashMap;
+import org.chocosolver.solver.constraints.Propagator;
+import org.chocosolver.solver.constraints.PropagatorPriority;
+import org.chocosolver.solver.exception.ContradictionException;
+import org.chocosolver.solver.variables.SetVar;
+import org.chocosolver.solver.variables.delta.ISetDeltaMonitor;
+import org.chocosolver.solver.variables.events.SetEventType;
+import org.chocosolver.util.ESat;
+import org.chocosolver.util.objects.setDataStructures.ISetIterator;
+import org.chocosolver.util.tools.ArrayUtils;
+
+/**
+ *
+ * @author jimmy
+ */
+public class PropIntersectionFilterSets extends Propagator<SetVar> {
+
+    private int k;
+    private ISetDeltaMonitor[] sdm;
+
+    public PropIntersectionFilterSets(SetVar[] sets, SetVar intersection) {
+        super(ArrayUtils.append(sets, new SetVar[]{intersection}), PropagatorPriority.QUADRATIC, true);
+        if (sets.length == 0) {
+            throw new IllegalArgumentException("The intersection of zero sets is undefined.");
+        }
+        if (sets.length == 1) {
+            throw new IllegalArgumentException("This propagator does not work for a single set, "
+                    + "use new PropAllEqual(new SetVar[]{sets[0], intersection}) instead.");
+        }
+        k = sets.length;
+        sdm = new ISetDeltaMonitor[k + 1];
+        for (int i = 0; i <= k; i++) {
+            sdm[i] = this.vars[i].monitorDelta(this);
+        }
+    }
+
+    @Override
+    public int getPropagationConditions(int vIdx) {
+        if (vIdx < k) {
+            return SetEventType.ADD_TO_KER.getMask();
+        } else {
+            return SetEventType.REMOVE_FROM_ENVELOPE.getMask();
+        }
+    }
+
+    private SetVar findSetThatDoesNotContainJInLB(int j) {
+        for (int i = 0; i < k - 1; i++) {
+            if (!vars[i].getLB().contains(j)) {
+                return vars[i];
+            }
+        }
+        return vars[k - 1];
+    }
+
+    @Override
+    public void propagate(int evtmask) throws ContradictionException {
+        SetVar intersection = vars[k];
+        // Maps elements in sets to the number of occurences of those elements.
+        TIntIntHashMap count = new TIntIntHashMap();
+        for (int i = 0; i < k; i++) {
+            ISetIterator iter = vars[i].getLB().iterator();
+            while (iter.hasNext()) {
+                int j = iter.nextInt();
+                if (!intersection.getUB().contains(j)) {
+                    if (count.adjustOrPutValue(j, 1, 1) >= k - 1) {
+                        // intersection does not contain j but k - 1 sets
+                        // contains j, hence the last set must not contain j.
+                        findSetThatDoesNotContainJInLB(j).remove(j, this);
+                    }
+                }
+            }
+        }
+        for (int i = 0; i <= k; i++) {
+            sdm[i].unfreeze();
+        }
+    }
+
+    private SetVar findUniqueSetThatDoesNotContainJInLB(int j) {
+        SetVar uniqueSet = null;
+        for (int i = 0; i < k; i++) {
+            if (!vars[i].getLB().contains(j)) {
+                if (uniqueSet != null) {
+                    return null;
+                }
+                uniqueSet = vars[i];
+            }
+        }
+        return uniqueSet;
+    }
+
+    @Override
+    public void propagate(int idxVarInProp, int mask) throws ContradictionException {
+        sdm[idxVarInProp].freeze();
+        if (idxVarInProp < k) {
+            SetVar intersection = vars[k];
+            sdm[idxVarInProp].forEach(j -> {
+                if (!intersection.getUB().contains(j)) {
+                    SetVar uniqueSet = findUniqueSetThatDoesNotContainJInLB(j);
+                    if (uniqueSet != null) {
+                        uniqueSet.remove(j, this);
+                    }
+                }
+            }, SetEventType.ADD_TO_KER);
+        } else {
+            sdm[idxVarInProp].forEach(j -> {
+                SetVar uniqueSet = findUniqueSetThatDoesNotContainJInLB(j);
+                if (uniqueSet != null) {
+                    uniqueSet.remove(j, this);
+                }
+            }, SetEventType.REMOVE_FROM_ENVELOPE);
+        }
+        sdm[idxVarInProp].unfreeze();
+    }
+
+    @Override
+    public ESat isEntailed() {
+        // Let PropIntersection do the work.
+        return ESat.TRUE;
+    }
+}

--- a/src/main/java/org/chocosolver/solver/constraints/set/PropIntersectionFilterSets.java
+++ b/src/main/java/org/chocosolver/solver/constraints/set/PropIntersectionFilterSets.java
@@ -1,29 +1,31 @@
 /**
- * Copyright (c) 2016, Ecole des Mines de Nantes All rights reserved.
+ * Copyright (c) 2016, Ecole des Mines de Nantes
+ * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer. 2. Redistributions in
- * binary form must reproduce the above copyright notice, this list of
- * conditions and the following disclaimer in the documentation and/or other
- * materials provided with the distribution. 3. All advertising materials
- * mentioning features or use of this software must display the following
- * acknowledgement: This product includes software developed by the
- * <organization>. 4. Neither the name of the <organization> nor the names of
- * its contributors may be used to endorse or promote products derived from this
- * software without specific prior written permission.
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. All advertising materials mentioning features or use of this software
+ *    must display the following acknowledgement:
+ *    This product includes software developed by the <organization>.
+ * 4. Neither the name of the <organization> nor the
+ *    names of its contributors may be used to endorse or promote products
+ *    derived from this software without specific prior written permission.
  *
- * THIS SOFTWARE IS PROVIDED BY <COPYRIGHT HOLDER> ''AS IS'' AND ANY EXPRESS OR
- * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
- * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
- * EVENT SHALL <COPYRIGHT HOLDER> BE LIABLE FOR ANY DIRECT, INDIRECT,
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
- * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
- * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
- * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
- * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
- * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ * THIS SOFTWARE IS PROVIDED BY <COPYRIGHT HOLDER> ''AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL <COPYRIGHT HOLDER> BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 package org.chocosolver.solver.constraints.set;
 

--- a/src/test/java/org/chocosolver/solver/constraints/set/IntersectionTest.java
+++ b/src/test/java/org/chocosolver/solver/constraints/set/IntersectionTest.java
@@ -38,11 +38,15 @@ import org.chocosolver.solver.Solver;
 import org.chocosolver.solver.exception.ContradictionException;
 import org.chocosolver.solver.search.loop.monitors.IMonitorContradiction;
 import org.chocosolver.solver.search.loop.monitors.IMonitorDownBranch;
+import org.chocosolver.solver.search.strategy.Search;
+import org.chocosolver.solver.search.strategy.selectors.values.SetDomainMin;
+import org.chocosolver.solver.search.strategy.strategy.SetStrategy;
 import org.chocosolver.solver.variables.SetVar;
 import org.chocosolver.solver.variables.Variable;
 import org.chocosolver.util.ESat;
 import org.chocosolver.util.objects.setDataStructures.ISet;
 import org.chocosolver.util.objects.setDataStructures.SetFactory;
+import org.chocosolver.util.tools.ArrayUtils;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.*;
@@ -151,6 +155,12 @@ public class IntersectionTest {
         return model.setVar(name, lb.toArray(), ub.toArray());
     }
 
+    private SetStrategy randomSearch(SetVar... vars) {
+        return Search.setVarSearch(
+                new org.chocosolver.solver.search.strategy.selectors.variables.Random<>(rand.nextLong()),
+                new SetDomainMin(), rand.nextBoolean(), vars);
+    }
+
     @Test(groups = "1s", timeOut=60000)
     public void testFuzzIdempotent() {
         for (int repeat = 0; repeat < 100; repeat++) {
@@ -168,6 +178,7 @@ public class IntersectionTest {
             }
             SetVar intersection = randSet("interection", model);
             model.intersection(sets, intersection).post();
+            model.getSolver().setSearch(randomSearch(ArrayUtils.append(sets, new SetVar[]{intersection})));
             checkSolutions(model, sets, intersection);
         }
     }
@@ -190,6 +201,7 @@ public class IntersectionTest {
             SetVar intersection = randSet("intersection", model);
             model.intersection(sets, intersection, true).post();
             model.getSolver().plugMonitor(new BoundConsistent(model.getSolver()));
+            model.getSolver().setSearch(randomSearch(ArrayUtils.append(sets, new SetVar[]{intersection})));
             checkSolutions(model, sets, intersection);
         }
     }

--- a/src/test/java/org/chocosolver/solver/constraints/set/IntersectionTest.java
+++ b/src/test/java/org/chocosolver/solver/constraints/set/IntersectionTest.java
@@ -29,8 +29,17 @@
  */
 package org.chocosolver.solver.constraints.set;
 
+import gnu.trove.set.TIntSet;
+import gnu.trove.set.hash.TIntHashSet;
+import java.util.Random;
 import org.chocosolver.solver.Model;
+import org.chocosolver.solver.Settings;
+import org.chocosolver.solver.Solver;
+import org.chocosolver.solver.exception.ContradictionException;
+import org.chocosolver.solver.search.loop.monitors.IMonitorContradiction;
+import org.chocosolver.solver.search.loop.monitors.IMonitorDownBranch;
 import org.chocosolver.solver.variables.SetVar;
+import org.chocosolver.solver.variables.Variable;
 import org.chocosolver.util.ESat;
 import org.chocosolver.util.objects.setDataStructures.ISet;
 import org.chocosolver.util.objects.setDataStructures.SetFactory;
@@ -51,7 +60,17 @@ public class IntersectionTest {
         SetVar intersect = model.setVar(new int[]{}, new int[]{1, 2, 3, 4, 5, 6});
         model.intersection(setVars, intersect).post();
 
-        checkSolutions(model, setVars, intersect);
+        assertEquals(229376, checkSolutions(model, setVars, intersect));
+    }
+
+    @Test(groups = "1s", timeOut=60000)
+    public void testNominalBoundConsistent() {
+        Model model = new Model();
+        SetVar[] setVars = model.setVarArray(3, new int[]{}, new int[]{0, 1, 2, 3, 4, 5});
+        SetVar intersect = model.setVar(new int[]{}, new int[]{1, 2, 3, 4, 5, 6});
+        model.intersection(setVars, intersect, true).post();
+
+        assertEquals(229376, checkSolutions(model, setVars, intersect));
     }
 
     @Test(groups = "1s", timeOut=60000)
@@ -61,7 +80,17 @@ public class IntersectionTest {
         SetVar intersect = model.setVar(new int[]{1, 2, 3, 4});
         model.intersection(setVars, intersect).post();
 
-        checkSolutions(model, setVars, intersect);
+        assertEquals(961, checkSolutions(model, setVars, intersect));
+    }
+
+    @Test(groups = "1s", timeOut=60000)
+    public void testVarsToIntersectBoundConsistent() {
+        Model model = new Model();
+        SetVar[] setVars = model.setVarArray(5, new int[]{}, new int[]{1, 2, 3, 4, 5, 6});
+        SetVar intersect = model.setVar(new int[]{1, 2, 3, 4});
+        model.intersection(setVars, intersect, true).post();
+
+        assertEquals(961, checkSolutions(model, setVars, intersect));
     }
 
     @Test(groups = "1s", timeOut=60000)
@@ -74,7 +103,20 @@ public class IntersectionTest {
         SetVar intersect = model.setVar(new int[]{}, new int[]{0, 1, 2, 3, 4, 5, 6, 7, 8, 9});
         model.intersection(setVars, intersect).post();
 
-        checkSolutions(model, setVars, intersect);
+        assertEquals(1, checkSolutions(model, setVars, intersect));
+    }
+
+    @Test(groups = "1s", timeOut=60000)
+    public void testIntersectToVarsBoundConsistent() {
+        Model model = new Model();
+        SetVar[] setVars = new SetVar[3];
+        setVars[0] = model.setVar(new int[]{0, 1, 2});
+        setVars[1] = model.setVar(new int[]{1, 2, 3});
+        setVars[2] = model.setVar(new int[]{2, 4, 5});
+        SetVar intersect = model.setVar(new int[]{}, new int[]{0, 1, 2, 3, 4, 5, 6, 7, 8, 9});
+        model.intersection(setVars, intersect, true).post();
+
+        assertEquals(1, checkSolutions(model, setVars, intersect));
     }
 
     @Test(groups = "1s", timeOut=60000)
@@ -91,8 +133,68 @@ public class IntersectionTest {
         assertFalse(model.getSolver().solve());
     }
 
+    private final Random rand = new Random();
 
-    private void checkSolutions(Model model, SetVar[] setVars, SetVar intersect) {
+    private TIntSet randIntSet() {
+        int size = rand.nextInt(6);
+        TIntSet set = new TIntHashSet(size);
+        for (int i = 0; i < size; i++) {
+            set.add(rand.nextInt(5));
+        }
+        return set;
+    }
+
+    private SetVar randSet(String name, Model model) {
+        TIntSet lb = randIntSet();
+        TIntSet ub = randIntSet();
+        ub.addAll(lb);
+        return model.setVar(name, lb.toArray(), ub.toArray());
+    }
+
+    @Test(groups = "1s", timeOut=60000)
+    public void testFuzzIdempotent() {
+        for (int repeat = 0; repeat < 100; repeat++) {
+            Model model = new Model();
+            model.set(new Settings() {
+
+                @Override
+                public Settings.Idem getIdempotencyStrategy() {
+                    return Settings.Idem.error;
+                }
+            });
+            SetVar[] sets = new SetVar[rand.nextInt(5) + 1];
+            for (int i = 0; i < sets.length; i++) {
+                sets[i] = randSet("set#" + i, model);
+            }
+            SetVar intersection = randSet("interection", model);
+            model.intersection(sets, intersection).post();
+            checkSolutions(model, sets, intersection);
+        }
+    }
+
+    @Test(groups = "1s", timeOut=60000)
+    public void testFuzzIdempotentAndBoundConsistent() {
+        for (int repeat = 0; repeat < 100; repeat++) {
+            Model model = new Model();
+            model.set(new Settings() {
+
+                @Override
+                public Settings.Idem getIdempotencyStrategy() {
+                    return Settings.Idem.error;
+                }
+            });
+            SetVar[] sets = new SetVar[rand.nextInt(5) + 1];
+            for (int i = 0; i < sets.length; i++) {
+                sets[i] = randSet("set#" + i, model);
+            }
+            SetVar intersection = randSet("intersection", model);
+            model.intersection(sets, intersection, true).post();
+            model.getSolver().plugMonitor(new BoundConsistent(model.getSolver()));
+            checkSolutions(model, sets, intersection);
+        }
+    }
+
+    private int checkSolutions(Model model, SetVar[] setVars, SetVar intersect) {
         int nbSol = 0;
         while (model.getSolver().solve()) {
             nbSol++;
@@ -106,8 +208,38 @@ public class IntersectionTest {
                 assertTrue(computed.contains(inIntersect));
             }
         }
-        assertTrue(nbSol > 0);
+        return nbSol;
     }
 
+    // Throws an error when bound consistency is violated.
+    public class BoundConsistent implements IMonitorDownBranch, IMonitorContradiction {
 
+        private final Solver solver;
+        private final StringBuilder lastDecision = new StringBuilder();
+
+        public BoundConsistent(Solver solver) {
+            this.solver = solver;
+        }
+
+        @Override
+        public void beforeDownBranch(boolean left) {
+            Variable[] vars = solver.getModel().getVars();
+            // Clear the string.
+            lastDecision.setLength(0);
+            lastDecision.append(left ? "Left" : "Right").append(" branch: ").append(solver.getDecisionPath().getLastDecision()).append('\n');
+            lastDecision.append("Variables: ");
+            for (Variable var : vars) {
+                lastDecision.append(var).append(' ');
+            }
+        }
+
+        @Override
+        public void onContradiction(ContradictionException cex) {
+            if (lastDecision.length() > 0) {
+                // Encountered a contradiction after a decision, hence not
+                // bound consistent since that decision should have been pruned.
+                throw new Error("Not bound consistent: " + "\n" + lastDecision + "\n" + cex, cex);
+            }
+        }
+    }
 }


### PR DESCRIPTION
This PR is with regards to issue #448.

I know in your message you said to specialize it for the binary case, but I need it for the n-ary case.

I've ran about a million fuzz tests for the intersection constraint. Based on these tests, I think PropIntersection and PropIntersectionFilterSets are both idempotent. In addition, I think the combination of these two propagators are bound consistent. I couldn't find a counterexample in the million fuzz tests.