### PR TITLE
Add an alternative constructor to AbstractVariable (explicit EvtScheduler) to maintain choco-graph compatibility

### DIFF
--- a/src/main/java/org/chocosolver/solver/variables/impl/AbstractVariable.java
+++ b/src/main/java/org/chocosolver/solver/variables/impl/AbstractVariable.java
@@ -149,6 +149,27 @@ public abstract class AbstractVariable implements Variable {
     //////////////////////////////////////////////////////////////////////////////////////
 
     /**
+     * Constructor to be used by choco extension. This (for the moment) a workaround for ensuring choco-graph
+     * compatibility (cf. comment in second constructor).
+     * @param name
+     * @param model
+     * @param scheduler
+     */
+    protected AbstractVariable(String name, Model model, EvtScheduler scheduler) {
+        this.name = name;
+        this.model = model;
+        this.views = new IView[2];
+        this.monitors = new IVariableMonitor[2];
+        this.propagators = new Propagator[8];
+        this.pindices = new int[8];
+        this.ID = this.model.nextId();
+        this.model.associates(this);
+        this.scheduler = scheduler;
+        this.dsize = this.scheduler.select(0) + 1;
+        this.dindices = new int[dsize + 1];
+    }
+
+    /**
      * Create the shared data of any type of variable.
      *
      * @param name  name of the variable
@@ -180,6 +201,13 @@ public abstract class AbstractVariable implements Variable {
             default:
                 // do not throw exception to allow extending the solver with other variable kinds (e.g. graph)
                 // event scheduler may be managed using java reflexion
+                //
+                // Comment by @Dimitri: This could be enhanced. The two following line will cause error in choco
+                //                      extensions (e.g. choco-graph). As a workaround I added the above constructor
+                //                      with an explicit scheduler argument, but this add code redundancy.
+                //                      I guess that a good solution would be to have the "typeAndkind()" information,
+                //                      (as well as which EvtScheduler to instantiate) to be defined at
+                //                      the class level.
                 break;
         }
         this.dsize = this.scheduler.select(0) + 1;


### PR DESCRIPTION
Some modifications since choco 4.0.6 broke the compatibility with choco-graph, but... I love both choco and choco-graph and I want to use both newest versions :cry:

The problem is located in the constructor of AbstractVariable. In fact, it tries to do operations on the EvtScheduler, which is not yet instantiated in choco-graph, since java reflexion is used afterwards for it.

As a workaround, I added an alternative constructor which accepts an EvtScheduler as an argument.

However, I believe that this could be handled more elegantly, such as for instance by defining the typeAndKind() and the EvtScheduler implementation at the class level. I did not want to make any design choice, but I am ok to work on this if needed.

PS: I have a commit for the choco-graph side, that I will pull request if this one is accepted, and then all the world will use choco and choco-graph newest versions, yeeeahhh !