### PR TITLE
Add stable module name

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -297,6 +297,9 @@
                         <manifest>
                             <addClasspath>true</addClasspath>
                         </manifest>
+                        <manifestEntries>
+                            <Automatic-Module-Name>org.chocosolver</Automatic-Module-Name>
+                        </manifestEntries>
                     </archive>
                     <finalName>${project.artifactId}-${project.version}-no-dep</finalName>
                 </configuration>


### PR DESCRIPTION
Fixes N/A .

#### Changes proposed in this PR:
- Add an Automatic-Module-Name entry to the MANIFEST.MF in order to be able to use the project as a dependency in modularized projects

#### Problem

We are developing a Combinatorial Testing Framework at [coffee4j](https://github.com/coffee4j/coffee4j) and we're using Choco Solver as a dependency. We aim to modularize our project with Java 9 Modules introduced with [Project Jigsaw](https://openjdk.java.net/projects/jigsaw/).
While compiling maven gives us this error message:
```
***********************************************************************************************************************************************
* Required filename-based automodules detected: [choco-solver-4.10.0.jar]. Please don't publish this project to a public artifact repository! *
***********************************************************************************************************************************************
```
as Choco Solver does indeed not specify an automatic module name. Other popular projects like Mockito (see mockito/mockito#1195 and mockito/mockito#1189) or AssertJ (see joel-costigliola/assertj-core#1221 and joel-costigliola/assertj-core#1220) in the past solved this problem by adding an Automatic-Module-Name entry to the MANIFEST.MF (short explanation how [here](http://branchandbound.net/blog/java/2017/12/automatic-module-name/), short summary of [naming conventions](https://sormuras.github.io/blog/2018-11-16-invalid-automatic-module-names.html) from one of the JUnit Developers).

We'd loved to see this change integrated, because we would like to use Java 9 Modules while still being able to publish our project to a public repository.
 
@chocoteam/core-developer
