### PR TITLE
Fix scale view instantiation.

### DIFF
--- a/src/main/java/org/chocosolver/solver/variables/view/ScaleView.java
+++ b/src/main/java/org/chocosolver/solver/variables/view/ScaleView.java
@@ -81,6 +81,9 @@ public final class ScaleView extends IntView {
 
     @Override
     protected boolean doInstantiateVar(int value) throws ContradictionException {
+        if (value % cste != 0) {
+            this.contradiction(this, MSG_INST);
+        }
         return var.instantiateTo(value / cste, this);
     }
 


### PR DESCRIPTION
Scale view allows instantiating to a value it does not contain. For example

```
      public static void main(String[] args) throws Exception {
        Model m = new Model();
        IntVar i = m.intVar("i", 0, 4);
        m.arithm(m.intScaleView(i, 10), "=", 11).post();

        Solver s = m.getSolver();
        while (s.solve()) {
            System.out.println(i + " * 10 = 11");
        }
    }
```

This will find solutions (and fail the entailment check).