### PR TITLE
Fix arithmetic bug with Ibex and power operator for integer exponents

### DIFF
--- a/solver/src/main/java/org/chocosolver/solver/expression/continuous/arithmetic/BiCArExpression.java
+++ b/solver/src/main/java/org/chocosolver/solver/expression/continuous/arithmetic/BiCArExpression.java
@@ -283,6 +283,6 @@ public class BiCArExpression implements CArExpression {
     }
 
     private boolean isIntegerConstant(RealVar realVar) {
-        return realVar.isAConstant() && (realVar.getLB() % 1) == 0;
+        return realVar.isAConstant() && Math.rint(realVar.getLB()) == realVar.getLB();
     }
 }

--- a/solver/src/main/java/org/chocosolver/solver/expression/continuous/arithmetic/BiCArExpression.java
+++ b/solver/src/main/java/org/chocosolver/solver/expression/continuous/arithmetic/BiCArExpression.java
@@ -108,7 +108,12 @@ public class BiCArExpression implements CArExpression {
                 case POW:
                     bounds = VariableUtils.boundsForPow(v1, v2);
                     me = model.realVar(bounds[0], bounds[1], p);
-                    model.realIbexGenericConstraint("{0}={1}^{2}", me, v1, v2).post();
+                    if (isIntegerConstant(v2)) {
+                        // See issue: #702
+                        model.realIbexGenericConstraint("{0}={1}^" + (int) v2.getLB(), me, v1).post();
+                    } else {
+                        model.realIbexGenericConstraint("{0}={1}^{2}", me, v1, v2).post();
+                    }
                     break;
                 case MIN:
                     bounds = VariableUtils.boundsForMinimum(v1, v2);
@@ -275,5 +280,9 @@ public class BiCArExpression implements CArExpression {
     @Override
     public String toString() {
         return op.name() + "(" + e1.toString() + "," + e2.toString() + ")";
+    }
+
+    private boolean isIntegerConstant(RealVar realVar) {
+        return realVar.isAConstant() && (realVar.getLB() % 1) == 0;
     }
 }

--- a/solver/src/test/java/org/chocosolver/solver/constraints/real/RealTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/real/RealTest.java
@@ -1135,4 +1135,22 @@ public class RealTest {
         model.getSolver().solve();
         Assert.assertTrue(t.getLB()>2.);
     }
+
+    @Test(groups = "1s")
+    public void testSchmitt2() {
+        // See ISSUE #702
+        Model model = new Model();
+        RealVar x = model.realVar("x", -100.0, 100.0, 0.01);
+        RealVar y = model.realVar("y", -100.0, 100.0, 0.01);
+        y.eq(x.pow(2)).ibex(0.01).post();
+        try {
+            model.getSolver().propagate();
+        } catch (ContradictionException cex) {
+            Assert.fail("Should thrown contradiction");
+        }
+        Assert.assertEquals(y.getLB(), 0.0, 0.01);
+        Assert.assertEquals(y.getUB(), 100.0, 0.01);
+        Assert.assertEquals(x.getLB(), -10.0, 0.01);
+        Assert.assertEquals(x.getUB(), 10.0, 0.01);
+    }
 }

--- a/solver/src/test/java/org/chocosolver/solver/expression/continuous/IbexTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/expression/continuous/IbexTest.java
@@ -212,8 +212,8 @@ public class IbexTest {
         Model model = new Model();
         RealVar x = model.realVar("x", -2, 2, 0.1d);
         RealVar y = model.realVar("y", 4, 5, 0.1d);
-        // note: pow(2.0d) does not recognize that d is exactly an even integer
-        eval(model, x.pow(2.0d).eq(y), 1);
+        // See ISSUE #702, now pow(double) can recognize integer variables
+        eval(model, x.pow(2.0d).eq(y), 2);
     }
 
     @Test(groups = "ibex", timeOut = 60000)


### PR DESCRIPTION
This changes proposes a handling for integer exponents of the continuous power function (#702). 

Fixes # .

Changes proposed in this PR:
- Changed `pow` function of `BiCArExpression` to identify integer exponents and create the right expression for ibex, where the exponent is declared as a constant.
- Create a test to simulate the scenario
- Fix broken other tests
 
@chocoteam/core-developer 
