### PR TITLE
Adding of new constructors for Task objects

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -6,7 +6,8 @@
  Contributors must sign the CLA to grant
  the AUTHORS copyright within the terms of the BSD-4 license.
 -->
-Jean-Guillaume  Fages <jg.fages@gmail.com>,
+Jean-Guillaume Fages <jg.fages@gmail.com>,
+Arthur Godet <arth.godet@gmail.com>,
 Jan Gregor <gregor.jan@gmail.com>,
 Fabien Hermenier <fabien.hermenier@unice.fr>,
 Narendra Jussien <njussien@gmail.com>,

--- a/scripts/settings.xml
+++ b/scripts/settings.xml
@@ -16,8 +16,6 @@
             <properties>
                 <gpg.keyname>${env.GPG_KEYNAME}</gpg.keyname>
                 <gpg.passphrase>${env.GPG_PASSPHRASE}</gpg.passphrase>
-                <gpg.keyname>${env.GPG_KEYNAME}</gpg.keyname>
-                <gpg.skip>true</gpg.skip>
             </properties>
         </profile>
     </profiles>

--- a/scripts/settings.xml
+++ b/scripts/settings.xml
@@ -1,5 +1,5 @@
 <settings xmlns="http://maven.apache.org/SETTINGS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
+    xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
     <servers>
         <server>
             <id>ossrh</id>
@@ -10,6 +10,16 @@
     <profiles>
         <profile>
             <id>release</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <properties>
+                <gpg.keyname>${env.GPG_KEYNAME}</gpg.keyname>
+                <gpg.passphrase>${env.GPG_PASSPHRASE}</gpg.passphrase>
+            </properties>
+        </profile>
+        <profile>
+            <id>sign</id>
             <activation>
                 <activeByDefault>true</activeByDefault>
             </activation>

--- a/scripts/settings.xml
+++ b/scripts/settings.xml
@@ -16,16 +16,8 @@
             <properties>
                 <gpg.keyname>${env.GPG_KEYNAME}</gpg.keyname>
                 <gpg.passphrase>${env.GPG_PASSPHRASE}</gpg.passphrase>
-            </properties>
-        </profile>
-        <profile>
-            <id>sign</id>
-            <activation>
-                <activeByDefault>true</activeByDefault>
-            </activation>
-            <properties>
                 <gpg.keyname>${env.GPG_KEYNAME}</gpg.keyname>
-                <gpg.passphrase>${env.GPG_PASSPHRASE}</gpg.passphrase>
+                <gpg.skip>true</gpg.skip>
             </properties>
         </profile>
     </profiles>

