### PR TITLE
A pure java alternative for power operations with integer positive exponents

### DIFF
--- a/solver/src/main/java/org/chocosolver/solver/constraints/real/RealPowerPropagator.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/real/RealPowerPropagator.java
@@ -1,0 +1,108 @@
+package org.chocosolver.solver.constraints.real;
+
+import org.chocosolver.solver.constraints.Propagator;
+import org.chocosolver.solver.constraints.PropagatorPriority;
+import org.chocosolver.solver.exception.ContradictionException;
+import org.chocosolver.solver.expression.continuous.arithmetic.RealIntervalConstant;
+import org.chocosolver.solver.variables.RealVar;
+import org.chocosolver.solver.variables.events.RealEventType;
+import org.chocosolver.util.ESat;
+import org.chocosolver.util.objects.RealInterval;
+import org.chocosolver.util.tools.RealUtils;
+
+/**
+ * It's a pure java alternative to ibex that must be used to calculate
+ * power operations (y = x^k) with integer positive exponents (k).
+ *
+ * <p>
+ * Just in case, this is an external library for interval arithmetic.
+ * Reference: https://jitpack.io/p/jinterval/jinterval#readme
+ * <p>
+ * This implementation is based from the chapter 16.1 "From Discrete to
+ * Continuous Constraints", example 16.2 [1].
+ * <p>
+ * [1] Francesca Rossi, Peter van Beek, and Toby Walsh. 2006. Handbook of
+ * Constraint Programming. Elsevier Science Inc., USA.
+ *
+ * @author João Pedro Schmitt
+ * @since 08/09/2020
+ */
+public class RealPowerPropagator extends Propagator<RealVar> {
+
+    private RealVar yVar;
+
+    private RealVar xVar;
+
+    private int k;
+
+    public RealPowerPropagator(RealVar yVar, RealVar xVar, int k) {
+        super(new RealVar[]{yVar, xVar}, PropagatorPriority.BINARY, false);
+        this.yVar = vars[0];
+        this.xVar = vars[1];
+        this.k = k;
+    }
+
+    @Override
+    public int getPropagationConditions(int vIdx) {
+        return RealEventType.BOUND.getMask();
+    }
+
+    @Override
+    public ESat isEntailed() {
+        ESat result = ESat.UNDEFINED;
+        if (isCompletelyInstantiated()) {
+            double lb = yVar.getLB() - Math.pow(xVar.getLB(), k);
+            double ub = yVar.getUB() - Math.pow(xVar.getUB(), k);
+            lb = RealUtils.roundValue(lb, xVar.getPrecision());
+            ub = RealUtils.roundValue(ub, xVar.getPrecision());
+            result = ESat.eval(lb <= 0 && 0 <= ub);
+        }
+        return result;
+    }
+
+    @Override
+    public final void propagate(int evtmask) throws ContradictionException {
+        boolean hasChanged = true;
+        // Projection + propagation
+        while (hasChanged) {
+            hasChanged = kPower();
+            hasChanged |= kRoot();
+        }
+    }
+
+    private boolean kPower() throws ContradictionException {
+        RealInterval x = new RealIntervalConstant(xVar.getLB(), xVar.getUB());
+        RealInterval y = new RealIntervalConstant(yVar.getLB(), yVar.getUB());
+        RealInterval power = RealUtils.iPower(x, k); // y = x^k
+        // For even power, y will range [0, +Inf]
+        // For odd power, y will range [-Inf, +Inf]
+        // So it doesn't require special handling to update the bounds
+        y = RealUtils.updateBounds(y, power);
+        return yVar.updateBounds(y.getLB(), y.getUB(), this);
+    }
+
+    private boolean kRoot() throws ContradictionException {
+        boolean isIntervalPositive = xVar.getLB() >= 0;
+        boolean isIntervalNegative = xVar.getUB() <= 0;
+        RealInterval x = new RealIntervalConstant(xVar.getLB(), xVar.getUB());
+        RealInterval y = new RealIntervalConstant(yVar.getLB(), yVar.getUB());
+        RealInterval root = RealUtils.iRoot(y, k); // x = root(y, k)
+        boolean isEven = k % 2 == 0;
+        // In all cases, bounds ar calculate as intersection between x and temp
+        if (isEven) {
+            if (isIntervalPositive) {
+                x = RealUtils.updateBounds(x, root.getLB(), root.getUB());
+            } else if (isIntervalNegative) {
+                x = RealUtils.updateBounds(x, -root.getUB(), -root.getLB());
+            } else { // It's crossing zero
+                x = RealUtils.updateBounds(x, -root.getUB(), root.getUB());
+            }
+        } else {
+            // For odd roots isn't necessary specific handling as roots can be negative naturally
+            x = RealUtils.updateBounds(x, root);
+        }
+        return xVar.updateLowerBound(x.getLB(), this) |
+                xVar.updateUpperBound(x.getUB(), this);
+    }
+
+}

