### PR TITLE
Added minor patch for missing initialization when calling propagate() before solve()

### DIFF
--- a/src/main/java/org/chocosolver/sat/PropNogoods.java
+++ b/src/main/java/org/chocosolver/sat/PropNogoods.java
@@ -143,7 +143,7 @@ public class PropNogoods extends Propagator<IntVar> {
 
     @Override
     public void propagate(int evtmask) throws ContradictionException {
-        assert initialized:"PropNogoods is not initialized";
+        if (!initialized) initialize();
         if (!sat_.ok_) fails();
         fp.clear();
         sat_.cancelUntil(0); // to deal with learnt clauses, only called on coarse grain propagation


### PR DESCRIPTION
I would like to propose this pull request. In ASSIST, we are calling propagate after adding a set of constraints to check, if the problem is still solvable. Unfortunately, initialize() is only called as part of solve(), so our propagate() calls hit the assertion. We could fix this by lines:

[ASSISTSolver.xtend](https://github.com/RobertHilbrich/assist-public/blob/master/ch.hilbri.assist.mapping/src/ch/hilbri/assist/mapping/solver/AssistSolver.xtend) lines 90-92, but this is not good for readability.

@chocoteam/core-developer 
