### PR TITLE
#641 - release no-dep.jar to maven repository.

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ So you only have to edit your `pom.xml` to declare the following library depende
    <groupId>org.choco-solver</groupId>
    <artifactId>choco-solver</artifactId>
    <version>4.10.2</version>
+   <classifier>no-dep</classifier>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -301,7 +301,7 @@
                             <Automatic-Module-Name>org.chocosolver</Automatic-Module-Name>
                         </manifestEntries>
                     </archive>
-                    <finalName>${project.artifactId}-${project.version}-no-dep</finalName>
+                    <classifier>no-dep</classifier>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
Fixes #641 

Changes proposed in this PR:
- releases both fat-jar and no-dep jar to maven repository.
 
To validate the chage, you can run `mvn install` and then  mvn will add both jar files to ~/.m2 folder.

@chocoteam/core-developer 
