### PR TITLE
Fix PropElement::isEntailed index out of range exception.

### DIFF
--- a/src/main/java/org/chocosolver/solver/constraints/set/PropElement.java
+++ b/src/main/java/org/chocosolver/solver/constraints/set/PropElement.java
@@ -186,10 +186,11 @@ public class PropElement extends Propagator<Variable> {
     @Override
     public ESat isEntailed() {
         if (index.isInstantiated()) {
-            if (disjoint(set, array[index.getValue() - offSet]) || disjoint(array[index.getValue() - offSet], set)) {
+            int i = index.getValue() - offSet;
+            if (i < 0 || i >= array.length || disjoint(set, array[i]) || disjoint(array[i], set)) {
                 return ESat.FALSE;
             } else {
-                if (set.isInstantiated() && array[index.getValue() - offSet].isInstantiated()) {
+                if (set.isInstantiated() && array[i].isInstantiated()) {
                     return ESat.TRUE;
                 } else {
                     return ESat.UNDEFINED;


### PR DESCRIPTION
For example, the following code will throw an index out of bounds exception:

```java
    public static void main(String[] args) {
        Model model = new Model();
        Constraint constraint = model.element(
                model.intVar(-1),
                new SetVar[]{model.setVar(1, 2, 3), model.setVar(2, 3, 4)},
                model.setVar("set", new int[0], new int[]{0, 1, 2, 3, 4})
        );
        System.out.println(constraint.isSatisfied());
    }
```