### PR TITLE
Fixed ArrayUtils.reverse() for generic data types when the array size is even

### DIFF
--- a/src/main/java/org/chocosolver/util/tools/ArrayUtils.java
+++ b/src/main/java/org/chocosolver/util/tools/ArrayUtils.java
@@ -38,7 +38,7 @@ import java.util.*;
  * This class contains various methods for manipulating arrays.
  * <br/>
  *
- * @author Charles Prud'homme, Jean-Guillaume Fages
+ * @author Charles Prud'homme, Jean-Guillaume Fages, Rene Helmke
  * @since 17 sept. 2010
  */
 public enum ArrayUtils {
@@ -269,11 +269,11 @@ public enum ArrayUtils {
      */
     public static <T> void reverse(T[] tab) {
         T tmp;
-        final int n = tab.length - 1;
+        final int n = tab.length;
         for (int i = 0; i < n / 2; i++) {
             tmp = tab[i];
-            tab[i] = tab[n - i];
-            tab[n - i] = tmp;
+            tab[i] = tab[n - i - 1];
+            tab[n - i - 1] = tmp;
         }
     }
 

--- a/src/test/java/org/chocosolver/util/tools/ArrayUtilsTest.java
+++ b/src/test/java/org/chocosolver/util/tools/ArrayUtilsTest.java
@@ -38,7 +38,7 @@ import org.testng.annotations.Test;
  * <p>
  * Project: choco.
  *
- * @author Charles Prud'homme
+ * @author Charles Prud'homme, Rene Helmke
  * @since 15/12/2015.
  */
 public class ArrayUtilsTest {
@@ -187,12 +187,13 @@ public class ArrayUtilsTest {
 
     @Test(groups="1s", timeOut=60000)
     public void testReverse1() throws Exception {
-        Number[] n1 = new Number[3];
+        Number[] n1 = new Number[4];
         n1[0] = 0.D;
         n1[1] = 1.D;
         n1[2] = 2.D;
+        n1[3] = 3.D;
         ArrayUtils.reverse(n1);
-        Assert.assertEquals(n1, new Number[]{2.D,1.D,0.D});
+        Assert.assertEquals(n1, new Number[]{3.D,2.D,1.D,0.D});
     }
 
     @Test(groups="1s", timeOut=60000)


### PR DESCRIPTION
The generic ArrayUtils.reverse() calculates the middle-element for Arrays containing an even number of elements wrong. Arrays containing an even amount of elements are being reversed improperly. This pull-Request fixes that issue.