### PR TITLE
Add test suite and fix math expressions for ibex integration

### DIFF
--- a/solver/src/main/java/org/chocosolver/solver/expression/continuous/arithmetic/BiCArExpression.java
+++ b/solver/src/main/java/org/chocosolver/solver/expression/continuous/arithmetic/BiCArExpression.java
@@ -106,12 +106,15 @@ public class BiCArExpression implements CArExpression {
                     model.realIbexGenericConstraint("{0}={1}/{2}", me, v1, v2).post();
                     break;
                 case POW:
-                    bounds = VariableUtils.boundsForPow(v1, v2);
-                    me = model.realVar(bounds[0], bounds[1], p);
                     if (isIntegerConstant(v2)) {
                         // See issue: #702
-                        model.realIbexGenericConstraint("{0}={1}^" + (int) v2.getLB(), me, v1).post();
+                        int exponent = (int) v2.getLB();
+                        bounds = VariableUtils.boundsForPow(v1, exponent);
+                        me = model.realVar(bounds[0], bounds[1], p);
+                        model.realIbexGenericConstraint("{0}={1}^" + exponent, me, v1).post();
                     } else {
+                        bounds = VariableUtils.boundsForPow(v1, v2);
+                        me = model.realVar(bounds[0], bounds[1], p);
                         model.realIbexGenericConstraint("{0}={1}^{2}", me, v1, v2).post();
                     }
                     break;

--- a/solver/src/main/java/org/chocosolver/solver/expression/continuous/arithmetic/UnCArExpression.java
+++ b/solver/src/main/java/org/chocosolver/solver/expression/continuous/arithmetic/UnCArExpression.java
@@ -118,11 +118,11 @@ public class UnCArExpression implements CArExpression {
                     model.realIbexGenericConstraint("{0}=cos({1})", me, v).post();
                     break;
                 case SIN:
-                    me = model.realVar(0.0, 1.0, p);
+                    me = model.realVar(-1.0, 1.0, p);
                     model.realIbexGenericConstraint("{0}=sin({1})", me, v).post();
                     break;
                 case TAN:
-                    me = model.realVar(0.0, Double.POSITIVE_INFINITY, p);
+                    me = model.realVar(Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY, p);
                     model.realIbexGenericConstraint("{0}=tan({1})", me, v).post();
                     break;
                 case ACOS:
@@ -142,11 +142,11 @@ public class UnCArExpression implements CArExpression {
                     model.realIbexGenericConstraint("{0}=cosh({1})", me, v).post();
                     break;
                 case SINH:
-                    me = model.realVar(0.0, Double.POSITIVE_INFINITY, p);
+                    me = model.realVar(Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY, p);
                     model.realIbexGenericConstraint("{0}=sinh({1})", me, v).post();
                     break;
                 case TANH:
-                    me = model.realVar(0.0, Double.POSITIVE_INFINITY, p);
+                    me = model.realVar(Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY, p);
                     model.realIbexGenericConstraint("{0}=tanh({1})", me, v).post();
                     break;
                 case ACOSH:

--- a/solver/src/main/java/org/chocosolver/util/tools/VariableUtils.java
+++ b/solver/src/main/java/org/chocosolver/util/tools/VariableUtils.java
@@ -10,6 +10,7 @@
 package org.chocosolver.util.tools;
 
 import org.chocosolver.solver.Model;
+import org.chocosolver.solver.expression.continuous.arithmetic.RealIntervalConstant;
 import org.chocosolver.solver.variables.IntVar;
 import org.chocosolver.solver.variables.RealVar;
 import org.chocosolver.solver.variables.Variable;
@@ -233,6 +234,26 @@ public class VariableUtils {
                 Math.pow(x.getUB(), y.getLB()),
                 Math.pow(x.getUB(), y.getUB())
         );
+    }
+
+    /**
+     * @param x a variable
+     * @param y a constant
+     * @return computes the bounds for "x ^ y"
+     */
+    public static double[] boundsForPow(RealVar x, double y) {
+        if (y >= 0) {
+            return bound(0,
+                    Math.pow(x.getLB(), y),
+                    Math.pow(x.getUB(), y));
+        } else {
+            // bounds for 1/x^y when x < 0
+            double bounds[] = bound(0,
+                    Math.pow(x.getLB(), Math.abs(y)),
+                    Math.pow(x.getUB(), Math.abs(y)));
+            RealInterval boundsDiv = RealUtils.odiv(new RealIntervalConstant(1.0, 1.0), new RealIntervalConstant(bounds[0], bounds[1]));
+            return new double[]{boundsDiv.getLB(), boundsDiv.getUB()};
+        }
     }
 
     /**

--- a/solver/src/test/java/org/chocosolver/solver/constraints/real/RealBase.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/real/RealBase.java
@@ -1,0 +1,63 @@
+/*
+ * This file is part of choco-solver, http://choco-solver.org/
+ *
+ * Copyright (c) 2020, IMT Atlantique. All rights reserved.
+ *
+ * Licensed under the BSD 4-clause license.
+ *
+ * See LICENSE file in the project root for full license information.
+ */
+package org.chocosolver.solver.constraints.real;
+
+import org.chocosolver.solver.Model;
+import org.chocosolver.solver.expression.continuous.relational.CReExpression;
+import org.chocosolver.solver.expression.discrete.relational.ReExpression;
+import org.chocosolver.solver.variables.BoolVar;
+import org.chocosolver.solver.variables.RealVar;
+import org.testng.Assert;
+import org.testng.annotations.BeforeMethod;
+
+public abstract class RealBase {
+
+    protected static final double MIN_LIM = -100.0;
+    protected static final double MAX_LIM = 100.0;
+    protected static final double PRECISION = 0.000_001;
+
+    protected Model model;
+
+    protected RealVar x;
+
+    protected RealVar y;
+
+    protected RealVar z;
+
+    protected RealVar v;
+
+    protected RealVar r;
+
+    protected BoolVar w;
+
+    @BeforeMethod
+    protected void before() {
+        model = new Model();
+        x = model.realVar("x", MIN_LIM, MAX_LIM, PRECISION);
+        y = model.realVar("y", MIN_LIM, MAX_LIM, PRECISION);
+        z = model.realVar("z", MIN_LIM, MAX_LIM, PRECISION);
+        v = model.realVar("v", MIN_LIM, MAX_LIM, PRECISION);
+        r = model.realVar("r", 0.0, MAX_LIM, PRECISION);
+        w = model.boolVar("w");
+    }
+
+    protected void assertBound(RealVar var, double lb, double ub) {
+        Assert.assertEquals(var.getLB(), lb, PRECISION);
+        Assert.assertEquals(var.getUB(), ub, PRECISION);
+    }
+
+    protected void postExpression(CReExpression expression) {
+        expression.ibex(PRECISION).post();
+    }
+
+    protected ReExpression getExpression(CReExpression expression) {
+        return expression.ibex(PRECISION).reify().eq(1);
+    }
+}

--- a/solver/src/test/java/org/chocosolver/solver/constraints/real/RealCubicTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/real/RealCubicTest.java
@@ -1,0 +1,187 @@
+/*
+ * This file is part of choco-solver, http://choco-solver.org/
+ *
+ * Copyright (c) 2020, IMT Atlantique. All rights reserved.
+ *
+ * Licensed under the BSD 4-clause license.
+ *
+ * See LICENSE file in the project root for full license information.
+ */
+package org.chocosolver.solver.constraints.real;
+
+import org.chocosolver.solver.constraints.real.RealBase;
+import org.chocosolver.solver.exception.ContradictionException;
+import org.testng.annotations.Ignore;
+import org.testng.annotations.Test;
+
+public class RealCubicTest extends RealBase {
+
+    @Test
+    public void sqr1Test() throws ContradictionException {
+        postExpression(y.eq(x.pow(3)));
+        model.getSolver().propagate();
+        assertBound(x, -4.641589, 4.641589);
+        assertBound(y, -100.0, 100.0);
+    }
+
+    @Test
+    public void sqr2Test() throws ContradictionException {
+        postExpression(x.ge(-2.5));
+        postExpression(x.le(4.5));
+        postExpression(y.eq(x.pow(3)));
+        model.getSolver().propagate();
+        assertBound(x, -2.5, 4.5);
+        assertBound(y, -15.625, 91.125);
+    }
+
+    @Test
+    public void sqr3Test() throws ContradictionException {
+        postExpression(x.ge(2.5));
+        postExpression(x.le(4.5));
+        postExpression(y.eq(x.pow(3)));
+        model.getSolver().propagate();
+        assertBound(x, 2.5, 4.5);
+        assertBound(y, 15.625, 91.125);
+    }
+
+    @Test
+    public void sqr4Test() throws ContradictionException {
+        postExpression(x.ge(-4.5));
+        postExpression(x.le(-2.5));
+        postExpression(y.eq(x.pow(3)));
+        model.getSolver().propagate();
+        assertBound(x, -4.5, -2.5);
+        assertBound(y, -91.125, -15.625);
+    }
+
+    @Test
+    @Ignore("Expecting IBEX release the contraction ratio parameter")
+    public void imp1Test() throws ContradictionException {
+        postExpression(x.ge(0));
+        postExpression(y.eq(9.5));
+        w.eq(1).imp(getExpression(x.pow(3).gt(y))).post();
+        w.eq(1).post();
+        model.getSolver().propagate();
+        assertBound(x, 2.117912, 100.0);
+    }
+
+    @Test
+    public void imp2Test() throws ContradictionException {
+        postExpression(x.ge(0));
+        postExpression(y.eq(10.5));
+        w.eq(1).imp(getExpression(x.pow(3).lt(y))).post();
+        w.eq(1).post();
+        model.getSolver().propagate();
+        assertBound(x, 0.0, 2.18976);
+    }
+
+    @Test
+    public void imp4Test() throws ContradictionException {
+        postExpression(x.le(0.0));
+        postExpression(y.eq(10.5));
+        w.eq(1).imp(getExpression(x.pow(3).lt(y))).post();
+        w.eq(1).post();
+        model.getSolver().propagate();
+        assertBound(x, -100.0, 0.0);
+    }
+
+    @Test
+    public void imp5Test() throws ContradictionException {
+        postExpression(x.ge(0));
+        postExpression(y.eq(-9.5));
+        w.eq(1).imp(getExpression(x.pow(3).gt(y))).post();
+        w.eq(1).post();
+        model.getSolver().propagate();
+        assertBound(x, 0.0, 100.0);
+    }
+
+    @Test
+    public void imp7Test() throws ContradictionException {
+        postExpression(x.le(0));
+        postExpression(y.eq(-3.5));
+        w.eq(1).post();
+        w.eq(1).imp(getExpression(x.pow(3).gt(y))).post();
+        model.getSolver().propagate();
+        assertBound(x, -1.518294, 0.0);
+    }
+
+    @Test
+    @Ignore("Expecting IBEX release the contraction ratio parameter")
+    public void imp8Test() throws ContradictionException {
+        postExpression(x.le(0));
+        postExpression(y.eq(-10.5));
+        w.eq(1).imp(getExpression(x.pow(3).lt(y))).post();
+        w.eq(1).post();
+        model.getSolver().propagate();
+        assertBound(x, -100.0, -2.18976);
+    }
+
+    @Test
+    public void sqr5Test() throws ContradictionException {
+        postExpression(z.eq(25.5));
+        postExpression(y.eq(-4.5));
+        postExpression(x.pow(3).le(z));
+        postExpression(x.pow(3).ge(y));
+        model.getSolver().propagate();
+        assertBound(x, -1.650964, 2.943383);
+    }
+
+    @Test
+    public void sqr6Test() throws ContradictionException {
+        postExpression(z.eq(25.5));
+        postExpression(y.eq(4.5));
+        postExpression(x.ge(0.0));
+        postExpression(x.pow(3).lt(z));
+        postExpression(x.pow(3).gt(y));
+        model.getSolver().propagate();
+        assertBound(x, 1.650964, 2.943383);
+    }
+
+    @Test
+    public void sqr7Test() throws ContradictionException {
+        postExpression(z.eq(25.5));
+        postExpression(y.eq(-4.5));
+        postExpression(x.le(0.0));
+        postExpression(x.pow(3).le(z));
+        postExpression(x.pow(3).ge(y));
+        model.getSolver().propagate();
+        assertBound(x, -1.650964, 0.0);
+    }
+
+    @Test
+    public void sqr8Test() throws ContradictionException {
+        postExpression(x.ge(0));
+        postExpression(x.le(Math.toRadians(45)));
+        postExpression(y.eq(x.cos()));
+        postExpression(z.eq(y.pow(3)));
+        postExpression(v.eq(z.sqrt()));
+        postExpression(v.le(0.9));
+
+        model.getSolver().propagate();
+        assertBound(x, 0.370436, 0.785398);
+        assertBound(y, 0.707107, 0.93217);
+        assertBound(z, 0.353553, 0.81);
+        assertBound(v, 0.594604, 0.9);
+    }
+
+    @Test
+    public void sqr9Test() throws ContradictionException {
+        postExpression(x.ge(0.2));
+        postExpression(x.le(0.8));
+        postExpression(y.eq(x.pow(3)));
+        model.getSolver().propagate();
+        assertBound(x, 0.2, 0.8);
+        assertBound(y, 0.008, 0.512);
+    }
+
+    @Test
+    public void sqr10Test() throws ContradictionException {
+        postExpression(x.ge(-0.2));
+        postExpression(x.le(0.8));
+        postExpression(y.eq(x.pow(3)));
+        model.getSolver().propagate();
+        assertBound(x, -0.2, 0.8);
+        assertBound(y, -0.008, 0.512);
+    }
+
+}

--- a/solver/src/test/java/org/chocosolver/solver/constraints/real/RealExponentTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/real/RealExponentTest.java
@@ -1,0 +1,49 @@
+package org.chocosolver.solver.constraints.real;
+
+import org.chocosolver.solver.constraints.real.RealBase;
+import org.chocosolver.solver.exception.ContradictionException;
+import org.testng.annotations.Test;
+
+public class RealExponentTest extends RealBase {
+
+    @Test
+    public void realExp1Test() throws ContradictionException {
+        postExpression(y.eq(x.pow(r)));
+        model.getSolver().propagate();
+        assertBound(x, 0.0, 100.0);
+        assertBound(r, 0.0, 100.0);
+        assertBound(y, 0.0, 100.0);
+    }
+
+    @Test
+    public void realExp2Test() throws ContradictionException {
+        postExpression(r.ge(10.0));
+        postExpression(y.eq(x.pow(r)));
+        model.getSolver().propagate();
+        assertBound(x, 0.0, 1.584893);
+        assertBound(r, 10.0, 100.0);
+        assertBound(y, 0.0, 100.0);
+    }
+
+    @Test
+    public void realExp3Test() throws ContradictionException {
+        postExpression(r.le(10.0));
+        postExpression(y.eq(x.pow(r)));
+        model.getSolver().propagate();
+        assertBound(x, 0.0, 100.0);
+        assertBound(r, 0.0, 10.0);
+        assertBound(y, 0.0, 100.0);
+    }
+
+    @Test
+    public void realExp4Test() throws ContradictionException {
+        postExpression(x.ge(8.0));
+        postExpression(x.le(10.0));
+        postExpression(y.eq(x.pow(r)));
+        model.getSolver().propagate();
+        assertBound(x, 8.0, 10.0);
+        assertBound(r, 0.0, 2.214619);
+        assertBound(y, 1.0, 100.0);
+    }
+
+}

--- a/solver/src/test/java/org/chocosolver/solver/constraints/real/RealNegativePowerTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/real/RealNegativePowerTest.java
@@ -1,0 +1,132 @@
+/*
+ * This file is part of choco-solver, http://choco-solver.org/
+ *
+ * Copyright (c) 2020, IMT Atlantique. All rights reserved.
+ *
+ * Licensed under the BSD 4-clause license.
+ *
+ * See LICENSE file in the project root for full license information.
+ */
+package org.chocosolver.solver.constraints.real;
+
+import org.chocosolver.solver.constraints.real.RealBase;
+import org.chocosolver.solver.exception.ContradictionException;
+import org.testng.annotations.Test;
+
+public class RealNegativePowerTest extends RealBase {
+
+    /**
+     * With even operations
+     */
+
+    @Test
+    public void powerEven1Test() throws ContradictionException {
+        postExpression(y.eq(x.pow(-2)));
+        model.getSolver().propagate();
+        assertBound(x, -100.0, 100.0);
+        assertBound(y, 0.0001, 100.0);
+    }
+
+    @Test
+    public void powerEven2Test() throws ContradictionException {
+        postExpression(x.ge(-0.5));
+        postExpression(x.le(0.5));
+        postExpression(y.eq(x.pow(-2)));
+        model.getSolver().propagate();
+        assertBound(x, -0.5, 0.5);
+        assertBound(y, 4.0, 100.0);
+    }
+
+    @Test
+    public void powerEven3Test() throws ContradictionException {
+        postExpression(x.ge(0));
+        postExpression(x.le(0.5));
+        postExpression(y.eq(x.pow(-2)));
+        model.getSolver().propagate();
+        assertBound(x, 0.1, 0.5);
+        assertBound(y, 4.0, 100.0);
+    }
+
+    @Test
+    public void powerEven4Test() throws ContradictionException {
+        postExpression(x.ge(2.0));
+        postExpression(y.eq(x.pow(-2)));
+        model.getSolver().propagate();
+        assertBound(x, 2.0, 100.0);
+        assertBound(y, 0.0001, 0.25);
+    }
+
+    @Test
+    public void powerEven5Test() throws ContradictionException {
+        postExpression(x.ge(-0.5));
+        postExpression(x.le(0));
+        postExpression(y.eq(x.pow(-2)));
+        model.getSolver().propagate();
+        assertBound(x, -0.5, -0.1);
+        assertBound(y, 4.0, 100.0);
+    }
+
+    @Test
+    public void powerEven6Test() throws ContradictionException {
+        postExpression(x.ge(-10000));
+        postExpression(x.le(-2));
+        postExpression(y.eq(x.pow(-2)));
+        model.getSolver().propagate();
+        assertBound(x, -100.0, -2.0);
+        assertBound(y, 0.0001, 0.25);
+    }
+
+    /**
+     * With odd operations
+     */
+
+    @Test
+    public void powerOdd2Test() throws ContradictionException {
+        postExpression(x.ge(-2));
+        postExpression(x.le(2));
+        postExpression(y.eq(x.pow(-3)));
+        model.getSolver().propagate();
+        assertBound(x, -2.0, 2.0);
+        assertBound(y, -100.0, 100.0);
+    }
+
+    @Test
+    public void powerOdd3Test() throws ContradictionException {
+        postExpression(x.ge(0));
+        postExpression(x.le(2));
+        postExpression(y.eq(x.pow(-3)));
+        model.getSolver().propagate();
+        assertBound(x, 0.215443, 2.0);
+        assertBound(y, 0.125, 100.0);
+    }
+
+    @Test
+    public void powerOdd4Test() throws ContradictionException {
+        postExpression(x.ge(2));
+        postExpression(y.eq(x.pow(-3)));
+        model.getSolver().propagate();
+        assertBound(x, 2.0, 100.0);
+        assertBound(y, 0.000001, 0.125);
+    }
+
+    @Test
+    public void powerOdd5Test() throws ContradictionException {
+        postExpression(x.ge(-2));
+        postExpression(x.le(0));
+        postExpression(y.eq(x.pow(-3)));
+        model.getSolver().propagate();
+        assertBound(x, -2.0, -0.215443);
+        assertBound(y, -100.0, -0.125);
+    }
+
+    @Test
+    public void powerOdd6Test() throws ContradictionException {
+        postExpression(x.ge(-10000.0));
+        postExpression(x.le(-2));
+        postExpression(y.eq(x.pow(-3)));
+        model.getSolver().propagate();
+        assertBound(x, -100.0, -2.0);
+        assertBound(y, -0.125, -0.000001);
+    }
+
+}

--- a/solver/src/test/java/org/chocosolver/solver/constraints/real/RealSquareTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/real/RealSquareTest.java
@@ -1,0 +1,167 @@
+/*
+ * This file is part of choco-solver, http://choco-solver.org/
+ *
+ * Copyright (c) 2020, IMT Atlantique. All rights reserved.
+ *
+ * Licensed under the BSD 4-clause license.
+ *
+ * See LICENSE file in the project root for full license information.
+ */
+package org.chocosolver.solver.constraints.real;
+
+import org.chocosolver.solver.constraints.real.RealBase;
+import org.chocosolver.solver.exception.ContradictionException;
+import org.testng.annotations.Ignore;
+import org.testng.annotations.Test;
+
+public class RealSquareTest extends RealBase {
+
+    @Test
+    public void sqr1Test() throws ContradictionException {
+        postExpression(y.eq(x.pow(2.0)));
+        model.getSolver().propagate();
+        assertBound(x, -10.0, 10.0);
+        assertBound(y, 0.0, 100.0);
+    }
+
+    @Test
+    public void sqr2Test() throws ContradictionException {
+        postExpression(x.ge(-2.5));
+        postExpression(x.le(4.5));
+        postExpression(y.eq(x.pow(2.0)));
+        model.getSolver().propagate();
+        assertBound(x, -2.5, 4.5);
+        assertBound(y, 0.0, 20.25);
+    }
+
+    @Test
+    public void sqr3Test() throws ContradictionException {
+        postExpression(x.ge(2.5));
+        postExpression(x.le(4.5));
+        postExpression(y.eq(x.pow(2.0)));
+        model.getSolver().propagate();
+        assertBound(x, 2.5, 4.5);
+        assertBound(y, 6.25, 20.25);
+    }
+
+    @Test
+    public void sqr4Test() throws ContradictionException {
+        postExpression(x.ge(-4.5));
+        postExpression(x.le(-2.5));
+        postExpression(y.eq(x.pow(2.0)));
+        model.getSolver().propagate();
+        assertBound(x, -4.5, -2.5);
+        assertBound(y, 6.25, 20.25);
+    }
+
+    @Test
+    @Ignore("Expecting IBEX release the contraction ratio parameter")
+    public void imp1Test() throws ContradictionException {
+        postExpression(x.ge(0.0));
+        postExpression(y.eq(3.5));
+        w.eq(1).imp(getExpression(x.pow(2.0).gt(y))).post();
+        w.eq(1).post();
+        model.getSolver().propagate();
+        assertBound(x, 1.870829, 100.0);
+    }
+
+    @Test
+    public void imp2Test() throws ContradictionException {
+        postExpression(x.ge(0.0));
+        postExpression(y.eq(10.5));
+        w.eq(1).imp(getExpression(x.pow(2.0).lt(y))).post();
+        w.eq(1).post();
+        model.getSolver().propagate();
+        assertBound(x, 0.0, 3.24037);
+    }
+
+    @Test
+    @Ignore("Expecting IBEX release the contraction ratio parameter")
+    public void imp3Test() throws ContradictionException {
+        postExpression(x.le(0.0));
+        postExpression(y.eq(3.5));
+        w.eq(1).imp(getExpression(x.pow(2.0).gt(y))).post();
+        w.eq(1).post();
+        model.getSolver().propagate();
+        assertBound(x, -100.0, -1.870829);
+    }
+
+    @Test
+    public void imp4Test() throws ContradictionException {
+        postExpression(x.le(0.0));
+        postExpression(y.eq(10.5));
+        w.eq(1).imp(getExpression(x.pow(2.0).lt(y))).post();
+        w.eq(1).post();
+        model.getSolver().propagate();
+        assertBound(x, -3.24037, 0.0);
+    }
+
+    @Test
+    public void sqr5Test() throws ContradictionException {
+        postExpression(z.eq(25.5));
+        postExpression(y.eq(4.5));
+        postExpression(x.pow(2.0).le(z));
+        postExpression(x.pow(2.0).ge(y));
+        model.getSolver().propagate();
+        assertBound(x, -5.049752, 5.049752);
+    }
+
+    @Test
+    public void sqr6Test() throws ContradictionException {
+        postExpression(z.eq(25.5));
+        postExpression(y.eq(4.5));
+        postExpression(x.ge(0.0));
+        postExpression(x.pow(2.0).lt(z));
+        postExpression(x.pow(2.0).gt(y));
+        model.getSolver().propagate();
+        assertBound(x, 2.121321, 5.049752);
+    }
+
+    @Test
+    public void sqr7Test() throws ContradictionException {
+        postExpression(z.eq(25.5));
+        postExpression(y.eq(4.5));
+        postExpression(x.le(0.0));
+        postExpression(x.pow(2.0).le(z));
+        postExpression(x.pow(2.0).ge(y));
+        model.getSolver().propagate();
+        assertBound(x, -5.049752, -2.12132);
+    }
+
+    @Test
+    public void sqr8Test() throws ContradictionException {
+        postExpression(x.ge(0.0));
+        postExpression(x.le(Math.toRadians(45)));
+        postExpression(y.eq(x.cos()));
+        postExpression(z.eq(y.pow(2.0)));
+        postExpression(v.eq(z.sqrt()));
+        postExpression(v.le(0.9));
+
+        model.getSolver().propagate();
+        assertBound(x, 0.451027, 0.785398);
+        assertBound(y, 0.707107, 0.9);
+        assertBound(z, 0.5, 0.81);
+        assertBound(v, 0.707107, 0.9);
+    }
+
+    @Test
+    public void sqr9Test() throws ContradictionException {
+        postExpression(x.ge(0.2));
+        postExpression(x.le(0.8));
+        postExpression(y.eq(x.pow(2.0)));
+        model.getSolver().propagate();
+        assertBound(x, 0.2, 0.8);
+        assertBound(y, 0.04, 0.64);
+    }
+
+    @Test
+    public void sqr10Test() throws ContradictionException {
+        postExpression(x.ge(-0.2));
+        postExpression(x.le(0.8));
+        postExpression(y.eq(x.pow(2.0)));
+        model.getSolver().propagate();
+        assertBound(x, -0.2, 0.8);
+        assertBound(y, 0.0, 0.64);
+    }
+
+}

--- a/solver/src/test/java/org/chocosolver/solver/constraints/real/RestTrigTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/real/RestTrigTest.java
@@ -1,0 +1,157 @@
+package org.chocosolver.solver.constraints.real;
+
+import org.testng.annotations.Test;
+
+public class RestTrigTest extends RealBase {
+
+    @Test
+    public void atan2Test() throws Exception {
+        postExpression(x.eq(y.atan2(Math.toRadians(45))));
+        model.getSolver().propagate();
+        assertBound(x, -1.562942, 1.562942);
+        assertBound(y, -100.0, 100.0);
+    }
+
+    @Test
+    public void atan22Test() throws Exception {
+        postExpression(z.eq(Math.toRadians(45)));
+        postExpression(x.eq(y.atan2(z)));
+        model.getSolver().propagate();
+        assertBound(x, -1.562942, 1.562942);
+        assertBound(y, -100.0, 100.0);
+        assertBound(z, Math.toRadians(45), Math.toRadians(45));
+    }
+
+    @Test
+    public void cosTest() throws Exception {
+        // https://www.medcalc.org/manual/_help/functions/cos.png
+        postExpression(x.ge(-2.0));
+        postExpression(x.le(2.0));
+        postExpression(y.eq(x.cos()));
+        model.getSolver().propagate();
+        assertBound(x, -2.0, 2.0);
+        assertBound(y, -0.416147, 1.0);
+    }
+
+    @Test
+    public void sinTest() throws Exception {
+        // https://www.medcalc.org/manual/_help/functions/sin.png
+        postExpression(x.ge(-1.0));
+        postExpression(x.le(1.0));
+        postExpression(y.eq(x.sin()));
+        model.getSolver().propagate();
+        assertBound(x, -1.0, 1.0);
+        assertBound(y, -0.841471, 0.841471);
+    }
+
+    @Test
+    public void tanTest() throws Exception {
+        // https://www.medcalc.org/manual/_help/functions/tan.png
+        postExpression(x.ge(-1.0));
+        postExpression(x.le(1.0));
+        postExpression(y.eq(x.tan()));
+        model.getSolver().propagate();
+        assertBound(x, -1.0, 1.0);
+        assertBound(y, -1.557408, 1.557408);
+    }
+
+    @Test
+    public void acosTest() throws Exception {
+        // https://www.medcalc.org/manual/_help/functions/acos.png
+        postExpression(x.ge(-1.0));
+        postExpression(x.le(1.0));
+        postExpression(y.eq(x.acos()));
+        model.getSolver().propagate();
+        assertBound(x, -1.0, 1.0);
+        assertBound(y, 0.0, 3.141593);
+    }
+
+    @Test
+    public void asinTest() throws Exception {
+        // https://www.medcalc.org/manual/_help/functions/asin.png
+        postExpression(x.ge(-1.0));
+        postExpression(x.le(1.0));
+        postExpression(y.eq(x.asin()));
+        model.getSolver().propagate();
+        assertBound(x, -1.0, 1.0);
+        assertBound(y, -1.570796, 1.570796);
+    }
+
+    @Test
+    public void atanTest() throws Exception {
+        // https://www.medcalc.org/manual/_help/functions/atan.png
+        postExpression(x.ge(-1.0));
+        postExpression(x.le(1.0));
+        postExpression(y.eq(x.atan()));
+        model.getSolver().propagate();
+        assertBound(x, -1.0, 1.0);
+        assertBound(y, -0.785398, 0.785398);
+    }
+
+    @Test
+    public void coshTest() throws Exception {
+        // https://www.medcalc.org/manual/_help/functions/cosh.png
+        postExpression(x.ge(-2.0));
+        postExpression(x.le(2.0));
+        postExpression(y.eq(x.cosh()));
+        model.getSolver().propagate();
+        assertBound(x, -2.0, 2.0);
+        assertBound(y, 1.0, 3.762196);
+    }
+
+    @Test
+    public void sinhTest() throws Exception {
+        // https://www.medcalc.org/manual/_help/functions/sinh.png
+        postExpression(x.ge(-2.5));
+        postExpression(x.le(2.5));
+        postExpression(y.eq(x.sinh()));
+        model.getSolver().propagate();
+        assertBound(x, -2.5, 2.5);
+        assertBound(y, -6.050204, 6.050204);
+    }
+
+    @Test
+    public void tanhTest() throws Exception {
+        // https://www.medcalc.org/manual/_help/functions/tanh.png
+        postExpression(x.ge(-2.0));
+        postExpression(x.le(2.0));
+        postExpression(y.eq(x.tanh()));
+        model.getSolver().propagate();
+        assertBound(x, -2.0, 2.0);
+        assertBound(y, -0.964028, 0.964028);
+    }
+
+    @Test
+    public void acoshTest() throws Exception {
+        // https://www.medcalc.org/manual/_help/functions/acosh.png
+        postExpression(x.ge(1.0));
+        postExpression(x.le(10.0));
+        postExpression(y.eq(x.acosh()));
+        model.getSolver().propagate();
+        assertBound(x, 1.0, 10.0);
+        assertBound(y, 0.0, 2.993223);
+    }
+
+    @Test
+    public void asinhTest() throws Exception {
+        // https://www.medcalc.org/manual/_help/functions/asinh.png
+        postExpression(x.ge(-4.0));
+        postExpression(x.le(4.0));
+        postExpression(y.eq(x.asinh()));
+        model.getSolver().propagate();
+        assertBound(x, -4.0, 4.0);
+        assertBound(y, -2.094713, 2.094713);
+    }
+
+    @Test
+    public void atanhTest() throws Exception {
+        // https://www.medcalc.org/manual/_help/functions/tanh.png
+        postExpression(x.ge(-0.5));
+        postExpression(x.le(0.5));
+        postExpression(y.eq(x.atanh()));
+        model.getSolver().propagate();
+        assertBound(x, -0.5, 0.5);
+        assertBound(y, -0.549306, 0.549306);
+    }
+
+}


### PR DESCRIPTION
I've been working with several ibex operations and I've found some inconsistencies.
The objective of this PR is three-fold:
1. To contribute with a test suite for several math cases
2. Improve the bounds calculation for power with negative constant exponent
3. Fix some bounds for `SIN`, `TAN`, `SINH` and `TANH`

I'm not sure why the previous boundaries for `SIN`, `TAN`, `SINH`, and `TANH` were defined that way, but I executed the whole test battery for the solver module and no tests were impacted by this change.
 
@chocoteam/core-developer 
