### PR TITLE
solver time stop criterion returns true despite search not started after call to hardReset()

### DIFF
--- a/src/main/java/org/chocosolver/solver/Solver.java
+++ b/src/main/java/org/chocosolver/solver/Solver.java
@@ -20,7 +20,6 @@ import org.chocosolver.solver.objective.ObjectiveFactory;
 import org.chocosolver.solver.propagation.PropagationEngine;
 import org.chocosolver.solver.search.SearchState;
 import org.chocosolver.solver.search.limits.ICounter;
-import org.chocosolver.solver.search.limits.TimeCounter;
 import org.chocosolver.solver.search.loop.Reporting;
 import org.chocosolver.solver.search.loop.learn.Learn;
 import org.chocosolver.solver.search.loop.learn.LearnNothing;

--- a/src/main/java/org/chocosolver/solver/Solver.java
+++ b/src/main/java/org/chocosolver/solver/Solver.java
@@ -752,9 +752,6 @@ public class Solver implements ISolver, IMeasures, IOutputFactory {
     public boolean isStopCriterionMet() {
         boolean ismet = false;
         for (int i = 0; i < criteria.size() && !ismet; i++) {
-            if(criteria.get(i) instanceof TimeCounter && this.getNodeCount() <= 0) {
-                continue; // time limit for search is not reached when search is not started
-            }
             ismet = criteria.get(i).isMet();
         }
         return ismet;

--- a/src/main/java/org/chocosolver/solver/Solver.java
+++ b/src/main/java/org/chocosolver/solver/Solver.java
@@ -20,6 +20,7 @@ import org.chocosolver.solver.objective.ObjectiveFactory;
 import org.chocosolver.solver.propagation.PropagationEngine;
 import org.chocosolver.solver.search.SearchState;
 import org.chocosolver.solver.search.limits.ICounter;
+import org.chocosolver.solver.search.limits.TimeCounter;
 import org.chocosolver.solver.search.loop.Reporting;
 import org.chocosolver.solver.search.loop.learn.Learn;
 import org.chocosolver.solver.search.loop.learn.LearnNothing;
@@ -751,6 +752,9 @@ public class Solver implements ISolver, IMeasures, IOutputFactory {
     public boolean isStopCriterionMet() {
         boolean ismet = false;
         for (int i = 0; i < criteria.size() && !ismet; i++) {
+            if(criteria.get(i) instanceof TimeCounter && this.getNodeCount() <= 0) {
+                continue; // time limit for search is not reached when search is not started
+            }
             ismet = criteria.get(i).isMet();
         }
         return ismet;

--- a/src/main/java/org/chocosolver/solver/search/measure/MeasuresRecorder.java
+++ b/src/main/java/org/chocosolver/solver/search/measure/MeasuresRecorder.java
@@ -98,8 +98,8 @@ public final class MeasuresRecorder extends Measures {
         state = SearchState.NEW;
         objectiveOptimal = false;
         solutionCount = 0;
-        timeCount = 0;
         stopStopwatch();
+        timeCount = 0;
         nodeCount = 0;
         backtrackCount = 0;
         failCount = 0;


### PR DESCRIPTION
Fixes #648 .

Changes proposed in this PR:
- Adds an `if` test in `Solver.isStopCriterionMet()` to avoid checking time stop criterion if the search is not started (this behaviour can happen after `Solver.hardReset()` )
 
@chocoteam/core-developer 