--- a/solver/src/main/java/org/chocosolver/solver/variables/IVariableFactory.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/IVariableFactory.java
@@ -470,51 +470,88 @@ public interface IVariableFactory extends ISelf<Model> {
     //*************************************************************************************
 
     /**
-     * Creates a task variable, based on a starting time <i>s</i> and a processing time <i>p</i>
-     * such that: s + p = e, where <i>e</i> is the ending time.
+     * Creates a task variable, based on a starting time <i>s</i> and a duration <i>d</i>
+     * such that: s + d = e, where <i>e</i> is the ending time.
      *
      * A call to {@link Task#ensureBoundConsistency()} is required before launching the resolution,
      * this will not be done automatically.
      *
      * @param s integer variable, starting time
-     * @param p fixed processing time
+     * @param d fixed duration
      * @return a task variable.
      */
-    default Task taskVar(IntVar s, int p) {
-        return new Task(s, ref().intVar(p), ref().intOffsetView(s, p));
+    default Task taskVar(IntVar s, int d) {
+        return new Task(s, d);
     }
 
     /**
-     * Creates a task variable, based on a starting time <i>s</i> and a processing time <i>p</i>
-     * such that: s + p = e, where <i>e</i> is the ending time.
+     * Creates a task variable, based on a starting time <i>s</i> and a duration <i>d</i>
+     * such that: s + d = e, where <i>e</i> is the ending time.
      *
      * A call to {@link Task#ensureBoundConsistency()} is required before launching the resolution,
      * this will not be done automatically.
      *
      * @param s integer variable, starting time
-     * @param p fixed processing time
+     * @param d integer variable, duration
      * @return a task variable.
      */
-    default Task taskVar(IntVar s, IntVar p) {
-        int[] bounds = VariableUtils.boundsForAddition(s, p);
-        IntVar end = ref().intVar(bounds[0], bounds[1]);
-        return new Task(s, p, end);
+    default Task taskVar(IntVar s, IntVar d) {
+        if(d.isInstantiated()) {
+            return new Task(s, d, ref().intOffsetView(s, d.getValue()));
+        } else {
+            int[] bounds = VariableUtils.boundsForAddition(s, d);
+            IntVar end = ref().intVar(bounds[0], bounds[1]);
+            return new Task(s, d, end);
+        }
+    }
+
+    /**
+     * Creates a task variable, based on a starting time <i>s</i> and a duration <i>d</i>
+     * such that: s + d = e, where <i>e</i> is the ending time.
+     *
+     * A call to {@link Task#ensureBoundConsistency()} is required before launching the resolution,
+     * this will not be done automatically.
+     *
+     * @param s integer variable, starting time
+     * @param d fixed duration
+     * @param e integer variable, ending time
+     * @return a task variable.
+     */
+    default Task taskVar(IntVar s, int d, IntVar e) {
+        return new Task(s, d, e);
     }
 
     /**
      * Creates a task variable, made of a starting time <i>s</i>,
-     * a processing time <i>p</i> and an ending time <i>e</i> such that: s + p = e.
+     * a duration <i>d</i> and an ending time <i>e</i> such that: s + d = e.
      *
      * A call to {@link Task#ensureBoundConsistency()} is required before launching the resolution,
      * this will not be done automatically.
      *
      * @param s integer variable, starting time
-     * @param p integer variable, processing time
+     * @param d integer variable, duration
      * @param e integer variable, ending time
      * @return a task variable.
      */
-    default Task taskVar(IntVar s, IntVar p, IntVar e) {
-        return new Task(s, p, e);
+    default Task taskVar(IntVar s, IntVar d, IntVar e) {
+        return taskVar(s, d, e, true);
+    }
+
+    /**
+     * Creates a task variable, made of a starting time <i>s</i>,
+     * a duration <i>d</i> and an ending time <i>e</i> such that: s + d = e.
+     *
+     * A call to {@link Task#ensureBoundConsistency()} is required before launching the resolution,
+     * this will not be done automatically.
+     *
+     * @param s integer variable, starting time
+     * @param d integer variable, duration
+     * @param e integer variable, ending time
+     * @param declareMonitor boolean parameter indicating if a TaskMonitor should be declared (if several Task share the same starting, processing and ending variables, there is no need to declare several TaskMonitor)
+     * @return a task variable.
+     */
+    default Task taskVar(IntVar s, IntVar d, IntVar e, boolean declareMonitor) {
+        return new Task(s, d, e, declareMonitor);
     }
 
     /**

--- a/solver/src/main/java/org/chocosolver/solver/variables/Task.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/Task.java
@@ -22,6 +22,7 @@ import org.chocosolver.solver.learn.ExplanationForSignedClause;
 import org.chocosolver.solver.learn.Implications;
 import org.chocosolver.solver.variables.events.IEventType;
 import org.chocosolver.solver.variables.events.IntEventType;
+import org.chocosolver.solver.variables.view.OffsetView;
 import org.chocosolver.util.objects.ValueSortedMap;
 import org.chocosolver.util.objects.setDataStructures.iterable.IntIterableRangeSet;
 
@@ -52,6 +53,58 @@ public class Task {
 
     /**
      * Container representing a task:
+     * It ensures that: start + duration = end, end being an offset view of start + d.
+     *
+     * @param model the Model of the variables
+     * @param est earliest starting time
+     * @param lst latest starting time
+     * @param p processing time
+     * @param ect earliest completion time
+     * @param lct latest completion time time
+     */
+    public Task(Model model, int est, int lst, int p, int ect, int lct) {
+        start = model.intVar(est, lst);
+        duration = model.intVar(p);
+        if(ect == est+p && lct == lst+p) {
+            end = start.getModel().intOffsetView(start, p);
+        } else {
+            end = model.intVar(ect, lct);
+            declareMonitor();
+        }
+    }
+
+    /**
+     * Container representing a task:
+     * It ensures that: start + duration = end, end being an offset view of start + d.
+     *
+     * @param s start variable
+     * @param d duration value
+     */
+    public Task(IntVar s, int d) {
+        start = s;
+        duration = start.getModel().intVar(d);
+        end = start.getModel().intOffsetView(start, d);
+    }
+
+    /**
+     * Container representing a task:
+     * It ensures that: start + duration = end, end being an offset view of start + d.
+     *
+     * @param s start variable
+     * @param d duration value
+     * @param e end variable
+     */
+    public Task(IntVar s, int d, IntVar e) {
+        start = s;
+        duration = start.getModel().intVar(d);
+        end = e;
+        if(!isOffsetView(s, d, e)) {
+            declareMonitor();
+        }
+    }
+
+    /**
+     * Container representing a task:
      * It ensures that: start + duration = end
      *
      * @param s start variable
@@ -59,15 +112,53 @@ public class Task {
      * @param e end variable
      */
     public Task(IntVar s, IntVar d, IntVar e) {
+        this(s, d, e, true);
+    }
+
+    /**
+     * Container representing a task:
+     * It ensures that: start + duration = end
+     *
+     * @param s start variable
+     * @param d duration variable
+     * @param e end variable
+     * @param declareMonitor boolean parameter indicating if a TaskMonitor should be declared
+     */
+    public Task(IntVar s, IntVar d, IntVar e, boolean declareMonitor) {
         start = s;
         duration = d;
         end = e;
-        if (s.hasEnumeratedDomain() || d.hasEnumeratedDomain() || e.hasEnumeratedDomain()) {
-            update = new TaskMonitorEnum(s, d, e);
-        } else {
-            update = new TaskMonitorBound(s, d, e);
+        if(declareMonitor && (!d.isInstantiated() || !isOffsetView(s, d.getValue(), e))) {
+            declareMonitor();
         }
-        Model model = s.getModel();
+    }
+
+    private static boolean isOffsetView(IntVar s, int d, IntVar e) {
+        if(e instanceof OffsetView) {
+            OffsetView offsetView = (OffsetView) e;
+            if(offsetView.cste == d && offsetView.equals(e)) {
+                return true;
+            }
+        }
+//        for(int p = 0; p<s.getNbViews(); p++) {
+//            IView view = s.getView(p);
+//            if(view instanceof OffsetView) {
+//                OffsetView offsetView = (OffsetView) view;
+//                if(offsetView.cste == d && offsetView.equals(e)) {
+//                    return true;
+//                }
+//            }
+//        }
+        return false;
+    }
+
+    private void declareMonitor() {
+        if (start.hasEnumeratedDomain() || duration.hasEnumeratedDomain() || end.hasEnumeratedDomain()) {
+            update = new TaskMonitor(start, duration, end, true);
+        } else {
+            update = new TaskMonitor(start, duration, end, false);
+        }
+        Model model = start.getModel();
         //noinspection unchecked
         ArrayList<Task> tset = (ArrayList<Task>) model.getHook(Model.TASK_SET_HOOK_NAME);
         if(tset == null){
@@ -106,6 +197,10 @@ public class Task {
         return end;
     }
 
+    public IVariableMonitor<IntVar> getMonitor() {
+        return update;
+    }
+
     private static void doExplain(IntVar S, IntVar D, IntVar E,
                                   ExplanationForSignedClause clause,
                                   ValueSortedMap<IntVar> front,
@@ -135,105 +230,59 @@ public class Task {
         }
     }
 
-    private class TaskMonitorEnum implements IVariableMonitor<IntVar> {
-
-        private IntVar S, D, E;
-
-        public TaskMonitorEnum(IntVar S, IntVar D, IntVar E) {
-            this.S = S;
-            this.D = D;
-            this.E = E;
-            S.addMonitor(this);
-            D.addMonitor(this);
-            E.addMonitor(this);
-        }
-
-        @Override
-        public void onUpdate(IntVar var, IEventType evt) throws ContradictionException {
-            boolean fixpoint = true;
-            while (fixpoint) {
-                // start
-                fixpoint = S.updateLowerBound(E.getLB() - D.getUB(), this);
-                fixpoint |= S.updateUpperBound(E.getUB() - D.getLB(), this);
-                // end
-                fixpoint |= E.updateLowerBound(S.getLB() + D.getLB(), this);
-                fixpoint |= E.updateUpperBound(S.getUB() + D.getUB(), this);
-                // duration
-                fixpoint |= D.updateLowerBound(E.getLB() - S.getUB(), this);
-                fixpoint |= D.updateUpperBound(E.getUB() - S.getLB(), this);
-            }
-        }
-
-        @Override
-        public void explain(ExplanationForSignedClause clause,
-                            ValueSortedMap<IntVar> front,
-                            Implications ig, int p) {
-            doExplain(S, D, E, clause, front, ig, p);
-        }
-
-        @Override
-        public void forEachIntVar(Consumer<IntVar> action) {
-            action.accept(S);
-            action.accept(D);
-            action.accept(E);
-        }
-
-        @Override
-        public String toString() {
-            return "Task["+S.getName()+"+"+D.getName()+"="+E.getName()+"]";
-        }
-    }
-
-    private class TaskMonitorBound implements IVariableMonitor<IntVar> {
-
-        private IntVar S, D, E;
-
-        public TaskMonitorBound(IntVar S, IntVar D, IntVar E) {
-            this.S = S;
-            this.D = D;
-            this.E = E;
-
-            S.addMonitor(this);
-            D.addMonitor(this);
-            E.addMonitor(this);
-        }
-
-        @Override
-        public void onUpdate(IntVar var, IEventType evt) throws ContradictionException {
-            // start
-            S.updateBounds(E.getLB() - D.getUB(), E.getUB() - D.getLB(), this);
-            // end
-            E.updateBounds(S.getLB() + D.getLB(), S.getUB() + D.getUB(), this);
-            // duration
-            D.updateBounds(E.getLB() - S.getUB(), E.getUB() - S.getLB(), this);
-        }
-
-        @Override
-        public void explain(ExplanationForSignedClause clause,
-                            ValueSortedMap<IntVar> front,
-                            Implications ig, int p) {
-            doExplain(S, D, E, clause, front, ig, p);
-        }
-
-        @Override
-        public void forEachIntVar(Consumer<IntVar> action) {
-            action.accept(S);
-            action.accept(D);
-            action.accept(E);
-        }
-
-        @Override
-        public String toString() {
-            return "Task["+S.getName()+"+"+D.getName()+"="+E.getName()+"]";
-        }
-    }
-
     @Override
     public String toString() {
         return "Task[" +
-                "start=" + start +
-                ", duration=" + duration +
-                ", end=" + end +
-                ']';
+            "start=" + start +
+            ", duration=" + duration +
+            ", end=" + end +
+            ']';
+    }
+
+    private static class TaskMonitor implements IVariableMonitor<IntVar> {
+        private final IntVar S, D, E;
+        private final boolean isEnum;
+
+        private TaskMonitor(IntVar S, IntVar D, IntVar E, boolean isEnum) {
+            this.S = S;
+            this.D = D;
+            this.E = E;
+            S.addMonitor(this);
+            D.addMonitor(this);
+            E.addMonitor(this);
+            this.isEnum = isEnum;
+        }
+
+        @Override
+        public void onUpdate(IntVar var, IEventType evt) throws ContradictionException {
+            boolean fixpoint;
+            do {
+                // start
+                fixpoint = S.updateBounds(E.getLB() - D.getUB(), E.getUB() - D.getLB(), this);
+                // end
+                fixpoint |= E.updateBounds(S.getLB() + D.getLB(), S.getUB() + D.getUB(), this);
+                // duration
+                fixpoint |= D.updateBounds(E.getLB() - S.getUB(), E.getUB() - S.getLB(), this);
+            } while (fixpoint && isEnum);
+        }
+
+        @Override
+        public void explain(ExplanationForSignedClause clause,
+                            ValueSortedMap<IntVar> front,
+                            Implications ig, int p) {
+            doExplain(S, D, E, clause, front, ig, p);
+        }
+
+        @Override
+        public void forEachIntVar(Consumer<IntVar> action) {
+            action.accept(S);
+            action.accept(D);
+            action.accept(E);
+        }
+
+        @Override
+        public String toString() {
+            return "Task["+S.getName()+"+"+D.getName()+"="+E.getName()+"]";
+        }
     }
 }

--- a/solver/src/test/java/org/chocosolver/solver/variables/TaskTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/variables/TaskTest.java
@@ -12,7 +12,9 @@ package org.chocosolver.solver.variables;
 import org.chocosolver.solver.Cause;
 import org.chocosolver.solver.Model;
 import org.chocosolver.solver.exception.ContradictionException;
+import org.chocosolver.solver.variables.view.OffsetView;
 import org.chocosolver.util.ESat;
+import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
@@ -147,13 +149,122 @@ public class TaskTest {
      * @return if an overlapping exists between the tasks
      */
     private boolean collide(Task one, Task two) {
-        return one.getStart().getValue() < two.getEnd().getValue() &&
-                one.getEnd().getValue() > two.getStart().getValue();
+        return one.getStart().getValue() < two.getEnd().getValue() && one.getEnd().getValue() > two.getStart().getValue();
     }
 
     private void checkVariable(IntVar var, int lb, int ub) {
         assertEquals(var.getLB(), lb);
         assertEquals(var.getUB(), ub);
+    }
+
+    ///////////////////////////////////////////////////////////////
+    /////////////////    Task constructors test    ////////////////
+    ///////////////////////////////////////////////////////////////
+
+    private static boolean sameTaskVars(Task t1, Task t2) {
+        return t1.getStart().getLB() == t2.getStart().getLB() && t1.getStart().getUB() == t2.getStart().getUB()
+            && t1.getDuration().getLB() == t2.getDuration().getLB() && t1.getDuration().getUB() == t2.getDuration().getUB()
+            && t1.getEnd().getLB() == t2.getEnd().getLB() && t1.getEnd().getUB() == t2.getEnd().getUB();
+    }
+
+    private static boolean hasTaskMonitor(Task task) {
+        return task.getMonitor() != null;
+    }
+
+    private void specificToTask(Model m) {
+        // Task(Model model, int est, int lst, int p, int ect, int lct)
+        Task t1 = new Task(m, 0, 10, 2, 0, 10);
+        Assert.assertTrue(hasTaskMonitor(t1));
+        Task t2 = new Task(m, 0, 10, 2, 2, 12);
+        Assert.assertFalse(hasTaskMonitor(t2));
+    }
+
+    private void specificToIVariableFactory(Model m) {
+        // taskVar(IntVar s, IntVar p)
+        IntVar s = m.intVar(0, 10);
+        IntVar p = m.intVar(1,5);
+        Task t1 = m.taskVar(s, p);
+        Assert.assertTrue(hasTaskMonitor(t1));
+
+        Task t2 = m.taskVar(s, m.intVar(2));
+        Assert.assertTrue(t2.getEnd() instanceof OffsetView);
+        Assert.assertFalse(hasTaskMonitor(t2));
+    }
+
+    private void inCommon(Model m) {
+        int d = 2;
+
+        // Task(IntVar s, int d)
+        Task t1 = new Task(m.intVar(0, 10), d);
+        Task t2 = m.taskVar(m.intVar(0, 10), d);
+        Assert.assertTrue(sameTaskVars(t1, t2));
+        Assert.assertFalse(hasTaskMonitor(t1));
+        Assert.assertFalse(hasTaskMonitor(t2));
+
+        // Task(IntVar s, int d, IntVar e)
+        Task t3 = new Task(m.intVar(0, 10), d, m.intVar(0, 10));
+        Task t4 = m.taskVar(m.intVar(0, 10), d, m.intVar(0, 10));
+        Assert.assertTrue(sameTaskVars(t3, t4));
+        Assert.assertTrue(hasTaskMonitor(t3));
+        Assert.assertTrue(hasTaskMonitor(t4));
+
+        IntVar s5 = m.intVar(0, 10);
+        Task t5 = new Task(s5, d, m.intOffsetView(s5, d));
+        IntVar s6 = m.intVar(0, 10);
+        Task t6 = m.taskVar(s6, d, m.intOffsetView(s6, d));
+        Assert.assertTrue(sameTaskVars(t5, t6));
+        Assert.assertFalse(hasTaskMonitor(t5));
+        Assert.assertFalse(hasTaskMonitor(t6));
+
+        // Task(IntVar s, IntVar d, IntVar e)
+        Task t7 = new Task(m.intVar(0, 10), m.intVar(1, 5), m.intVar(0, 10));
+        Task t8 = m.taskVar(m.intVar(0, 10), m.intVar(1, 5), m.intVar(0, 10));
+        Assert.assertTrue(sameTaskVars(t7, t8));
+        Assert.assertTrue(hasTaskMonitor(t7));
+        Assert.assertTrue(hasTaskMonitor(t8));
+
+        IntVar s9 = m.intVar(0, 10);
+        Task t9 = new Task(s9, m.intVar(d), m.intOffsetView(s9, d));
+        IntVar s10 = m.intVar(0, 10);
+        Task t10 = m.taskVar(s10, m.intVar(d), m.intOffsetView(s10, d));
+        Assert.assertTrue(sameTaskVars(t9, t10));
+        Assert.assertFalse(hasTaskMonitor(t9));
+        Assert.assertFalse(hasTaskMonitor(t10));
+
+        // Task(IntVar s, IntVar d, IntVar e, boolean declareMonitor)
+        Task t11 = new Task(m.intVar(0, 10), m.intVar(1, 5), m.intVar(0, 10), true);
+        Task t12 = m.taskVar(m.intVar(0, 10), m.intVar(1, 5), m.intVar(0, 10), true);
+        Assert.assertTrue(sameTaskVars(t11, t12));
+        Assert.assertTrue(hasTaskMonitor(t11));
+        Assert.assertTrue(hasTaskMonitor(t12));
+
+        Task t13 = new Task(m.intVar(0, 10), m.intVar(1, 5), m.intVar(0, 10), false);
+        Task t14 = m.taskVar(m.intVar(0, 10), m.intVar(1, 5), m.intVar(0, 10), false);
+        Assert.assertTrue(sameTaskVars(t13, t14));
+        Assert.assertFalse(hasTaskMonitor(t13));
+        Assert.assertFalse(hasTaskMonitor(t14));
+
+        IntVar s15 = m.intVar(0, 10);
+        Task t15 = new Task(s15, m.intVar(d), m.intOffsetView(s15, d), true);
+        IntVar s16 = m.intVar(0, 10);
+        Task t16 = m.taskVar(s16, m.intVar(d), m.intOffsetView(s16, d), true);
+        Assert.assertTrue(sameTaskVars(t15, t16));
+        Assert.assertFalse(hasTaskMonitor(t15));
+        Assert.assertFalse(hasTaskMonitor(t16));
+    }
+
+    @Test(groups = "1s", timeOut=60000)
+    public void testingTaskConstructors() {
+        Model m = new Model();
+
+        /* Task specific constructors */
+        specificToTask(m);
+
+        /* Constructing methods in common between Task and IVariableFactory */
+        inCommon(m);
+
+        /* IVariableFactory specific constructors */
+        specificToIVariableFactory(m);
     }
 
 


### PR DESCRIPTION
Fixes #643 .

Changes proposed in this PR:
-  Adding of new constructors to help the user creating Task objects (with optimal solver-memory use)

The idea of adding an IntVar for height inside the Task object (as it could be in other solvers) was rejected : a same Task (understand a time interval) could be used in several cumulative constraints with different resource consumption (different height).

This pull request is the same as #654 but this one is created with higher rights from the beginning.

@chocoteam/core-developer