--- a/solver/src/main/java/org/chocosolver/solver/expression/continuous/arithmetic/CArExpression.java
+++ b/solver/src/main/java/org/chocosolver/solver/expression/continuous/arithmetic/CArExpression.java
@@ -316,7 +316,7 @@ public interface CArExpression extends RealInterval {
      * @return return the expression "x^y" where this is "x"
      */
     default CArExpression pow(double y) {
-        return new BiCArExpression(CArExpression.Operator.POW, this, this.getModel().realVar(y));
+        return new CstCArExpression(CArExpression.Operator.POW, this, y);
     }
 
     /**

--- a/solver/src/main/java/org/chocosolver/solver/expression/continuous/arithmetic/CstCArExpression.java
+++ b/solver/src/main/java/org/chocosolver/solver/expression/continuous/arithmetic/CstCArExpression.java
@@ -1,0 +1,85 @@
+package org.chocosolver.solver.expression.continuous.arithmetic;
+
+import org.chocosolver.solver.ICause;
+import org.chocosolver.solver.constraints.Constraint;
+import org.chocosolver.solver.constraints.real.RealPowerPropagator;
+import org.chocosolver.solver.exception.ContradictionException;
+import org.chocosolver.solver.variables.RealVar;
+import org.chocosolver.util.objects.RealInterval;
+import org.chocosolver.util.tools.RealUtils;
+
+/**
+ * Unary continuous arithmetic expression with a constant
+ *
+ * @author João Pedro Schmitt
+ * @since 08/09/2020
+ */
+public class CstCArExpression extends UnCArExpression {
+
+    private static final String ERROR_MSG_OPERATION_CSTE = "Equation does not support %s with constant %.2f. Consider using Ibex instead.";
+
+    private static final String ERROR_MSG_OPERATION = "Equation does not support %s. Consider using Ibex instead.";
+
+    /**
+     * Constant of the arithmetic expression
+     */
+    double constant;
+
+    /**
+     * Builds a unary expression with constant
+     *
+     * @param op  operator
+     * @param exp an continuous arithmetic expression
+     */
+    public CstCArExpression(Operator op, CArExpression exp, double c) {
+        super(op, exp);
+        this.constant = c;
+    }
+
+    @Override
+    public RealVar realVar(double p) {
+        if (me == null) {
+            RealVar xVar = e.realVar(p);
+            switch (op) {
+                case POW:
+                    if (isInteger(constant)) {
+                        int k = (int) constant;
+                        if (constant >= 0) {
+                            // y = x^k
+                            RealInterval powerResult = RealUtils.iPower(xVar, k);
+                            me = model.realVar(powerResult.getLB(), powerResult.getUB(), xVar.getPrecision());
+                            model.post(new Constraint(model.generateName(), new RealPowerPropagator(me, xVar, k)));
+                        } else {
+                            // y = 1/x^k
+                            k = -k;
+                            RealInterval powerResult = RealUtils.iPower(xVar, k);
+                            RealVar xPowerK = model.realVar(powerResult.getLB(), powerResult.getUB(), xVar.getPrecision());
+                            model.post(new Constraint(model.generateName(), new RealPowerPropagator(xPowerK, xVar, k)));
+                            me = model.realVar(powerResult.getLB(), powerResult.getUB(), xVar.getPrecision());
+                            model.realIbexGenericConstraint("{0}=1/{1}", me, xPowerK).post();
+                        }
+                    } else {
+                        model.realIbexGenericConstraint("{0}={1}^" + constant, me, xVar).post();
+                    }
+                    break;
+                default:
+                    throw new UnsupportedOperationException("Unary arithmetic expressions does not support " + op.name());
+            }
+        }
+        return me;
+    }
+
+    @Override
+    public void tighten() {
+        throw new UnsupportedOperationException(String.format(ERROR_MSG_OPERATION, op.name()));
+    }
+
+    @Override
+    public void project(ICause cause) throws ContradictionException {
+        throw new UnsupportedOperationException(String.format(ERROR_MSG_OPERATION, op.name()));
+    }
+
+    private boolean isInteger(double value) {
+        return Math.rint(value) == value;
+    }
+}

--- a/solver/src/main/java/org/chocosolver/solver/expression/continuous/arithmetic/UnCArExpression.java
+++ b/solver/src/main/java/org/chocosolver/solver/expression/continuous/arithmetic/UnCArExpression.java
@@ -48,7 +48,7 @@ public class UnCArExpression implements CArExpression {
     /**
      * The expression this expression relies on
      */
-    private CArExpression e;
+    CArExpression e;
 
     IStateDouble l;
     IStateDouble u;

--- a/solver/src/main/java/org/chocosolver/solver/variables/RealVar.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/RealVar.java
@@ -93,4 +93,5 @@ public interface RealVar extends Variable, CArExpression {
     void silentlyAssign(RealInterval bounds);
 
     void silentlyAssign(double lb, double ub);
+
 }

--- a/solver/src/main/java/org/chocosolver/util/tools/RealUtils.java
+++ b/solver/src/main/java/org/chocosolver/util/tools/RealUtils.java
@@ -12,6 +12,8 @@ package org.chocosolver.util.tools;
 import org.chocosolver.solver.expression.continuous.arithmetic.RealIntervalConstant;
 import org.chocosolver.util.objects.RealInterval;
 
+import java.util.Locale;
+
 /**
  * Some tools for float computing.
  * Inspired from IAMath : interval.sourceforge.net
@@ -729,4 +731,24 @@ public class RealUtils {
         return new RealIntervalConstant(retInf, retSup);
     }
 
+    public static RealInterval updateBounds(RealInterval var, RealInterval newInterval) {
+        return updateBounds(var, newInterval.getLB(), newInterval.getUB());
+    }
+
+    public static RealInterval updateBounds(RealInterval var, double lb, double ub) {
+        return new RealIntervalConstant(
+                Math.max(var.getLB(), lb),
+                Math.min(var.getUB(), ub));
+    }
+
+    public static double roundValue(double value, double precision) {
+        int numDecPlaces = 0;
+        while (1 > Math.pow(10, numDecPlaces) * precision) {
+            numDecPlaces++;
+        }
+        double roundedValue = Double.valueOf(String.format(Locale.US, "%." + numDecPlaces + "f", value));
+        // See: https://stackoverflow.com/questions/61388914/
+        roundedValue = roundedValue + 0.0;
+        return roundedValue;
+    }
 }

--- a/solver/src/test/java/org/chocosolver/solver/constraints/real/power/RealCubicTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/real/power/RealCubicTest.java
@@ -1,0 +1,179 @@
+package org.chocosolver.solver.constraints.real.power;
+
+import org.chocosolver.solver.exception.ContradictionException;
+import org.chocosolver.solver.variables.BoolVar;
+import org.chocosolver.solver.variables.RealVar;
+import org.testng.annotations.Ignore;
+import org.testng.annotations.Test;
+
+public class RealCubicTest extends RealPowerBase {
+
+    @Test
+    public void sqr1Test() throws ContradictionException {
+        postExpression(y.eq(x.pow(3)));
+        model.getSolver().propagate();
+        assertBound(x, -4.641589, 4.641589);
+        assertBound(y, -100.0, 100.0);
+    }
+
+    @Test
+    public void sqr2Test() throws ContradictionException {
+        postExpression(x.ge(-2.5));
+        postExpression(x.le(4.5));
+        postExpression(y.eq(x.pow(3)));
+        model.getSolver().propagate();
+        assertBound(x, -2.5, 4.5);
+        assertBound(y, -15.625, 91.125);
+    }
+
+    @Test
+    public void sqr3Test() throws ContradictionException {
+        postExpression(x.ge(2.5));
+        postExpression(x.le(4.5));
+        postExpression(y.eq(x.pow(3)));
+        model.getSolver().propagate();
+        assertBound(x, 2.5, 4.5);
+        assertBound(y, 15.625, 91.125);
+    }
+
+    @Test
+    public void sqr4Test() throws ContradictionException {
+        postExpression(x.ge(-4.5));
+        postExpression(x.le(-2.5));
+        postExpression(y.eq(x.pow(3)));
+        model.getSolver().propagate();
+        assertBound(x, -4.5, -2.5);
+        assertBound(y, -91.125, -15.625);
+    }
+
+    @Test
+    @Ignore("Expecting IBEX release the contraction ratio parameter")
+    public void imp1Test() throws ContradictionException {
+        postExpression(x.ge(0));
+        postExpression(y.eq(9.5));
+        w.eq(1).imp(getExpression(x.pow(3).gt(y))).post();
+        w.eq(1).post();
+        model.getSolver().propagate();
+        assertBound(x, 2.117912, 100.0);
+    }
+
+    @Test
+    public void imp2Test() throws ContradictionException {
+        postExpression(x.ge(0));
+        postExpression(y.eq(10.5));
+        w.eq(1).imp(getExpression(x.pow(3).lt(y))).post();
+        w.eq(1).post();
+        model.getSolver().propagate();
+        assertBound(x, 0.0, 2.18976);
+    }
+
+    @Test
+    public void imp4Test() throws ContradictionException {
+        postExpression(x.le(0.0));
+        postExpression(y.eq(10.5));
+        w.eq(1).imp(getExpression(x.pow(3).lt(y))).post();
+        w.eq(1).post();
+        model.getSolver().propagate();
+        assertBound(x, -100.0, 0.0);
+    }
+
+    @Test
+    public void imp5Test() throws ContradictionException {
+        postExpression(x.ge(0));
+        postExpression(y.eq(-9.5));
+        w.eq(1).imp(getExpression(x.pow(3).gt(y))).post();
+        w.eq(1).post();
+        model.getSolver().propagate();
+        assertBound(x, 0.0, 100.0);
+    }
+
+    @Test
+    public void imp7Test() throws ContradictionException {
+        postExpression(x.le(0));
+        postExpression(y.eq(-3.5));
+        w.eq(1).post();
+        w.eq(1).imp(getExpression(x.pow(3).gt(y))).post();
+        model.getSolver().propagate();
+        assertBound(x, -1.518294, 0.0);
+    }
+
+    @Test
+    @Ignore("Expecting IBEX release the contraction ratio parameter")
+    public void imp8Test() throws ContradictionException {
+        postExpression(x.le(0));
+        postExpression(y.eq(-10.5));
+        w.eq(1).imp(getExpression(x.pow(3).lt(y))).post();
+        w.eq(1).post();
+        model.getSolver().propagate();
+        assertBound(x, -100.0, -2.18976);
+    }
+
+    @Test
+    public void sqr5Test() throws ContradictionException {
+        postExpression(z.eq(25.5));
+        postExpression(y.eq(-4.5));
+        postExpression(x.pow(3).le(z));
+        postExpression(x.pow(3).ge(y));
+        model.getSolver().propagate();
+        assertBound(x, -1.650964, 2.943383);
+    }
+
+    @Test
+    public void sqr6Test() throws ContradictionException {
+        postExpression(z.eq(25.5));
+        postExpression(y.eq(4.5));
+        postExpression(x.ge(0.0));
+        postExpression(x.pow(3).lt(z));
+        postExpression(x.pow(3).gt(y));
+        model.getSolver().propagate();
+        assertBound(x, 1.650964, 2.943383);
+    }
+
+    @Test
+    public void sqr7Test() throws ContradictionException {
+        postExpression(z.eq(25.5));
+        postExpression(y.eq(-4.5));
+        postExpression(x.le(0.0));
+        postExpression(x.pow(3).le(z));
+        postExpression(x.pow(3).ge(y));
+        model.getSolver().propagate();
+        assertBound(x, -1.650964, 0.0);
+    }
+
+    @Test
+    public void sqr8Test() throws ContradictionException {
+        postExpression(x.ge(0));
+        postExpression(x.le(Math.toRadians(45)));
+        postExpression(y.eq(x.cos()));
+        postExpression(z.eq(y.pow(3)));
+        postExpression(v.eq(z.sqrt()));
+        postExpression(v.le(0.9));
+
+        model.getSolver().propagate();
+        assertBound(x, 0.370436, 0.785398);
+        assertBound(y, 0.707107, 0.93217);
+        assertBound(z, 0.353553, 0.81);
+        assertBound(v, 0.594604, 0.9);
+    }
+
+    @Test
+    public void sqr9Test() throws ContradictionException {
+        postExpression(x.ge(0.2));
+        postExpression(x.le(0.8));
+        postExpression(y.eq(x.pow(3)));
+        model.getSolver().propagate();
+        assertBound(x, 0.2, 0.8);
+        assertBound(y, 0.008, 0.512);
+    }
+
+    @Test
+    public void sqr10Test() throws ContradictionException {
+        postExpression(x.ge(-0.2));
+        postExpression(x.le(0.8));
+        postExpression(y.eq(x.pow(3)));
+        model.getSolver().propagate();
+        assertBound(x, -0.2, 0.8);
+        assertBound(y, -0.008, 0.512);
+    }
+
+}

--- a/solver/src/test/java/org/chocosolver/solver/constraints/real/power/RealNegativePowerTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/real/power/RealNegativePowerTest.java
@@ -1,0 +1,128 @@
+package org.chocosolver.solver.constraints.real.power;
+
+import org.chocosolver.solver.exception.ContradictionException;
+import org.testng.annotations.Ignore;
+import org.testng.annotations.Test;
+
+public class RealNegativePowerTest extends RealPowerBase {
+
+    /**
+     * With even operations
+     */
+
+    @Test
+    @Ignore("Expecting IBEX release the contraction ratio parameter")
+    public void powerEven1Test() throws ContradictionException {
+        postExpression(y.eq(x.pow(-2)));
+        model.getSolver().propagate();
+        assertBound(x, -100.0, 100.0);
+        assertBound(y, 0.0001, 100.0);
+    }
+
+    @Test
+    @Ignore("Expecting IBEX release the contraction ratio parameter")
+    public void powerEven2Test() throws ContradictionException {
+        postExpression(x.ge(-10));
+        postExpression(x.le(10));
+        postExpression(y.eq(x.pow(-2)));
+        model.getSolver().propagate();
+        assertBound(x, 0.01, 100.0);
+        assertBound(y, -10.0, 10.0);
+    }
+
+    @Test
+    @Ignore("Expecting IBEX release the contraction ratio parameter")
+    public void powerEven3Test() throws ContradictionException {
+        postExpression(x.ge(0));
+        postExpression(x.le(2));
+        postExpression(y.eq(x.pow(-2)));
+        model.getSolver().propagate();
+        assertBound(x, 0.1, 2.0);
+        assertBound(y, 0.25, 100.0);
+    }
+
+    @Test
+    public void powerEven4Test() throws ContradictionException {
+        postExpression(x.ge(2.0));
+        postExpression(y.eq(x.pow(-2)));
+        model.getSolver().propagate();
+        assertBound(x, 2.0, 100.0);
+        assertBound(y, 0.0001, 0.25);
+    }
+
+    @Test
+    @Ignore("Expecting IBEX release the contraction ratio parameter")
+    public void powerEven5Test() throws ContradictionException {
+        postExpression(x.ge(-2));
+        postExpression(x.le(0));
+        postExpression(y.eq(x.pow(-2)));
+        model.getSolver().propagate();
+        assertBound(x, -2.0, -0.1);
+        assertBound(y, 0.25, 100.0);
+    }
+
+    @Test
+    public void powerEven6Test() throws ContradictionException {
+        postExpression(x.ge(-10000));
+        postExpression(x.le(-2));
+        postExpression(y.eq(x.pow(-2)));
+        model.getSolver().propagate();
+        assertBound(x, -100.0, -2.0);
+        assertBound(y, 0.0001, 0.25);
+    }
+
+    @Test
+    @Ignore("Expecting IBEX release the contraction ratio parameter")
+    public void powerEven7Test() throws ContradictionException {
+        postExpression(x.ge(-2));
+        postExpression(x.le(2));
+        postExpression(y.eq(x.pow(-2)));
+        model.getSolver().propagate();
+        assertBound(x, -2.0, 2.0);
+        assertBound(y, 0.25, 100.0);
+    }
+
+    /**
+     * With odd operations
+     */
+
+    @Test
+    public void powerOdd3Test() throws ContradictionException {
+        postExpression(x.ge(0));
+        postExpression(x.le(2));
+        postExpression(y.eq(x.pow(-3)));
+        model.getSolver().propagate();
+        assertBound(x, 0.215443, 2.0);
+        assertBound(y, 0.125, 100.0);
+    }
+
+    @Test
+    public void powerOdd4Test() throws ContradictionException {
+        postExpression(x.ge(2));
+        postExpression(y.eq(x.pow(-3)));
+        model.getSolver().propagate();
+        assertBound(x, 2.0, 100.0);
+        assertBound(y, 0.000001, 0.125);
+    }
+
+    @Test
+    public void powerOdd5Test() throws ContradictionException {
+        postExpression(x.ge(-2));
+        postExpression(x.le(0));
+        postExpression(y.eq(x.pow(-3)));
+        model.getSolver().propagate();
+        assertBound(x, -2.0, -0.215443);
+        assertBound(y, -100.0, -0.125);
+    }
+
+    @Test
+    public void powerOdd6Test() throws ContradictionException {
+        postExpression(x.ge(-10000.0));
+        postExpression(x.le(-2));
+        postExpression(y.eq(x.pow(-3)));
+        model.getSolver().propagate();
+        assertBound(x, -100.0, -2.0);
+        assertBound(y, -0.125, -0.000001);
+    }
+
+}

--- a/solver/src/test/java/org/chocosolver/solver/constraints/real/power/RealPowerBase.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/real/power/RealPowerBase.java
@@ -1,0 +1,54 @@
+package org.chocosolver.solver.constraints.real.power;
+
+import org.chocosolver.solver.Model;
+import org.chocosolver.solver.expression.continuous.relational.CReExpression;
+import org.chocosolver.solver.expression.discrete.relational.ReExpression;
+import org.chocosolver.solver.variables.BoolVar;
+import org.chocosolver.solver.variables.RealVar;
+import org.testng.Assert;
+import org.testng.annotations.BeforeMethod;
+
+public abstract class RealPowerBase {
+
+    protected static final double MIN_LIM = -100.0;
+    protected static final double MAX_LIM = 100.0;
+    protected static final double PRECISION = 0.000_001;
+
+    protected Model model;
+
+    protected RealVar x;
+
+    protected RealVar y;
+
+    protected RealVar z;
+
+    protected RealVar v;
+
+    protected RealVar e;
+
+    protected BoolVar w;
+
+    @BeforeMethod
+    protected void before() {
+        model = new Model();
+        x = model.realVar("x", MIN_LIM, MAX_LIM, PRECISION);
+        y = model.realVar("y", MIN_LIM, MAX_LIM, PRECISION);
+        z = model.realVar("z", MIN_LIM, MAX_LIM, PRECISION);
+        v = model.realVar("v", MIN_LIM, MAX_LIM, PRECISION);
+        e = model.realVar("e", 0.0, MAX_LIM, PRECISION);
+        w = model.boolVar("w");
+    }
+
+    protected void assertBound(RealVar var, double lb, double ub) {
+        Assert.assertEquals(var.getLB(), lb, PRECISION);
+        Assert.assertEquals(var.getUB(), ub, PRECISION);
+    }
+
+    protected void postExpression(CReExpression expression) {
+        expression.ibex(PRECISION).post();
+    }
+
+    protected ReExpression getExpression(CReExpression expression) {
+        return expression.ibex(PRECISION).reify().eq(1);
+    }
+}

--- a/solver/src/test/java/org/chocosolver/solver/constraints/real/power/RealSquareTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/real/power/RealSquareTest.java
@@ -1,0 +1,157 @@
+package org.chocosolver.solver.constraints.real.power;
+
+import org.chocosolver.solver.exception.ContradictionException;
+import org.testng.annotations.Ignore;
+import org.testng.annotations.Test;
+
+public class RealSquareTest extends RealPowerBase {
+
+    @Test
+    public void sqr1Test() throws ContradictionException {
+        postExpression(y.eq(x.pow(2.0)));
+        model.getSolver().propagate();
+        assertBound(x, -10.0, 10.0);
+        assertBound(y, 0.0, 100.0);
+    }
+
+    @Test
+    public void sqr2Test() throws ContradictionException {
+        postExpression(x.ge(-2.5));
+        postExpression(x.le(4.5));
+        postExpression(y.eq(x.pow(2.0)));
+        model.getSolver().propagate();
+        assertBound(x, -2.5, 4.5);
+        assertBound(y, 0.0, 20.25);
+    }
+
+    @Test
+    public void sqr3Test() throws ContradictionException {
+        postExpression(x.ge(2.5));
+        postExpression(x.le(4.5));
+        postExpression(y.eq(x.pow(2.0)));
+        model.getSolver().propagate();
+        assertBound(x, 2.5, 4.5);
+        assertBound(y, 6.25, 20.25);
+    }
+
+    @Test
+    public void sqr4Test() throws ContradictionException {
+        postExpression(x.ge(-4.5));
+        postExpression(x.le(-2.5));
+        postExpression(y.eq(x.pow(2.0)));
+        model.getSolver().propagate();
+        assertBound(x, -4.5, -2.5);
+        assertBound(y, 6.25, 20.25);
+    }
+
+    @Test
+    @Ignore("Expecting IBEX release the contraction ratio parameter")
+    public void imp1Test() throws ContradictionException {
+        postExpression(x.ge(0.0));
+        postExpression(y.eq(3.5));
+        w.eq(1).imp(getExpression(x.pow(2.0).gt(y))).post();
+        w.eq(1).post();
+        model.getSolver().propagate();
+        assertBound(x, 1.870829, 100.0);
+    }
+
+    @Test
+    public void imp2Test() throws ContradictionException {
+        postExpression(x.ge(0.0));
+        postExpression(y.eq(10.5));
+        w.eq(1).imp(getExpression(x.pow(2.0).lt(y))).post();
+        w.eq(1).post();
+        model.getSolver().propagate();
+        assertBound(x, 0.0, 3.24037);
+    }
+
+    @Test
+    @Ignore("Expecting IBEX release the contraction ratio parameter")
+    public void imp3Test() throws ContradictionException {
+        postExpression(x.le(0.0));
+        postExpression(y.eq(3.5));
+        w.eq(1).imp(getExpression(x.pow(2.0).gt(y))).post();
+        w.eq(1).post();
+        model.getSolver().propagate();
+        assertBound(x, -100.0, -1.870829);
+    }
+
+    @Test
+    public void imp4Test() throws ContradictionException {
+        postExpression(x.le(0.0));
+        postExpression(y.eq(10.5));
+        w.eq(1).imp(getExpression(x.pow(2.0).lt(y))).post();
+        w.eq(1).post();
+        model.getSolver().propagate();
+        assertBound(x, -3.24037, 0.0);
+    }
+
+    @Test
+    public void sqr5Test() throws ContradictionException {
+        postExpression(z.eq(25.5));
+        postExpression(y.eq(4.5));
+        postExpression(x.pow(2.0).le(z));
+        postExpression(x.pow(2.0).ge(y));
+        model.getSolver().propagate();
+        assertBound(x, -5.049752, 5.049752);
+    }
+
+    @Test
+    public void sqr6Test() throws ContradictionException {
+        postExpression(z.eq(25.5));
+        postExpression(y.eq(4.5));
+        postExpression(x.ge(0.0));
+        postExpression(x.pow(2.0).lt(z));
+        postExpression(x.pow(2.0).gt(y));
+        model.getSolver().propagate();
+        assertBound(x, 2.121321, 5.049752);
+    }
+
+    @Test
+    public void sqr7Test() throws ContradictionException {
+        postExpression(z.eq(25.5));
+        postExpression(y.eq(4.5));
+        postExpression(x.le(0.0));
+        postExpression(x.pow(2.0).le(z));
+        postExpression(x.pow(2.0).ge(y));
+        model.getSolver().propagate();
+        assertBound(x, -5.049752, -2.12132);
+    }
+
+    @Test
+    public void sqr8Test() throws ContradictionException {
+        postExpression(x.ge(0.0));
+        postExpression(x.le(Math.toRadians(45)));
+        postExpression(y.eq(x.cos()));
+        postExpression(z.eq(y.pow(2.0)));
+        postExpression(v.eq(z.sqrt()));
+        postExpression(v.le(0.9));
+
+        model.getSolver().propagate();
+        assertBound(x, 0.451027, 0.785398);
+        assertBound(y, 0.707107, 0.9);
+        assertBound(z, 0.5, 0.81);
+        assertBound(v, 0.707107, 0.9);
+    }
+
+    @Test
+    public void sqr9Test() throws ContradictionException {
+        postExpression(x.ge(0.2));
+        postExpression(x.le(0.8));
+        postExpression(y.eq(x.pow(2.0)));
+        model.getSolver().propagate();
+        assertBound(x, 0.2, 0.8);
+        assertBound(y, 0.04, 0.64);
+    }
+
+    @Test
+    public void sqr10Test() throws ContradictionException {
+        postExpression(x.ge(-0.2));
+        postExpression(x.le(0.8));
+        postExpression(y.eq(x.pow(2.0)));
+        model.getSolver().propagate();
+        assertBound(x, -0.2, 0.8);
+        assertBound(y, 0.0, 0.64);
+    }
+
+}


### PR DESCRIPTION
Changes proposed in this PR:
- Add a pure java alternative for power operations with integer positive exponents.
- Add tests to increase the coverage of expected results for power operations (some of these tests are waiting the release of the contraction ratio parameter in ibex)
 
@chocoteam/core-developer 
