### PR TITLE
rework pom

### DIFF
--- a/cutoffseq/pom.xml
+++ b/cutoffseq/pom.xml
@@ -16,18 +16,18 @@
 
     <parent>
         <groupId>org.choco-solver</groupId>
-        <artifactId>choco</artifactId>
+        <artifactId>Choco</artifactId>
         <version>4.10.4-SNAPSHOT</version>
     </parent>
-    <artifactId>cutoffseq</artifactId>
-    <version>1.0.5</version>
+    <artifactId>Cutoffseq</artifactId>
     <packaging>jar</packaging>
 
-    <name>cutoffseq</name>
+    <name>Cutoffseq</name>
     <description>Cutoff sequence generator.</description>
 
     <properties>
         <main_dir>.${file.separator}..</main_dir>
     </properties>
 
+    <groupId>org.choco-solver.choco</groupId>
 </project>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -16,13 +16,13 @@
 
   <parent>
     <groupId>org.choco-solver</groupId>
-    <artifactId>choco</artifactId>
+    <artifactId>Choco</artifactId>
     <version>4.10.4-SNAPSHOT</version>
   </parent>
-  <artifactId>examples</artifactId>
+  <artifactId>Examples</artifactId>
   <packaging>jar</packaging>
 
-  <name>examples</name>
+  <name>Examples</name>
   <description>Choco-solver in practice
   </description>
 
@@ -32,20 +32,18 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.choco-solver</groupId>
-      <artifactId>choco-solver</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.choco-solver</groupId>
-      <artifactId>pf4cs</artifactId>
-      <version>1.0.5</version>
-    </dependency>
-    <dependency>
       <groupId>args4j</groupId>
       <artifactId>args4j</artifactId>
       <version>2.33</version>
       <scope>compile</scope>
+    </dependency>
+    <dependency>
+    	<groupId>org.choco-solver.choco</groupId>
+    	<artifactId>Solver</artifactId>
+    </dependency>
+    <dependency>
+    	<groupId>org.choco-solver.choco</groupId>
+    	<artifactId>Pf4cs</artifactId>
     </dependency>
   </dependencies>
   <build>
@@ -70,4 +68,5 @@
       </plugin>
     </plugins>
   </build>
+  <groupId>org.choco-solver.choco</groupId>
 </project>

--- a/parsers/pom.xml
+++ b/parsers/pom.xml
@@ -16,13 +16,13 @@
 
     <parent>
         <groupId>org.choco-solver</groupId>
-        <artifactId>choco</artifactId>
+        <artifactId>Choco</artifactId>
         <version>4.10.4-SNAPSHOT</version>
     </parent>
-    <artifactId>choco-parsers</artifactId>
+    <artifactId>Parsers</artifactId>
     <packaging>jar</packaging>
 
-    <name>choco-parsers</name>
+    <name>Parsers</name>
     <description>Provide parsers from FlatZinc and XCSP to Choco-solver.
     </description>
 
@@ -31,21 +31,11 @@
     </properties>
 
     <dependencies>
-        <dependency>
-            <groupId>org.choco-solver</groupId>
-            <artifactId>choco-solver</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.choco-solver</groupId>
-            <artifactId>pf4cs</artifactId>
-            <version>1.0.5</version>
-        </dependency>
-        <dependency>
-            <groupId>org.choco-solver</groupId>
-            <artifactId>choco-geost</artifactId>
-            <version>4.0.5</version>
-        </dependency>
+<!--         <dependency> -->
+<!--             <groupId>org.choco-solver</groupId> -->
+<!--             <artifactId>choco-geost</artifactId> -->
+<!--             <version>4.0.5</version> -->
+<!--         </dependency> -->
         <dependency>
             <groupId>net.sf.trove4j</groupId>
             <artifactId>trove4j</artifactId>
@@ -76,6 +66,14 @@
             <artifactId>poi</artifactId>
             <version>4.1.2</version>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+        	<groupId>org.choco-solver.choco</groupId>
+        	<artifactId>Solver</artifactId>
+        </dependency>
+        <dependency>
+        	<groupId>org.choco-solver.choco</groupId>
+        	<artifactId>Pf4cs</artifactId>
         </dependency>
     </dependencies>
 
@@ -138,4 +136,5 @@
             </plugin>
         </plugins>
     </build>
+    <groupId>org.choco-solver.choco</groupId>
 </project>

