### PR TITLE
Enable nogood stealing (on restart) for ParallelPortfolio

### DIFF
--- a/solver/src/main/java/org/chocosolver/solver/constraints/nary/sat/NogoodStealer.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/nary/sat/NogoodStealer.java
@@ -1,0 +1,152 @@
+/**
+ * This file is part of choco-solver, http://choco-solver.org/
+ *
+ * Copyright (c) 2017, IMT Atlantique. All rights reserved.
+ *
+ * Licensed under the BSD 4-clause license. See LICENSE file in the project root for full license
+ * information.
+ */
+package org.chocosolver.solver.constraints.nary.sat;
+
+import gnu.trove.map.hash.TIntIntHashMap;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import org.chocosolver.solver.Model;
+import org.chocosolver.solver.search.loop.monitors.NogoodFromRestarts;
+import org.chocosolver.solver.variables.Variable;
+
+/**
+ * This class manages no-goods sharing among models involved in a {@link
+ * org.chocosolver.solver.ParallelPortfolio}. In this, we make the following hypothesis: all models
+ * were created following the very same steps. The consequence is that a variable has the same ID in
+ * all models.
+ * <p>
+ * Project: choco.
+ *
+ * @author Charles Prud'homme
+ * @since 10/02/2020.
+ */
+public class NogoodStealer {
+
+    /**
+     * A singleton that steals nothing
+     */
+    public static final NogoodStealer NONE = new NogoodStealer() {
+        @Override
+        public void add(Model model) {
+            // void
+        }
+
+        @Override
+        public synchronized void nogoodStealing(Model model, NogoodFromRestarts caller) {
+            // void
+        }
+
+        @Override
+        public <V extends Variable> V getById(V var, Model model) {
+            return var;
+        }
+    };
+
+    /**
+     * List of models to steal nogoods from
+     */
+    private final List<Model> models;
+
+    /**
+     * Maintain relation between id of a variable and its position in a model.
+     * @implSpec This is a strong assumption that all models are equivalent (ie, each variable
+     * has the same ID among models).
+     */
+    private final TIntIntHashMap id2pos;
+
+    /**
+     * Create a class that steal nogoods (based on decision path) from models and store them in
+     * another one.
+     */
+    public NogoodStealer() {
+        this.models = new ArrayList<>();
+        this.id2pos = new TIntIntHashMap(10,.5f,-1,-1);
+    }
+
+    /**
+     * Add a model to steal nogood from (based on decision path)
+     * @param model
+     */
+    public void add(Model model) {
+        assert valid(model): "Cannot share nogoods between non equivalent models";
+        this.models.add(model);
+    }
+
+    private boolean valid(Model model) {
+        if (this.models.size() > 0) {
+            Variable[] vars0 = this.models.get(0).getVars();
+            Variable[] vars1 = model.getVars();
+            if (vars0.length == vars1.length) {
+                for (int i = 0; i < vars0.length; i++) {
+                    if (vars0[i].getId() != vars1[i].getId()
+                        || !vars0[i].getName().equals(vars1[i].getName())
+                        || vars0[i].getNbProps() != vars1[i].getNbProps()) {
+                        return false;
+                    }
+                }
+            } else {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Extract nogoods from decision paths of all models but <i>model</i>.
+     * @param model the model to skip
+     * @param caller nogoods extractor
+     */
+    public synchronized void nogoodStealing(Model model, NogoodFromRestarts caller) {
+        for (Model m : models) {
+            if (m != model) {
+                caller.extractNogoodFromPath(m.getSolver().getDecisionPath());
+            }
+        }
+    }
+
+    /**
+     * @param <V> type of variable to find
+     * @param var variable to look for (based on its ID)
+     * @param model prop
+     * @return the variable equivalent to <i>var</i> to declared in <i>png</i>
+     * (ie, from another model)
+     */
+    public <V extends Variable> V getById(V var, Model model) {
+        int p = id2pos.get(var.getId());
+        if(p == -1){
+            p = binarySearch(model, var.getId());
+        }
+        //noinspection unchecked
+        return (V) model.getVar(p);
+    }
+
+    /**
+     * Adapted from {@link java.util.Arrays#binarySearch(Object[], Object, Comparator)}
+     */
+    private static <T> int binarySearch(Model model, int key) {
+        int low = 0;
+        int high = model.getNbVars();
+
+        while (low <= high) {
+            int mid = (low + high) >>> 1;
+            Variable midVal = model.getVar(mid);
+            int cmp = midVal.getId() - key;
+            if (cmp < 0) {
+                low = mid + 1;
+            } else if (cmp > 0) {
+                high = mid - 1;
+            } else {
+                return mid; // key found
+            }
+        }
+        return -(low + 1);  // key not found.
+    }
+
+}

--- a/solver/src/main/java/org/chocosolver/solver/constraints/nary/sat/NogoodStealer.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/nary/sat/NogoodStealer.java
@@ -87,7 +87,8 @@ public class NogoodStealer {
                 for (int i = 0; i < vars0.length; i++) {
                     if (vars0[i].getId() != vars1[i].getId()
                         || !vars0[i].getName().equals(vars1[i].getName())
-                        || vars0[i].getNbProps() != vars1[i].getNbProps()) {
+                        || vars0[i].getNbProps() != vars1[i].getNbProps()
+                    ) {
                         return false;
                     }
                 }

--- a/solver/src/main/java/org/chocosolver/solver/constraints/nary/sat/PropNogoods.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/nary/sat/PropNogoods.java
@@ -9,27 +9,32 @@
  */
 package org.chocosolver.solver.constraints.nary.sat;
 
+import static org.chocosolver.sat.SatSolver.makeLiteral;
+import static org.chocosolver.sat.SatSolver.negated;
+import static org.chocosolver.sat.SatSolver.sign;
+import static org.chocosolver.sat.SatSolver.var;
+
 import gnu.trove.list.TIntList;
 import gnu.trove.list.array.TIntArrayList;
 import gnu.trove.map.hash.TIntObjectHashMap;
 import gnu.trove.map.hash.TLongIntHashMap;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.BitSet;
+import java.util.Deque;
 import org.chocosolver.memory.IStateInt;
 import org.chocosolver.sat.SatSolver;
-import org.chocosolver.sat.SatSolver.*;
+import org.chocosolver.sat.SatSolver.Clause;
 import org.chocosolver.solver.Model;
 import org.chocosolver.solver.constraints.Propagator;
 import org.chocosolver.solver.constraints.PropagatorPriority;
 import org.chocosolver.solver.exception.ContradictionException;
-import org.chocosolver.solver.variables.BoolVar;
 import org.chocosolver.solver.variables.IntVar;
 import org.chocosolver.solver.variables.SetVar;
 import org.chocosolver.solver.variables.Variable;
 import org.chocosolver.util.ESat;
 import org.chocosolver.util.tools.VariableUtils;
-
-import java.util.*;
-
-import static org.chocosolver.sat.SatSolver.*;
 
 
 /**
@@ -125,7 +130,7 @@ public class PropNogoods extends Propagator<Variable> {
      * @param model the model that declares the propagator
      */
     public PropNogoods(Model model) {
-        super(new BoolVar[]{model.boolVar(true)}, PropagatorPriority.VERY_SLOW, true);
+        super(new Variable[]{model.getVar(0)}, PropagatorPriority.VERY_SLOW, true);
         this.vars = new Variable[0];// erase model.ONE from the variable scope
 
         int k = 16;

--- a/solver/src/main/java/org/chocosolver/solver/search/loop/monitors/NogoodFromRestarts.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/loop/monitors/NogoodFromRestarts.java
@@ -9,16 +9,21 @@
  */
 package org.chocosolver.solver.search.loop.monitors;
 
-import org.chocosolver.sat.SatSolver;
-import org.chocosolver.solver.Model;
-import org.chocosolver.solver.constraints.nary.sat.PropNogoods;
-import org.chocosolver.solver.search.strategy.assignments.DecisionOperatorFactory;
-import org.chocosolver.solver.search.strategy.decision.Decision;
-import org.chocosolver.solver.search.strategy.decision.IntDecision;
-import org.chocosolver.solver.search.strategy.decision.SetDecision;
-
 import java.util.ArrayDeque;
 import java.util.Arrays;
+import org.chocosolver.sat.SatSolver;
+import org.chocosolver.solver.Model;
+import org.chocosolver.solver.constraints.nary.sat.NogoodStealer;
+import org.chocosolver.solver.constraints.nary.sat.PropNogoods;
+import org.chocosolver.solver.search.strategy.assignments.DecisionOperator;
+import org.chocosolver.solver.search.strategy.assignments.DecisionOperatorFactory;
+import org.chocosolver.solver.search.strategy.decision.Decision;
+import org.chocosolver.solver.search.strategy.decision.DecisionPath;
+import org.chocosolver.solver.search.strategy.decision.IntDecision;
+import org.chocosolver.solver.search.strategy.decision.SetDecision;
+import org.chocosolver.solver.variables.IntVar;
+import org.chocosolver.solver.variables.SetVar;
+import org.chocosolver.solver.variables.Variable;
 
 /**
  * A constraint for the specific Nogood store designed to store ONLY positive decisions.
@@ -38,6 +43,7 @@ public class NogoodFromRestarts implements IMonitorRestart {
     /**
      * Stores the decision path before
      */
+    @SuppressWarnings("rawtypes")
     private ArrayDeque<Decision> decisions;
 
     /**
@@ -46,107 +52,110 @@ public class NogoodFromRestarts implements IMonitorRestart {
     private final PropNogoods png;
 
     /**
-     * A constraint for the specific Nogood store designed to store ONLY positive decisions.
-     * Beware :
-     * - Must be posted as a constraint AND plugged as a monitor as well
-     * - Cannot be reified
-     * - Only works for integer variables
-     * - Only works if branching decisions are assignments (neither domain split nor value removal)
-     *
+     * {@link NogoodStealer} that helps sharing no-goods among models.
+     */
+    private final NogoodStealer nogoodStealer;
+
+    /**
+     * A constraint for the specific Nogood store designed to store IntVar and SetVar-based decisions.
      * @param model solver to observe
      */
     public NogoodFromRestarts(Model model) {
-        png = model.getNogoodStore().getPropNogoods();
-        decisions = new ArrayDeque<>(16);
+        this(model, NogoodStealer.NONE);
+    }
+
+    /**
+     * A constraint for the specific Nogood store designed to store IntVar and SetVar-based decisions.
+     * @param model solver to observe
+     * @param stealer when nogoods can be shared among (equivalent) models
+     */
+    public NogoodFromRestarts(Model model, NogoodStealer stealer) {
+        this.png = model.getNogoodStore().getPropNogoods();
+        this.decisions = new ArrayDeque<>(16);
+        this.nogoodStealer = stealer;
+        this.nogoodStealer.add(model);
     }
 
     @Override
     public void beforeRestart() {
-        extractNogoodFromPath();
+        extractNogoodFromPath(png.getModel().getSolver().getDecisionPath());
+        nogoodStealer.nogoodStealing(png.getModel(), this);
     }
 
     @SuppressWarnings("unchecked")
-    private void extractNogoodFromPath() {
-        int d = (int) png.getModel().getSolver().getNodeCount();
-        png.getModel().getSolver().getDecisionPath().transferInto(decisions, false);
-        Decision decision;
+    public void extractNogoodFromPath(DecisionPath decisionPath) {
+        assert decisions.isEmpty();
+        decisionPath.transferInto(decisions, false);
+        int d = decisions.size();
+        Decision<Variable> decision;
         int[] lits = new int[d];
         int i = 0;
         while (!decisions.isEmpty()) {
             decision = decisions.pollFirst();
-            if (decision instanceof IntDecision) {
-                IntDecision id = (IntDecision) decision;
-                if (id.getDecOp() == DecisionOperatorFactory.makeIntEq()) {
-                    if (id.hasNext() || id.getArity() == 1) {
-                        lits[i++] = SatSolver.negated(png.Literal(id.getDecisionVariable(), id.getDecisionValue(), true));
-                    } else {
-                        if (i == 0) {
-                            // value can be removed permanently from var!
-                            png.addLearnt(SatSolver.negated(png.Literal(id.getDecisionVariable(), id.getDecisionValue(), true)));
-                        } else {
-                            lits[i] = SatSolver.negated(png.Literal(id.getDecisionVariable(), id.getDecisionValue(), true));
-                            png.addLearnt(Arrays.copyOf(lits, i + 1));
-                        }
-                    }
-                } else if (id.getDecOp() == DecisionOperatorFactory.makeIntNeq()) {
-                    if (id.hasNext()) {
-                        lits[i++] = png.Literal(id.getDecisionVariable(), id.getDecisionValue(), true);
-                    } else {
-                        if (i == 0) {
-                            // value can be removed permanently from var!
-                            png.addLearnt(png.Literal(id.getDecisionVariable(), id.getDecisionValue(), true));
-                        } else {
-                            lits[i] = png.Literal(id.getDecisionVariable(), id.getDecisionValue(), true);
-                            png.addLearnt(Arrays.copyOf(lits, i + 1));
-                        }
-                    }
-                } else if (id.getDecOp() == DecisionOperatorFactory.makeIntSplit()) {
-                    if (id.hasNext() || id.getArity() == 1) {
-                        lits[i++] = SatSolver.negated(png.Literal(id.getDecisionVariable(), id.getDecisionValue(), false));
-                    } else {
-                        if (i == 0) {
-                            // value can be removed permanently from var!
-                            png.addLearnt(SatSolver.negated(png.Literal(id.getDecisionVariable(), id.getDecisionValue(), false)));
-                        } else {
-                            lits[i] = SatSolver.negated(png.Literal(id.getDecisionVariable(), id.getDecisionValue(), false));
-                            png.addLearnt(Arrays.copyOf(lits, i + 1));
-                        }
-                    }
-                } else if (id.getDecOp() == DecisionOperatorFactory.makeIntReverseSplit()) {
-                    if (id.hasNext()) {
-                        lits[i++] = png.Literal(id.getDecisionVariable(), id.getDecisionValue(), false);
-                    } else {
-                        if (i == 0) {
-                            // value can be removed permanently from var!
-                            png.addLearnt(png.Literal(id.getDecisionVariable(), id.getDecisionValue(), false));
-                        } else {
-                            lits[i] = png.Literal(id.getDecisionVariable(), id.getDecisionValue(), false);
-                            png.addLearnt(Arrays.copyOf(lits, i + 1));
-                        }
-                    }
-                } else {
-                    throw new UnsupportedOperationException("NogoodStoreFromRestarts cannot deal with such operator: " + ((IntDecision) decision).getDecOp());
-                }
-            } else if (decision instanceof SetDecision) {
-                SetDecision sd = (SetDecision) decision;
-                if (sd.getDecOp() == DecisionOperatorFactory.makeSetForce()) {
-                    if (sd.hasNext() || sd.getArity() == 1) {
-                        lits[i++] = SatSolver.negated(png.Literal(sd.getDecisionVariable(), sd.getDecisionValue(), true));
-                    } else {
-                        if (i == 0) {
-                            // value can be removed permanently from var!
-                            png.addLearnt(SatSolver.negated(png.Literal(sd.getDecisionVariable(), sd.getDecisionValue(), true)));
-                        } else {
-                            lits[i] = SatSolver.negated(png.Literal(sd.getDecisionVariable(), sd.getDecisionValue(), true));
-                            png.addLearnt(Arrays.copyOf(lits, i + 1));
-                        }
-                    }
-                } else {
-                    throw new UnsupportedOperationException("NogoodStoreFromRestarts cannot deal with such operator: " + ((SetDecision) decision).getDecOp());
-                }
+            int lit = asLit(decision);
+            if (decision.hasNext() || decision.getArity() == 1) {
+                lits[i++] = lit;
             } else {
-                throw new UnsupportedOperationException("NogoodStoreFromRestarts can only deal with IntDecision and SetDecision.");
+                if (i == 0) {
+                    // value can be removed permanently from var!
+                    png.addLearnt(lit);
+                } else {
+                    lits[i] = lit;
+                    png.addLearnt(Arrays.copyOf(lits, i + 1));
+                }
             }
         }
+    }
+
+    /**
+     * Transform this decision into a literal to be used in {@link PropNogoods}.
+     *
+     * @param decision a decision
+     * @return the literal corresponding to this decision
+     */
+    private <V extends Variable> int asLit(Decision<V> decision) {
+        if (decision instanceof IntDecision) {
+            IntDecision id = (IntDecision) decision;
+            return asLit(
+                nogoodStealer.getById(id.getDecisionVariable(), png.getModel()), id.getDecOp(),
+                id.getDecisionValue()
+            );
+        } else if (decision instanceof SetDecision) {
+            SetDecision id = (SetDecision) decision;
+            return asLit(
+                nogoodStealer.getById(id.getDecisionVariable(), png.getModel()), id.getDecOp(),
+                id.getDecisionValue()
+            );
+        } else {
+            throw new UnsupportedOperationException("Cannot deal with such decision: " + decision);
+        }
+    }
+
+    private int asLit(IntVar var, DecisionOperator<IntVar> op, int val) {
+        int l;
+        if (DecisionOperatorFactory.makeIntEq().equals(op)) {
+            l = SatSolver.negated(png.Literal(var, val, true));
+        } else if (DecisionOperatorFactory.makeIntNeq().equals(op)) {
+            l = png.Literal(var, val, true);
+        } else if (DecisionOperatorFactory.makeIntSplit().equals(op)) {
+            l = SatSolver.negated(png.Literal(var, val, false));
+        } else if (DecisionOperatorFactory.makeIntReverseSplit().equals(op)) {
+            l = png.Literal(var, val, false);
+        } else {
+            throw new UnsupportedOperationException("Cannot deal with such operator: " + op);
+        }
+        return l;
+    }
+
+    private int asLit(SetVar var, DecisionOperator<SetVar> op, int val) {
+        int l;
+        if (op == DecisionOperatorFactory.makeSetForce()) {
+            l = SatSolver.negated(png.Literal(var, val, true));
+        } else if (op == DecisionOperatorFactory.makeSetRemove()) {
+            l = png.Literal(var, val, true);
+        } else {
+            throw new UnsupportedOperationException("Cannot deal with such operator: " + op);
+        }
+        return l;
     }
 }

--- a/solver/src/main/java/org/chocosolver/solver/search/loop/monitors/NogoodFromRestarts.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/loop/monitors/NogoodFromRestarts.java
@@ -151,9 +151,9 @@ public class NogoodFromRestarts implements IMonitorRestart {
 
     private int asLit(SetVar var, DecisionOperator<SetVar> op, int val) {
         int l;
-        if (op == DecisionOperatorFactory.makeSetForce()) {
+        if (DecisionOperatorFactory.makeSetForce().equals(op)) {
             l = SatSolver.negated(png.Literal(var, val, true));
-        } else if (op == DecisionOperatorFactory.makeSetRemove()) {
+        } else if (DecisionOperatorFactory.makeSetRemove().equals(op)) {
             l = png.Literal(var, val, true);
         } else {
             throw new UnsupportedOperationException("Cannot deal with such operator: " + op);

--- a/solver/src/main/java/org/chocosolver/solver/search/loop/monitors/NogoodFromRestarts.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/loop/monitors/NogoodFromRestarts.java
@@ -117,13 +117,15 @@ public class NogoodFromRestarts implements IMonitorRestart {
         if (decision instanceof IntDecision) {
             IntDecision id = (IntDecision) decision;
             return asLit(
-                nogoodStealer.getById(id.getDecisionVariable(), png.getModel()), id.getDecOp(),
+                nogoodStealer.getById(id.getDecisionVariable(), png.getModel()), 
+                id.getDecOp(),
                 id.getDecisionValue()
             );
         } else if (decision instanceof SetDecision) {
             SetDecision id = (SetDecision) decision;
             return asLit(
-                nogoodStealer.getById(id.getDecisionVariable(), png.getModel()), id.getDecOp(),
+                nogoodStealer.getById(id.getDecisionVariable(), png.getModel()), 
+                id.getDecOp(),
                 id.getDecisionValue()
             );
         } else {

--- a/solver/src/test/java/org/chocosolver/solver/PortFolioTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/PortFolioTest.java
@@ -9,16 +9,18 @@
  */
 package org.chocosolver.solver;
 
-import org.chocosolver.solver.search.restart.MonotonicRestartStrategy;
-import org.chocosolver.solver.variables.IntVar;
-import org.testng.Assert;
-import org.testng.annotations.Test;
+import static org.chocosolver.solver.ModelTest.knapsack;
+import static org.chocosolver.solver.search.strategy.Search.activityBasedSearch;
+import static org.chocosolver.solver.search.strategy.Search.inputOrderLBSearch;
+import static org.chocosolver.solver.search.strategy.Search.randomSearch;
 
 import java.util.List;
 import java.util.stream.Collectors;
-
-import static org.chocosolver.solver.ModelTest.knapsack;
-import static org.chocosolver.solver.search.strategy.Search.*;
+import org.chocosolver.solver.search.restart.MonotonicRestartStrategy;
+import org.chocosolver.solver.variables.IntVar;
+import org.chocosolver.util.ProblemMaker;
+import org.testng.Assert;
+import org.testng.annotations.Test;
 
 /**
  * <br/>
@@ -42,6 +44,24 @@ public class PortFolioTest {
 
         Assert.assertEquals(pares.getBestModel().getSolver().getSolutionCount(), 1);
         System.gc();
+    }
+
+    @Test(groups="10s", timeOut=60000)
+    public void testP11() {
+        ParallelPortfolio pares = new ParallelPortfolio();
+        int n = 6; // number of solvers to use
+        for (int i = 0; i < n; i++) {
+            pares.addModel(ProblemMaker.makeGolombRuler(10));
+        }
+        pares.stealNogoodsOnRestarts();
+        int nbSols = 0;
+        while(pares.solve()){
+            nbSols++;
+        }
+        Model finder = pares.getBestModel();
+        Assert.assertTrue(nbSols > 0);
+        Assert.assertNotNull(finder);
+        Assert.assertEquals(finder.getSolver().getObjectiveManager().getBestSolutionValue(), 55);
     }
 
     @Test(groups="10s", timeOut=60000)

--- a/solver/src/test/java/org/chocosolver/solver/constraints/nary/NogoodTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/nary/NogoodTest.java
@@ -9,6 +9,9 @@
  */
 package org.chocosolver.solver.constraints.nary;
 
+import static org.chocosolver.solver.search.strategy.Search.randomSearch;
+import static org.testng.Assert.assertEquals;
+
 import gnu.trove.list.TIntList;
 import gnu.trove.list.array.TIntArrayList;
 import org.chocosolver.sat.SatSolver;
@@ -26,9 +29,6 @@ import org.chocosolver.solver.variables.IntVar;
 import org.chocosolver.solver.variables.SetVar;
 import org.testng.Assert;
 import org.testng.annotations.Test;
-
-import static org.chocosolver.solver.search.strategy.Search.randomSearch;
-import static org.testng.Assert.assertEquals;
 
 /**
  * <br/>
@@ -66,11 +66,12 @@ public class NogoodTest {
     @Test(groups="1s", timeOut=60000)
     public void test3() {
         Model model = new Model("nogoods");
-        PropNogoods ngstore = model.getNogoodStore().getPropNogoods();
-        ngstore.initialize();
         IntVar x = model.intVar("x", -1, 1, false);
         IntVar y = model.intVar("y", 0, 2, false);
         IntVar z = model.intVar("z", 1, 5, false);
+        PropNogoods ngstore = model.getNogoodStore().getPropNogoods();
+        ngstore.initialize();
+
 
         TIntList ng = new TIntArrayList();
         ng.add(SatSolver.negated(ngstore.Literal(x, 1, true)));

--- a/solver/src/test/java/org/chocosolver/solver/constraints/nary/sat/PropNogoodsTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/nary/sat/PropNogoodsTest.java
@@ -9,8 +9,13 @@
  */
 package org.chocosolver.solver.constraints.nary.sat;
 
+import static org.chocosolver.solver.constraints.nary.sat.PropNogoods.iseq;
+import static org.chocosolver.solver.constraints.nary.sat.PropNogoods.ivalue;
+import static org.chocosolver.solver.constraints.nary.sat.PropNogoods.leq;
+
 import gnu.trove.list.TIntList;
 import gnu.trove.list.array.TIntArrayList;
+import java.util.Random;
 import org.chocosolver.sat.SatSolver;
 import org.chocosolver.solver.Cause;
 import org.chocosolver.solver.Model;
@@ -22,10 +27,6 @@ import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
-
-import java.util.Random;
-
-import static org.chocosolver.solver.constraints.nary.sat.PropNogoods.*;
 
 /**
  * Test class for PropNogoods
@@ -262,8 +263,6 @@ public class PropNogoodsTest {
 
     @Test(groups="1s", timeOut=60000)
     public void testIseq(){
-        Model model = new Model("nogoods");
-        PNG = model.getNogoodStore().getPropNogoods();
         Random rnd = new Random();
         for(int i = 0 ; i < 1_000_000; i++){
             rnd.setSeed(i);


### PR DESCRIPTION
Offer the possibility, when using a `ParallelPortfolio`, to steal no-goods from decision path of other models. The unique (strong) assumption is that all models are *equivalent* :
- each variable exists in all models, 
- each variable has the same ID in all models 
- each variable is declared at the same position in all models. 

When this option is on, any worker with a restart policy will extract a nogood on each restart, based on its decision path, **and** based on current decision path of other models in the portfolio. 