--- a/parsers/src/main/java/org/chocosolver/parser/flatzinc/Flatzinc4Lexer.java
+++ b/parsers/src/main/java/org/chocosolver/parser/flatzinc/Flatzinc4Lexer.java
@@ -1,22 +1,15 @@
-/*
- * This file is part of choco-parsers, http://choco-solver.org/
- *
- * Copyright (c) 2020, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
- * See LICENSE file in the project root for full license information.
- */
 // Generated from Flatzinc4Lexer.g4 by ANTLR 4.8
 package org.chocosolver.parser.flatzinc;
 
 
+import org.antlr.v4.runtime.Lexer;
+import org.antlr.v4.runtime.CharStream;
+import org.antlr.v4.runtime.Token;
+import org.antlr.v4.runtime.TokenStream;
 import org.antlr.v4.runtime.*;
-import org.antlr.v4.runtime.atn.ATN;
-import org.antlr.v4.runtime.atn.ATNDeserializer;
-import org.antlr.v4.runtime.atn.LexerATNSimulator;
-import org.antlr.v4.runtime.atn.PredictionContextCache;
+import org.antlr.v4.runtime.atn.*;
 import org.antlr.v4.runtime.dfa.DFA;
+import org.antlr.v4.runtime.misc.*;
 
 @SuppressWarnings({"all", "warnings", "unchecked", "unused", "cast"})
 public class Flatzinc4Lexer extends Lexer {

--- a/parsers/src/main/java/org/chocosolver/parser/flatzinc/Flatzinc4Parser.java
+++ b/parsers/src/main/java/org/chocosolver/parser/flatzinc/Flatzinc4Parser.java
@@ -1,30 +1,23 @@
-/*
- * This file is part of choco-parsers, http://choco-solver.org/
- *
- * Copyright (c) 2020, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
- * See LICENSE file in the project root for full license information.
- */
 // Generated from Flatzinc4Parser.g4 by ANTLR 4.8
 package org.chocosolver.parser.flatzinc;
 
-import org.antlr.v4.runtime.*;
-import org.antlr.v4.runtime.atn.ATN;
-import org.antlr.v4.runtime.atn.ATNDeserializer;
-import org.antlr.v4.runtime.atn.ParserATNSimulator;
-import org.antlr.v4.runtime.atn.PredictionContextCache;
-import org.antlr.v4.runtime.dfa.DFA;
-import org.antlr.v4.runtime.tree.TerminalNode;
 import org.chocosolver.parser.flatzinc.ast.*;
 import org.chocosolver.parser.flatzinc.ast.declaration.*;
 import org.chocosolver.parser.flatzinc.ast.expression.*;
-import org.chocosolver.solver.Model;
 import org.chocosolver.solver.ResolutionPolicy;
+import org.chocosolver.solver.Model;
 
 import java.util.ArrayList;
 import java.util.List;
+
+import org.antlr.v4.runtime.atn.*;
+import org.antlr.v4.runtime.dfa.DFA;
+import org.antlr.v4.runtime.*;
+import org.antlr.v4.runtime.misc.*;
+import org.antlr.v4.runtime.tree.*;
+import java.util.List;
+import java.util.Iterator;
+import java.util.ArrayList;
 
 @SuppressWarnings({"all", "warnings", "unchecked", "unused", "cast"})
 public class Flatzinc4Parser extends Parser {

--- a/pf4cs/pom.xml
+++ b/pf4cs/pom.xml
@@ -16,18 +16,18 @@
 
     <parent>
         <groupId>org.choco-solver</groupId>
-        <artifactId>choco</artifactId>
+        <artifactId>Choco</artifactId>
         <version>4.10.4-SNAPSHOT</version>
     </parent>
-    <artifactId>pf4cs</artifactId>
-    <version>1.0.5</version>
+    <artifactId>Pf4cs</artifactId>
     <packaging>jar</packaging>
 
-    <name>pf4cs</name>
+    <name>Pf4cs</name>
     <description>Problem facade for constraint solvers.</description>
 
     <properties>
         <main_dir>.${file.separator}..</main_dir>
     </properties>
 
+    <groupId>org.choco-solver.choco</groupId>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -14,10 +14,10 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.choco-solver</groupId>
-    <artifactId>choco</artifactId>
+    <artifactId>Choco</artifactId>
     <version>4.10.4-SNAPSHOT</version>
     <packaging>pom</packaging>
-    <name>choco</name>
+    <name>Choco</name>
     <url>http://choco-solver.org/</url>
     <description>
         A Free and Open-Source library dedicated to Constraint Programming.
@@ -569,4 +569,28 @@
         </plugins>
     </reporting>
 
+    <dependencyManagement>
+    	<dependencies>
+    		<dependency>
+    			<groupId>org.choco-solver.choco</groupId>
+    			<artifactId>Solver</artifactId>
+    			<version>${project.version}</version>
+    		</dependency>
+    		<dependency>
+    			<groupId>org.choco-solver.choco</groupId>
+    			<artifactId>Pf4cs</artifactId>
+    			<version>${project.version}</version>
+    		</dependency>
+    		<dependency>
+    			<groupId>org.choco-solver.choco</groupId>
+    			<artifactId>Sat</artifactId>
+    			<version>${project.version}</version>
+    		</dependency>
+    		<dependency>
+    			<groupId>org.choco-solver.choco</groupId>
+    			<artifactId>Cutoffseq</artifactId>
+    			<version>${project.version}</version>
+    		</dependency>
+    	</dependencies>
+    </dependencyManagement>
 </project>

--- a/sat/pom.xml
+++ b/sat/pom.xml
@@ -15,14 +15,13 @@
 
     <parent>
         <groupId>org.choco-solver</groupId>
-        <artifactId>choco</artifactId>
+        <artifactId>Choco</artifactId>
         <version>4.10.4-SNAPSHOT</version>
     </parent>
-    <artifactId>choco-sat</artifactId>
-    <version>1.0.2</version>
+    <artifactId>Sat</artifactId>
 
     <packaging>jar</packaging>
-    <name>choco-sat</name>
+    <name>Sat</name>
 
     <description>A SAT solver, used internally in choco-solver
     </description>
@@ -39,4 +38,5 @@
         </dependency>
     </dependencies>
 
+    <groupId>org.choco-solver.choco</groupId>
 </project>

--- a/solver/pom.xml
+++ b/solver/pom.xml
@@ -16,13 +16,13 @@
 
     <parent>
         <groupId>org.choco-solver</groupId>
-        <artifactId>choco</artifactId>
+        <artifactId>Choco</artifactId>
         <version>4.10.4-SNAPSHOT</version>
     </parent>
-    <artifactId>choco-solver</artifactId>
+    <artifactId>Solver</artifactId>
     <packaging>jar</packaging>
 
-    <name>choco-solver</name>
+    <name>Solver</name>
 
     <description>Open-source constraint solver.
     </description>
@@ -32,16 +32,6 @@
     </properties>
 
     <dependencies>
-        <dependency>
-            <groupId>org.choco-solver</groupId>
-            <artifactId>choco-sat</artifactId>
-            <version>1.0.2</version>
-        </dependency>
-        <dependency>
-            <groupId>org.choco-solver</groupId>
-            <artifactId>cutoffseq</artifactId>
-            <version>1.0.5</version>
-        </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
@@ -72,6 +62,14 @@
             <groupId>org.knowm.xchart</groupId>
             <artifactId>xchart</artifactId>
             <version>3.6.4</version>
+        </dependency>
+        <dependency>
+        	<groupId>org.choco-solver.choco</groupId>
+        	<artifactId>Sat</artifactId>
+        </dependency>
+        <dependency>
+        	<groupId>org.choco-solver.choco</groupId>
+        	<artifactId>Cutoffseq</artifactId>
         </dependency>
     </dependencies>
 
@@ -115,4 +113,5 @@
         </plugins>
     </build>
 
+    <groupId>org.choco-solver.choco</groupId>
 </project>


### PR DESCRIPTION
Just a few changes on the poms.

- the root pom is org.choco-solver.Choco . It manages the version of the sub projects to ${project.version}.
 - the solver subproject is renamed org.choco-solver.choco.Solver
 - basically each sub project is renamed with a upper case first letter,  and placed in the lower case package of the parent pom (so parent is org.choco-solver.Choco => package is org.choco-solver.choco.X )
 - each child project version is set to the root project version. No more specific version to upload, when deploying/releasing all are released altogether.
 - push new version with version=x.y.z ; mvn versions:set -DnewVersion=$version . This also allows to tag and push the tag after deploy : git tag "$version" ; git push --tags 

Still bugged as the geost ? project requires choco-solver 10.0.5 and … well it can't compile.

Anyhow not supposed to be accepted, just an example.
