### PR TITLE
Migrate graph variables from choco-graph - Refactor graph API - Implement set views over graph variables

### DIFF
--- a/solver/src/main/java/org/chocosolver/solver/constraints/graph/PropNbEdges.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/graph/PropNbEdges.java
@@ -1,0 +1,130 @@
+/*
+ * This file is part of choco-solver, http://choco-solver.org/
+ *
+ * Copyright (c) 2021, IMT Atlantique. All rights reserved.
+ *
+ * Licensed under the BSD 4-clause license.
+ *
+ * See LICENSE file in the project root for full license information.
+ */
+package org.chocosolver.solver.constraints.graph;
+
+import org.chocosolver.solver.variables.events.GraphEventType;
+import org.chocosolver.solver.variables.GraphVar;
+import org.chocosolver.solver.constraints.Propagator;
+import org.chocosolver.solver.constraints.PropagatorPriority;
+import org.chocosolver.solver.exception.ContradictionException;
+import org.chocosolver.solver.variables.IntVar;
+import org.chocosolver.solver.variables.Variable;
+import org.chocosolver.solver.variables.events.IntEventType;
+import org.chocosolver.util.ESat;
+import org.chocosolver.util.objects.setDataStructures.ISet;
+
+/**
+ * Propagator that ensures that Nb arcs/edges belong to the final graph
+ *
+ * @author Jean-Guillaume Fages
+ */
+public class PropNbEdges extends Propagator<Variable> {
+
+	//***********************************************************************************
+	// VARIABLES
+	//***********************************************************************************
+
+	protected GraphVar g;
+	protected IntVar k;
+
+	//***********************************************************************************
+	// CONSTRUCTORS
+	//***********************************************************************************
+
+	public PropNbEdges(GraphVar graph, IntVar k) {
+		super(new Variable[]{graph, k}, PropagatorPriority.LINEAR, false);
+		this.g = graph;
+		this.k = k;
+	}
+
+	//***********************************************************************************
+	// PROPAGATIONS
+	//***********************************************************************************
+
+	@Override
+	public void propagate(int evtmask) throws ContradictionException {
+		int nbK = 0;
+		int nbE = 0;
+		ISet env = g.getPotentialNodes();
+		for (int i : env) {
+			nbE += g.getPotentialSuccessorsOf(i).size();
+			nbK += g.getMandatorySuccessorsOf(i).size();
+		}
+		if (!g.isDirected()) {
+			nbK /= 2;
+			nbE /= 2;
+		}
+		filter(nbK, nbE);
+	}
+
+	private void filter(int nbK, int nbE) throws ContradictionException {
+		k.updateLowerBound(nbK, this);
+		k.updateUpperBound(nbE, this);
+		if (nbK != nbE && k.isInstantiated()) {
+			ISet nei;
+			ISet env = g.getPotentialNodes();
+			if (k.getValue() == nbE) {
+				for (int i : env) {
+					nei = g.getUB().getSuccessorsOf(i);
+					for (int j : nei) {
+						g.enforceEdge(i, j, this);
+					}
+				}
+			}
+			if (k.getValue() == nbK) {
+				ISet neiKer;
+				for (int i : env) {
+					nei = g.getUB().getSuccessorsOf(i);
+					neiKer = g.getLB().getSuccessorsOf(i);
+					for (int j : nei) {
+						if (!neiKer.contains(j)) {
+							g.removeEdge(i, j, this);
+						}
+					}
+				}
+			}
+		}
+	}
+
+	//***********************************************************************************
+	// INFO
+	//***********************************************************************************
+
+	@Override
+	public int getPropagationConditions(int vIdx) {
+		if (vIdx == 0) {
+			return GraphEventType.REMOVE_EDGE.getMask() + GraphEventType.ADD_EDGE.getMask();
+		} else {
+			return IntEventType.boundAndInst();
+		}
+	}
+
+	@Override
+	public ESat isEntailed() {
+		int nbK = 0;
+		int nbE = 0;
+		ISet env = g.getPotentialNodes();
+		for (int i : env) {
+			nbE += g.getUB().getSuccessorsOf(i).size();
+			nbK += g.getLB().getSuccessorsOf(i).size();
+		}
+		if (!g.isDirected()) {
+			nbK /= 2;
+			nbE /= 2;
+		}
+		if (nbK > k.getUB() || nbE < k.getLB()) {
+			return ESat.FALSE;
+		}
+		if (k.isInstantiated() && g.isInstantiated()) {
+			return ESat.TRUE;
+		}
+		return ESat.UNDEFINED;
+	}
+}

--- a/solver/src/main/java/org/chocosolver/solver/constraints/graph/PropNbNodes.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/graph/PropNbNodes.java
@@ -1,0 +1,104 @@
+/*
+ * This file is part of choco-solver, http://choco-solver.org/
+ *
+ * Copyright (c) 2021, IMT Atlantique. All rights reserved.
+ *
+ * Licensed under the BSD 4-clause license.
+ *
+ * See LICENSE file in the project root for full license information.
+ */
+package org.chocosolver.solver.constraints.graph;
+
+import org.chocosolver.solver.variables.events.GraphEventType;
+import org.chocosolver.solver.variables.GraphVar;
+import org.chocosolver.solver.constraints.Propagator;
+import org.chocosolver.solver.constraints.PropagatorPriority;
+import org.chocosolver.solver.exception.ContradictionException;
+import org.chocosolver.solver.variables.IntVar;
+import org.chocosolver.solver.variables.Variable;
+import org.chocosolver.solver.variables.events.IntEventType;
+import org.chocosolver.util.ESat;
+import org.chocosolver.util.objects.setDataStructures.ISet;
+
+/**
+ * Propagator that ensures that k nodes belong to the final graph
+ *
+ * @author Jean-Guillaume Fages
+ */
+public class PropNbNodes extends Propagator<Variable> {
+
+	//***********************************************************************************
+	// VARIABLES
+	//***********************************************************************************
+
+	private GraphVar g;
+	private IntVar k;
+
+	//***********************************************************************************
+	// CONSTRUCTORS
+	//***********************************************************************************
+
+	public PropNbNodes(GraphVar graph, IntVar k) {
+		super(new Variable[]{graph, k}, PropagatorPriority.LINEAR, false);
+		this.g = graph;
+		this.k = k;
+	}
+
+	//***********************************************************************************
+	// PROPAGATIONS
+	//***********************************************************************************
+
+	@Override
+	public void propagate(int evtmask) throws ContradictionException {
+		int env = g.getPotentialNodes().size();
+		int ker = g.getMandatoryNodes().size();
+		k.updateLowerBound(ker, this);
+		k.updateUpperBound(env, this);
+		if (ker == env) {
+			setPassive();
+		} else if (k.isInstantiated()) {
+			int v = k.getValue();
+			ISet envNodes = g.getPotentialNodes();
+			if (v == env) {
+				for (int i : envNodes) {
+					g.enforceNode(i, this);
+				}
+				setPassive();
+			} else if (v == ker) {
+				ISet kerNodes = g.getMandatoryNodes();
+				for (int i : envNodes) {
+					if (!kerNodes.contains(i)) {
+						g.removeNode(i, this);
+					}
+				}
+				setPassive();
+			}
+		}
+	}
+
+	//***********************************************************************************
+	// INFO
+	//***********************************************************************************
+
+	@Override
+	public int getPropagationConditions(int vIdx) {
+		if (vIdx == 0) {
+			return GraphEventType.REMOVE_NODE.getMask() + GraphEventType.ADD_NODE.getMask();
+		} else {
+			return IntEventType.boundAndInst();
+		}
+	}
+
+	@Override
+	public ESat isEntailed() {
+		int env = g.getPotentialNodes().size();
+		int ker = g.getMandatoryNodes().size();
+		if (env < k.getLB() || ker > k.getUB()) {
+			return ESat.FALSE;
+		}
+		if (env == ker) {
+			return ESat.TRUE;
+		}
+		return ESat.UNDEFINED;
+	}
+}

--- a/solver/src/main/java/org/chocosolver/solver/constraints/nary/PropDiffN.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/nary/PropDiffN.java
@@ -77,7 +77,7 @@ public class PropDiffN extends Propagator<IntVar> {
 
     private void prop(int varIdx) {
         int v = varIdx % n;
-        ISetIterator iter = overlappingBoxes.getNeighOf(v).iterator();
+        ISetIterator iter = overlappingBoxes.getNeighborsOf(v).iterator();
         while (iter.hasNext()) {
             int i = iter.nextInt();
             if (!mayOverlap(v, i)) {
@@ -125,7 +125,7 @@ public class PropDiffN extends Propagator<IntVar> {
 
     private boolean prune(int j) throws ContradictionException {
         boolean hasFiltered = false;
-        ISetIterator iter = overlappingBoxes.getNeighOf(j).iterator();
+        ISetIterator iter = overlappingBoxes.getNeighborsOf(j).iterator();
         while (iter.hasNext()) {
             int i = iter.nextInt();
             if(doOverlap(i, j, true)) {
@@ -146,7 +146,7 @@ public class PropDiffN extends Propagator<IntVar> {
         int am = vars[i + 2 * n].getLB() * vars[i + 3 * n].getLB();
         int xLengthMin = vars[i + 2 * n].getLB();
         int yLengthMin = vars[i + 3 * n].getLB();
-        ISetIterator iter = overlappingBoxes.getNeighOf(i).iterator();
+        ISetIterator iter = overlappingBoxes.getNeighborsOf(i).iterator();
         while (iter.hasNext()) {
             int j = iter.nextInt();
             xm = Math.min(xm, vars[j].getLB());
@@ -163,7 +163,7 @@ public class PropDiffN extends Propagator<IntVar> {
 
         if (xLengthMin > 0 && yLengthMin > 0) {
             int maxNumberRectangles = ((xM - xm) / xLengthMin) * ((yM - ym) / yLengthMin);
-            if (maxNumberRectangles < overlappingBoxes.getNeighOf(i).size()+1) {
+            if (maxNumberRectangles < overlappingBoxes.getNeighborsOf(i).size()+1) {
                 fails();
             }
         }

--- a/solver/src/main/java/org/chocosolver/solver/constraints/nary/alldifferent/algo/AlgoAllDiffAC.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/nary/alldifferent/algo/AlgoAllDiffAC.java
@@ -106,8 +106,8 @@ public class AlgoAllDiffAC {
 
     private void findMaximumMatching() throws ContradictionException {
         for (int i = 0; i < n2; i++) {
-            digraph.getSuccOf(i).clear();
-            digraph.getPredOf(i).clear();
+            digraph.getSuccessorsOf(i).clear();
+            digraph.getPredecessorsOf(i).clear();
         }
         free.set(0, n2);
         int k, ub;
@@ -120,11 +120,11 @@ public class AlgoAllDiffAC {
                 int j = map.get(k);
                 if (mate == j) {
                     assert free.get(i) && free.get(j);
-                    digraph.addArc(j, i);
+                    digraph.addEdge(j, i);
                     free.clear(i);
                     free.clear(j);
                 } else {
-                    digraph.addArc(i, j);
+                    digraph.addEdge(i, j);
                 }
             }
         }
@@ -132,7 +132,7 @@ public class AlgoAllDiffAC {
             tryToMatch(i);
         }
         for (int i = 0; i < n; i++) {
-            matching[i] = digraph.getPredOf(i).isEmpty()?-1:digraph.getPredOf(i).iterator().next();
+            matching[i] = digraph.getPredecessorsOf(i).isEmpty()?-1:digraph.getPredecessorsOf(i).iterator().next();
         }
     }
 
@@ -143,8 +143,8 @@ public class AlgoAllDiffAC {
             free.clear(i);
             int tmp = mate;
             while (tmp != i) {
-                digraph.removeArc(father[tmp], tmp);
-                digraph.addArc(tmp, father[tmp]);
+                digraph.removeEdge(father[tmp], tmp);
+                digraph.addEdge(tmp, father[tmp]);
                 tmp = father[tmp];
             }
         } else {
@@ -160,7 +160,7 @@ public class AlgoAllDiffAC {
         ISetIterator succs;
         while (indexFirst != indexLast) {
             x = fifo[indexFirst++];
-            succs = digraph.getSuccOf(x).iterator();
+            succs = digraph.getSuccessorsOf(x).iterator();
             while (succs.hasNext()) {
                 int y = succs.nextInt();
                 if (!in.get(y)) {
@@ -186,9 +186,9 @@ public class AlgoAllDiffAC {
             digraph.addNode(n2);
             for (int i = n; i < n2; i++) {
                 if (free.get(i)) {
-                    digraph.addArc(i, n2);
+                    digraph.addEdge(i, n2);
                 } else {
-                    digraph.addArc(n2, i);
+                    digraph.addEdge(n2, i);
                 }
             }
         }
@@ -212,7 +212,7 @@ public class AlgoAllDiffAC {
                     filter |= v.instantiateTo(k, aCause);
                 } else {
                     filter |= v.removeValue(k, aCause);
-                    digraph.removeArc(i, j);
+                    digraph.removeEdge(i, j);
                 }
             }
         }
@@ -234,14 +234,14 @@ public class AlgoAllDiffAC {
                 ub = v.getUB();
                 for (int k = v.getLB(); k <= ub; k++) {
                     j = map.get(k);
-                    if (!(digraph.arcExists(i, j) || digraph.arcExists(j, i))) {
+                    if (!(digraph.containsEdge(i, j) || digraph.containsEdge(j, i))) {
                         filter |= v.removeValue(k, aCause);
                     }
                 }
                 int lb = v.getLB();
                 for (int k = v.getUB(); k >= lb; k--) {
                     j = map.get(k);
-                    if (!(digraph.arcExists(i, j) || digraph.arcExists(j, i))) {
+                    if (!(digraph.containsEdge(i, j) || digraph.containsEdge(j, i))) {
                         filter |= v.removeValue(k, aCause);
                     }
                 }

--- a/solver/src/main/java/org/chocosolver/solver/constraints/nary/alldifferent/algo/AlgoAllDiffACFast.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/nary/alldifferent/algo/AlgoAllDiffACFast.java
@@ -68,7 +68,7 @@ public class AlgoAllDiffACFast extends AlgoAllDiffAC{
         ISetIterator predece;
         for (int i = free.nextSetBit(n); i >= n && i < n2; i = free.nextSetBit(i + 1)) {
             distinction.set(i);
-            predece = digraph.getPredOf(i).iterator();
+            predece = digraph.getPredecessorsOf(i).iterator();
             while (predece.hasNext()) {
                 int x = predece.nextInt();
                 if (!distinction.get(x)) {
@@ -80,7 +80,7 @@ public class AlgoAllDiffACFast extends AlgoAllDiffAC{
                 int y = fifo[indexFirst++];
                 int v = matching[y];
                 distinction.set(v);
-                predece = digraph.getPredOf(v).iterator();
+                predece = digraph.getPredecessorsOf(v).iterator();
                 while (predece.hasNext()) {
                     int x = predece.nextInt();
                     if (!distinction.get(x)) {
@@ -107,14 +107,14 @@ public class AlgoAllDiffACFast extends AlgoAllDiffAC{
                 if (!distinction.get(j)) {
                     if (distinction.get(i)) { // Remove type 1 redundant edges between Γ(A) and Dc-A.
                         filter |= v.removeValue(k, aCause);
-                        digraph.removeArc(i, j);
+                        digraph.removeEdge(i, j);
                     } else { // Remove type 2 redundant edges between Xc-Γ(A) and Dc-A.
                         if (nodeSCC[i] != nodeSCC[j]) {
                             if (matching[i] == j) {
                                 filter |= v.instantiateTo(k, aCause);
                             } else {
                                 filter |= v.removeValue(k, aCause);
-                                digraph.removeArc(i, j);
+                                digraph.removeEdge(i, j);
                             }
                         }
                     }

--- a/solver/src/main/java/org/chocosolver/solver/constraints/nary/circuit/PropCircuitSCC.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/nary/circuit/PropCircuitSCC.java
@@ -105,13 +105,13 @@ public class PropCircuitSCC extends Propagator<IntVar> {
 		int last = -1;
 		int n_R = SCCfinder.getNbSCC();
 		for (int i = 0; i < n_R; i++) {
-			if (G_R.getPredOf(i).isEmpty()) {
+			if (G_R.getPredecessorsOf(i).isEmpty()) {
 				if(first!=-1){
 					fails();
 				}
 				first = i;
 			}
-			if (G_R.getSuccOf(i).isEmpty()) {
+			if (G_R.getSuccessorsOf(i).isEmpty()) {
 				if(last!=-1){
 					fails();
 				}
@@ -136,10 +136,10 @@ public class PropCircuitSCC extends Propagator<IntVar> {
 	public void rebuild(int source) {
 		for(int i=0;i<n2;i++){
 			mates[i].clear();
-			support.getSuccOf(i).clear();
-			support.getPredOf(i).clear();
-			G_R.getPredOf(i).clear();
-			G_R.getSuccOf(i).clear();
+			support.getSuccessorsOf(i).clear();
+			support.getPredecessorsOf(i).clear();
+			G_R.getPredecessorsOf(i).clear();
+			G_R.getSuccessorsOf(i).clear();
 		}
 		G_R.getNodes().clear();
 		for(int i=0;i<n;i++){
@@ -148,9 +148,9 @@ public class PropCircuitSCC extends Propagator<IntVar> {
 			int ub = v.getUB();
 			for(int j=lb;j<=ub;j=v.nextValue(j)){
 				if(j-offSet==source){
-					support.addArc(i,n);
+					support.addEdge(i,n);
 				}else{
-					support.addArc(i,j-offSet);
+					support.addEdge(i,j-offSet);
 				}
 			}
 		}
@@ -164,11 +164,11 @@ public class PropCircuitSCC extends Propagator<IntVar> {
 		int x;
 		for (int i = 0; i < n; i++) {
 			x = sccOf[i];
-			succs = support.getSuccOf(i).iterator();
+			succs = support.getSuccessorsOf(i).iterator();
 			while (succs.hasNext()) {
 				int j = succs.nextInt();
 				if (x != sccOf[j]) {
-					G_R.addArc(x, sccOf[j]);
+					G_R.addEdge(x, sccOf[j]);
 					mates[x].add((i + 1) * n2 + j);
 				}
 			}
@@ -183,16 +183,16 @@ public class PropCircuitSCC extends Propagator<IntVar> {
 			return 1;
 		}
 		int next = -1;
-		ISetIterator succs = G_R.getSuccOf(node).iterator();
+		ISetIterator succs = G_R.getSuccessorsOf(node).iterator();
 		while(succs.hasNext()){
 			int x = succs.nextInt();
-			if (G_R.getPredOf(x).size() == 1) {
+			if (G_R.getPredecessorsOf(x).size() == 1) {
 				if (next != -1) {
 					return 0;
 				}
 				next = x;
 			} else {
-				G_R.removeArc(node, x);
+				G_R.removeEdge(node, x);
 			}
 		}
 		succs = mates[node].iterator();
@@ -265,9 +265,9 @@ public class PropCircuitSCC extends Propagator<IntVar> {
 			forceOutDoor(outDoor);
 			// If 1 in and 1 out and |scc| > 2 then forbid in->out
 			// Is only 1 in ?
-			if (G_R.getPredOf(sccFrom).iterator().hasNext()) {
+			if (G_R.getPredecessorsOf(sccFrom).iterator().hasNext()) {
 				int in = -1;
-				int p = G_R.getPredOf(sccFrom).iterator().next();
+				int p = G_R.getPredecessorsOf(sccFrom).iterator().next();
 				ISetIterator iterP = mates[p].iterator();
 				while (iterP.hasNext()) {
 					int i = iterP.nextInt();

--- a/solver/src/main/java/org/chocosolver/solver/constraints/nary/circuit/PropCircuit_AntiArboFiltering.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/nary/circuit/PropCircuit_AntiArboFiltering.java
@@ -34,16 +34,16 @@ public class PropCircuit_AntiArboFiltering extends PropCircuit_ArboFiltering {
 
 	protected void filterFromDom(int duplicatedNode) throws ContradictionException {
 		for (int i = 0; i < n + 1; i++) {
-			connectedGraph.getSuccOf(i).clear();
-			connectedGraph.getPredOf(i).clear();
+			connectedGraph.getSuccessorsOf(i).clear();
+			connectedGraph.getPredecessorsOf(i).clear();
 		}
 		for (int i = 0; i < n; i++) {
 			int ub = vars[i].getUB();
 			for (int y = vars[i].getLB(); y <= ub; y = vars[i].nextValue(y)) {
 				if (y - offSet == duplicatedNode) {
-					connectedGraph.addArc(n, i);
+					connectedGraph.addEdge(n, i);
 				}else {
-					connectedGraph.addArc(y - offSet, i);
+					connectedGraph.addEdge(y - offSet, i);
 				}
 			}
 		}

--- a/solver/src/main/java/org/chocosolver/solver/constraints/nary/circuit/PropCircuit_ArboFiltering.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/nary/circuit/PropCircuit_ArboFiltering.java
@@ -91,16 +91,16 @@ public class PropCircuit_ArboFiltering extends Propagator<IntVar> {
 
     protected void filterFromDom(int duplicatedNode) throws ContradictionException {
         for (int i = 0; i < n + 1; i++) {
-            connectedGraph.getSuccOf(i).clear();
-            connectedGraph.getPredOf(i).clear();
+            connectedGraph.getSuccessorsOf(i).clear();
+            connectedGraph.getPredecessorsOf(i).clear();
         }
         for (int i = 0; i < n; i++) {
             int ub = vars[i].getUB();
             for (int y = vars[i].getLB(); y <= ub; y = vars[i].nextValue(y)) {
                 if (i == duplicatedNode) {
-                    connectedGraph.addArc(n, y - offSet);
+                    connectedGraph.addEdge(n, y - offSet);
                 } else {
-                    connectedGraph.addArc(i, y - offSet);
+                    connectedGraph.addEdge(i, y - offSet);
                 }
             }
         }

--- a/solver/src/main/java/org/chocosolver/solver/constraints/nary/circuit/PropSubcircuitDominatorFilter.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/nary/circuit/PropSubcircuitDominatorFilter.java
@@ -103,9 +103,9 @@ public class PropSubcircuitDominatorFilter extends Propagator<IntVar> {
 			int ub = vars[i].getUB();
 			for (int y = vars[i].getLB(); y <= ub; y = vars[i].nextValue(y)) {
 				if (i == duplicatedNode || i == y-offSet) {
-					connectedGraph.addArc(n, y - offSet);
+					connectedGraph.addEdge(n, y - offSet);
 				}else{
-					connectedGraph.addArc(i, y - offSet);
+					connectedGraph.addEdge(i, y - offSet);
 				}
 			}
 		}
@@ -143,9 +143,9 @@ public class PropSubcircuitDominatorFilter extends Propagator<IntVar> {
 			int ub = vars[i].getUB();
 			for (int y = vars[i].getLB(); y <= ub; y = vars[i].nextValue(y)) {
 				if (y - offSet == duplicatedNode || i == y-offSet) {
-					connectedGraph.addArc(n, i);
+					connectedGraph.addEdge(n, i);
 				}else{
-					connectedGraph.addArc(y - offSet, i);
+					connectedGraph.addEdge(y - offSet, i);
 				}
 			}
 		}
@@ -176,8 +176,8 @@ public class PropSubcircuitDominatorFilter extends Propagator<IntVar> {
 
 	private void clear(){
 		for (int i = 0; i < n + 1; i++) {
-			connectedGraph.getSuccOf(i).clear();
-			connectedGraph.getPredOf(i).clear();
+			connectedGraph.getSuccessorsOf(i).clear();
+			connectedGraph.getPredecessorsOf(i).clear();
 		}
 	}
 

--- a/solver/src/main/java/org/chocosolver/solver/constraints/nary/cumulative/PropGraphCumulative.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/nary/cumulative/PropGraphCumulative.java
@@ -84,12 +84,12 @@ public class PropGraphCumulative extends PropCumulative {
                 ISetIterator tcIt = toCompute.iterator();
                 while (tcIt.hasNext()){
                     int i = tcIt.nextInt();
-                    for (int j : g.getNeighOf(i)) {
+                    for (int j : g.getNeighborsOf(i)) {
                         if (disjoint(i, j)) {
                             g.removeEdge(i, j);
                         }
                     }
-                    count += g.getNeighOf(i).size();
+                    count += g.getNeighborsOf(i).size();
                     if(count >= 2*n)break;
                 }
                 if (count >= 2*n) {
@@ -117,7 +117,7 @@ public class PropGraphCumulative extends PropCumulative {
             int v = varIdx % n;
             if(h[v].getUB()==0 || d[v].getUB()==0){
                 allTasks.remove(v);
-                ISetIterator gIt = g.getNeighOf(v).iterator();
+                ISetIterator gIt = g.getNeighborsOf(v).iterator();
                 while (gIt.hasNext()){
                     g.removeEdge(v,gIt.nextInt());
                 }
@@ -134,7 +134,7 @@ public class PropGraphCumulative extends PropCumulative {
     protected void filterAround(int taskIndex) throws ContradictionException {
         tasks.clear();
         tasks.add(taskIndex);
-        ISetIterator env = g.getNeighOf(taskIndex).iterator();
+        ISetIterator env = g.getNeighborsOf(taskIndex).iterator();
         while (env.hasNext()) {
             tasks.add(env.nextInt());
         }
@@ -147,7 +147,7 @@ public class PropGraphCumulative extends PropCumulative {
 
     private void graphComputation() {
         for (int i = 0; i < n; i++) {
-            g.getNeighOf(i).clear();
+            g.getNeighborsOf(i).clear();
         }
         Event[] events = new Event[2 * n];
         ArraySort<Event> sort = new ArraySort<>(events.length, true, false);

--- a/solver/src/main/java/org/chocosolver/solver/constraints/nary/nvalue/PropAtLeastNValues_AC.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/nary/nvalue/PropAtLeastNValues_AC.java
@@ -110,8 +110,8 @@ public class PropAtLeastNValues_AC extends Propagator<IntVar> {
 
     private void buildDigraph() {
         for (int i = 0; i < n2; i++) {
-            digraph.getSuccOf(i).clear();
-            digraph.getPredOf(i).clear();
+            digraph.getSuccessorsOf(i).clear();
+            digraph.getPredecessorsOf(i).clear();
         }
         free.set(0, n2);
         int j, k, ub;
@@ -124,7 +124,7 @@ public class PropAtLeastNValues_AC extends Propagator<IntVar> {
             ub = v.getUB();
             for (k = v.getLB(); k <= ub; k = v.nextValue(k)) {
                 j = map.get(k);
-                digraph.addArc(i, j);
+                digraph.addEdge(i, j);
             }
         }
     }
@@ -139,7 +139,7 @@ public class PropAtLeastNValues_AC extends Propagator<IntVar> {
         }
         int card = 0;
         for (int i = 0; i < n; i++) {
-            if (digraph.getPredOf(i).size()>0) {
+            if (digraph.getPredecessorsOf(i).size()>0) {
                 card++;
             }
         }
@@ -153,8 +153,8 @@ public class PropAtLeastNValues_AC extends Propagator<IntVar> {
             free.clear(i);
             int tmp = mate;
             while (tmp != i) {
-                digraph.removeArc(father[tmp], tmp);
-                digraph.addArc(tmp, father[tmp]);
+                digraph.removeEdge(father[tmp], tmp);
+                digraph.addEdge(tmp, father[tmp]);
                 tmp = father[tmp];
             }
         }
@@ -168,7 +168,7 @@ public class PropAtLeastNValues_AC extends Propagator<IntVar> {
         ISetIterator succs;
         while (indexFirst != indexLast) {
             x = fifo[indexFirst++];
-            succs = digraph.getSuccOf(x).iterator();
+            succs = digraph.getSuccessorsOf(x).iterator();
             while (succs.hasNext()) {
                 int y = succs.nextInt();
                 if (!in.get(y)) {
@@ -196,16 +196,16 @@ public class PropAtLeastNValues_AC extends Propagator<IntVar> {
         //TODO CHECK THIS PART
         for (int i = 0; i < n; i++) {
             if (free.get(i)) {
-                digraph.addArc(n2, i);
+                digraph.addEdge(n2, i);
             } else {
-                digraph.addArc(i, n2);
+                digraph.addEdge(i, n2);
             }
         }
         for (int i = n; i < n2; i++) {
             if (free.get(i)) {
-                digraph.addArc(i, n2 + 1);
+                digraph.addEdge(i, n2 + 1);
             } else {
-                digraph.addArc(n2 + 1, i);
+                digraph.addEdge(n2 + 1, i);
             }
         }
         SCCfinder.findAllSCC();
@@ -224,11 +224,11 @@ public class PropAtLeastNValues_AC extends Propagator<IntVar> {
             for (int k = v.getLB(); k <= ub; k = v.nextValue(k)) {
                 j = map.get(k);
                 if (nodeSCC[i] != nodeSCC[j]) {
-                    if (digraph.getPredOf(i).contains(j)) {
+                    if (digraph.getPredecessorsOf(i).contains(j)) {
                         v.instantiateTo(k, this);
                     } else {
                         v.removeValue(k, this);
-                        digraph.removeArc(i, j);
+                        digraph.removeEdge(i, j);
                     }
                 }
             }
@@ -236,7 +236,7 @@ public class PropAtLeastNValues_AC extends Propagator<IntVar> {
                 ub = v.getUB();
                 for (int k = v.getLB(); k <= ub; k = v.nextValue(k)) {
                     j = map.get(k);
-                    if (digraph.arcExists(i, j) || digraph.arcExists(j, i)) {
+                    if (digraph.containsEdge(i, j) || digraph.containsEdge(j, i)) {
                         break;
                     } else {
                         v.removeValue(k, this);
@@ -245,7 +245,7 @@ public class PropAtLeastNValues_AC extends Propagator<IntVar> {
                 int lb = v.getLB();
                 for (int k = ub; k >= lb; k = v.previousValue(k)) {
                     j = map.get(k);
-                    if (digraph.arcExists(i, j) || digraph.arcExists(j, i)) {
+                    if (digraph.containsEdge(i, j) || digraph.containsEdge(j, i)) {
                         break;
                     } else {
                         v.removeValue(k, this);
@@ -271,12 +271,12 @@ public class PropAtLeastNValues_AC extends Propagator<IntVar> {
         digraph.removeNode(n2 + 1);
         free.clear();
         for (int i = 0; i < n; i++) {
-            if (digraph.getPredOf(i).size() == 0) {
+            if (digraph.getPredecessorsOf(i).size() == 0) {
                 free.set(i);
             }
         }
         for (int i = n; i < n2; i++) {
-            if (digraph.getSuccOf(i).size() == 0) {
+            if (digraph.getSuccessorsOf(i).size() == 0) {
                 free.set(i);
             }
         }
@@ -329,8 +329,8 @@ public class PropAtLeastNValues_AC extends Propagator<IntVar> {
         private int idx;
 
         public void execute(int i) throws ContradictionException {
-            digraph.removeArc(idx, map.get(i));
-            digraph.removeArc(map.get(i), idx);
+            digraph.removeEdge(idx, map.get(i));
+            digraph.removeEdge(map.get(i), idx);
         }
 
         @Override

--- a/solver/src/main/java/org/chocosolver/solver/constraints/nary/nvalue/amnv/graph/Gi.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/nary/nvalue/amnv/graph/Gi.java
@@ -47,7 +47,7 @@ public class Gi extends G {
     public void build() {
         int n = getNbMaxNodes();
         for (int i = 0; i < n; i++) {
-            getNeighOf(i).clear();
+            getNeighborsOf(i).clear();
         }
         for (int i = 0; i < n; i++) {
             for (int i2 = i + 1; i2 < n; i2++) {
@@ -66,7 +66,7 @@ public class Gi extends G {
     }
 
     public void update(int i) {
-        ISetIterator nei = getNeighOf(i).iterator();
+        ISetIterator nei = getNeighborsOf(i).iterator();
         while (nei.hasNext()) {
             int j = nei.nextInt();
             if (!intersect(i, j)) {

--- a/solver/src/main/java/org/chocosolver/solver/constraints/nary/nvalue/amnv/mis/MD.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/nary/nvalue/amnv/mis/MD.java
@@ -60,7 +60,7 @@ public class MD implements F{
 		out.clear();
 		inMIS.clear();
 		for (int i = 0; i < n; i++) {
-			nbNeighbours[i] = graph.getNeighOf(i).size();
+			nbNeighbours[i] = graph.getNeighborsOf(i).size();
 		}
 		int idx = out.nextClearBit(0);
 		while (idx < n) {
@@ -78,7 +78,7 @@ public class MD implements F{
 		inMIS.set(node);
 		out.set(node);
 		int sizeFifo=0;
-		ISetIterator nei = graph.getNeighOf(node).iterator();
+		ISetIterator nei = graph.getNeighborsOf(node).iterator();
 		while (nei.hasNext()) {
 			int j = nei.nextInt();
 			if (!out.get(j)) {
@@ -87,7 +87,7 @@ public class MD implements F{
 			}
 		}
 		for (int i=0; i<sizeFifo; i++) {
-			nei = graph.getNeighOf(fifo[i]).iterator();
+			nei = graph.getNeighborsOf(fifo[i]).iterator();
 			while (nei.hasNext()) {
 				nbNeighbours[nei.nextInt()]--;
 			}

--- a/solver/src/main/java/org/chocosolver/solver/constraints/nary/nvalue/amnv/mis/MDRk.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/nary/nvalue/amnv/mis/MDRk.java
@@ -86,7 +86,7 @@ public class MDRk extends MD {
             }
             inMIS.set(idx);
             out.set(idx);
-            ISetIterator nei = graph.getNeighOf(idx).iterator();
+            ISetIterator nei = graph.getNeighborsOf(idx).iterator();
             while (nei.hasNext()){
                 out.set(nei.nextInt());
             }

--- a/solver/src/main/java/org/chocosolver/solver/constraints/nary/nvalue/amnv/mis/Rk.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/nary/nvalue/amnv/mis/Rk.java
@@ -87,7 +87,7 @@ public class Rk implements F {
             }
             inMIS.set(idx);
             out.set(idx);
-            ISetIterator nei = graph.getNeighOf(idx).iterator();
+            ISetIterator nei = graph.getNeighborsOf(idx).iterator();
             while (nei.hasNext()) {
                 out.set(nei.nextInt());
             }

--- a/solver/src/main/java/org/chocosolver/solver/constraints/nary/nvalue/amnv/rules/R3.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/nary/nvalue/amnv/rules/R3.java
@@ -71,7 +71,7 @@ public class R3 implements R {
                 for (int k = lb; k <= ub; k = vars[i].nextValue(k)) {
                     valToRem[last++] = k;
                 }
-                ISetIterator nei = graph.getNeighOf(i).iterator();
+                ISetIterator nei = graph.getNeighborsOf(i).iterator();
                 while (nei.hasNext()) {
                     int j = nei.nextInt();
                     if (mis.get(j)) {

--- a/solver/src/main/java/org/chocosolver/solver/constraints/nary/tree/PropAntiArborescences.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/nary/tree/PropAntiArborescences.java
@@ -85,16 +85,16 @@ public class PropAntiArborescences extends Propagator<IntVar> {
 
     private void structuralPruning() throws ContradictionException {
         for (int i = 0; i < n + 1; i++) {
-            connectedGraph.getSuccOf(i).clear();
-            connectedGraph.getPredOf(i).clear();
+            connectedGraph.getSuccessorsOf(i).clear();
+            connectedGraph.getPredecessorsOf(i).clear();
         }
         for (int i = 0; i < n; i++) {
             int ub = vars[i].getUB();
             for (int y = vars[i].getLB(); y <= ub; y = vars[i].nextValue(y)) {
                 if (i == y) { // can be a root node
-                    connectedGraph.addArc(i, n);
+                    connectedGraph.addEdge(i, n);
                 } else {
-                    connectedGraph.addArc(i, y - offSet);
+                    connectedGraph.addEdge(i, y - offSet);
                 }
             }
         }

--- a/solver/src/main/java/org/chocosolver/solver/search/strategy/Search.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/strategy/Search.java
@@ -156,7 +156,7 @@ public class Search {
 
     /**
      * Lexicographic graph branching strategy.
-     * Branch on nodes then arcs/edges.
+     * Branch on nodes then edges.
      * <br>
      * <br> node branching:
      * Let i be the first node such that
@@ -164,9 +164,9 @@ public class Search {
      * The decision adds i to the kernel of g.
      * It is fails, then i is removed from the envelope of g.
      * <br>
-     * arc/edge branching:
+     * edge branching:
      * <br> node branching:
-     * Let (i,j) be the first arc/edge such that
+     * Let (i,j) be the first edge such that
      * (i,j) in envelope(g) and (i,j) not in kernel(g).
      * The decision adds (i,j) to the kernel of g.
      * It is fails, then (i,j) is removed from the envelope of g

--- a/solver/src/main/java/org/chocosolver/solver/search/strategy/Search.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/strategy/Search.java
@@ -26,10 +26,7 @@ import org.chocosolver.solver.search.strategy.decision.IbexDecision;
 import org.chocosolver.solver.search.strategy.selectors.values.*;
 import org.chocosolver.solver.search.strategy.selectors.variables.*;
 import org.chocosolver.solver.search.strategy.strategy.*;
-import org.chocosolver.solver.variables.IntVar;
-import org.chocosolver.solver.variables.RealVar;
-import org.chocosolver.solver.variables.SetVar;
-import org.chocosolver.solver.variables.Variable;
+import org.chocosolver.solver.variables.*;
 import org.chocosolver.util.bandit.MOSS;
 import org.chocosolver.util.bandit.Static;
 import org.chocosolver.util.tools.VariableUtils;
@@ -151,6 +148,33 @@ public class Search {
      */
     public static SetStrategy setVarSearch(SetVar... sets) {
         return setVarSearch(new GeneralizedMinDomVarSelector(), new SetDomainMin(), true, sets);
+    }
+
+    // ************************************************************************************
+    // GRAPHVAR STRATEGIES
+    // ************************************************************************************
+
+    /**
+     * Lexicographic graph branching strategy.
+     * Branch on nodes then arcs/edges.
+     * <br>
+     * <br> node branching:
+     * Let i be the first node such that
+     * i in envelope(g) and i not in kernel(g).
+     * The decision adds i to the kernel of g.
+     * It is fails, then i is removed from the envelope of g.
+     * <br>
+     * arc/edge branching:
+     * <br> node branching:
+     * Let (i,j) be the first arc/edge such that
+     * (i,j) in envelope(g) and (i,j) not in kernel(g).
+     * The decision adds (i,j) to the kernel of g.
+     * It is fails, then (i,j) is removed from the envelope of g
+     *
+     * @param g a graph variable to branch on
+     */
+    public static GraphStrategy graphVarLexSearch(GraphVar g) {
+        return new GraphStrategy(g);
     }
 
     // ************************************************************************************
@@ -439,7 +463,7 @@ public class Search {
 
     /**
      * Creates a default search strategy for the given model. This heuristic is complete (handles
-     * IntVar, BoolVar, SetVar and RealVar)
+     * IntVar, BoolVar, SetVar, GraphVar, and RealVar)
      *
      * @param model a model requiring a default search strategy
      */
@@ -449,6 +473,7 @@ public class Search {
         // 1. retrieve variables, keeping the declaration order, and put them in four groups:
         List<IntVar> livars = new ArrayList<>(); // integer and boolean variables
         List<SetVar> lsvars = new ArrayList<>(); // set variables
+        List<GraphVar> lgvars = new ArrayList<>(); // graph variables
         List<RealVar> lrvars = new ArrayList<>();// real variables.
         Variable[] variables = model.getVars();
         Variable objective = null;
@@ -463,6 +488,9 @@ public class Search {
                         break;
                     case Variable.SET:
                         lsvars.add((SetVar) var);
+                        break;
+                    case Variable.GRAPH:
+                        lgvars.add((GraphVar) var);
                         break;
                     case Variable.REAL:
                         lrvars.add((RealVar) var);
@@ -493,6 +521,11 @@ public class Search {
         }
         if (lsvars.size() > 0) {
             strats.add(setVarSearch(lsvars.toArray(new SetVar[0])));
+        }
+        if (lgvars.size() > 0) {
+            for (GraphVar g : lgvars) {
+                strats.add(new GraphStrategy(g));
+            }
         }
         if (lrvars.size() > 0) {
             strats.add(realVarSearch(lrvars.toArray(new RealVar[0])));

--- a/solver/src/main/java/org/chocosolver/solver/search/strategy/assignments/GraphAssignment.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/strategy/assignments/GraphAssignment.java
@@ -58,7 +58,7 @@ public abstract class GraphAssignment implements Serializable {
 			if (from == -1 || to == -1) {
 				throw new UnsupportedOperationException();
 			}
-			var.enforceArc(from, to, cause);
+			var.enforceEdge(from, to, cause);
 		}
 
 		@Override
@@ -66,7 +66,7 @@ public abstract class GraphAssignment implements Serializable {
 			if (from == -1 || to == -1) {
 				throw new UnsupportedOperationException();
 			}
-			var.removeArc(from, to, cause);
+			var.removeEdge(from, to, cause);
 		}
 
 		@Override

--- a/solver/src/main/java/org/chocosolver/solver/search/strategy/assignments/GraphAssignment.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/strategy/assignments/GraphAssignment.java
@@ -1,0 +1,104 @@
+/*
+ * This file is part of choco-solver, http://choco-solver.org/
+ *
+ * Copyright (c) 2021, IMT Atlantique. All rights reserved.
+ *
+ * Licensed under the BSD 4-clause license.
+ *
+ * See LICENSE file in the project root for full license information.
+ */
+package org.chocosolver.solver.search.strategy.assignments;
+
+import org.chocosolver.solver.variables.GraphVar;
+import org.chocosolver.solver.ICause;
+import org.chocosolver.solver.exception.ContradictionException;
+
+import java.io.Serializable;
+
+/**
+ * <br/>
+ *
+ * @author Charles Prud'homme
+ * @since 03/02/11
+ */
+public abstract class GraphAssignment implements Serializable {
+
+	public abstract void apply(GraphVar var, int node, ICause cause) throws ContradictionException;
+
+	public abstract void unapply(GraphVar var, int node, ICause cause) throws ContradictionException;
+
+	public abstract void apply(GraphVar var, int from, int to, ICause cause) throws ContradictionException;
+
+	public abstract void unapply(GraphVar var, int from, int to, ICause cause) throws ContradictionException;
+
+	public abstract String toString();
+
+	public static GraphAssignment graph_enforcer = new GraphAssignment() {
+
+		@Override
+		public void apply(GraphVar var, int node, ICause cause) throws ContradictionException {
+			if (node < var.getNbMaxNodes()) {
+				var.enforceNode(node, cause);
+			} else {
+				throw new UnsupportedOperationException();
+			}
+		}
+
+		@Override
+		public void unapply(GraphVar var, int node, ICause cause) throws ContradictionException {
+			if (node < var.getNbMaxNodes()) {
+				var.removeNode(node, cause);
+			} else {
+				throw new UnsupportedOperationException();
+			}
+		}
+
+		@Override
+		public void apply(GraphVar var, int from, int to, ICause cause) throws ContradictionException {
+			if (from == -1 || to == -1) {
+				throw new UnsupportedOperationException();
+			}
+			var.enforceArc(from, to, cause);
+		}
+
+		@Override
+		public void unapply(GraphVar var, int from, int to, ICause cause) throws ContradictionException {
+			if (from == -1 || to == -1) {
+				throw new UnsupportedOperationException();
+			}
+			var.removeArc(from, to, cause);
+		}
+
+		@Override
+		public String toString() {
+			return " enforcing ";
+		}
+	};
+
+	public static GraphAssignment graph_remover = new GraphAssignment() {
+		@Override
+		public void apply(GraphVar var, int value, ICause cause) throws ContradictionException {
+			graph_enforcer.unapply(var, value, cause);
+		}
+
+		@Override
+		public void unapply(GraphVar var, int value, ICause cause) throws ContradictionException {
+			graph_enforcer.apply(var, value, cause);
+		}
+
+		@Override
+		public void apply(GraphVar var, int from, int to, ICause cause) throws ContradictionException {
+			graph_enforcer.unapply(var, from, to, cause);
+		}
+
+		@Override
+		public void unapply(GraphVar var, int from, int to, ICause cause) throws ContradictionException {
+			graph_enforcer.apply(var, from, to, cause);
+		}
+
+		@Override
+		public String toString() {
+			return " removal ";
+		}
+	};
+}

--- a/solver/src/main/java/org/chocosolver/solver/search/strategy/decision/GraphDecision.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/strategy/decision/GraphDecision.java
@@ -1,0 +1,92 @@
+/*
+ * This file is part of choco-solver, http://choco-solver.org/
+ *
+ * Copyright (c) 2021, IMT Atlantique. All rights reserved.
+ *
+ * Licensed under the BSD 4-clause license.
+ *
+ * See LICENSE file in the project root for full license information.
+ */
+package org.chocosolver.solver.search.strategy.decision;
+
+import org.chocosolver.solver.search.strategy.assignments.GraphAssignment;
+import org.chocosolver.solver.variables.GraphVar;
+import org.chocosolver.solver.exception.ContradictionException;
+import org.chocosolver.util.PoolManager;
+
+public class GraphDecision extends Decision<GraphVar> {
+
+	//***********************************************************************************
+	// VARIABLES
+	//***********************************************************************************
+
+	protected GraphAssignment assignment;
+	protected int from, to;
+	protected final PoolManager<GraphDecision> poolManager;
+
+	//***********************************************************************************
+	// CONSTRUCTORS
+	//***********************************************************************************
+
+	public GraphDecision(PoolManager<GraphDecision> poolManager) {
+		super(2);
+		this.poolManager = poolManager;
+	}
+
+	@Override
+	public Object getDecisionValue() {
+		if (to == -1) {
+			return from;
+		} else {
+			return new int[]{from, to};
+		}
+	}
+
+	public void setNode(GraphVar variable, int node, GraphAssignment graph_ass) {
+		super.set(variable);
+		this.from = node;
+		this.to = -1;
+		assignment = graph_ass;
+	}
+
+	public void setArc(GraphVar variable, int from, int to, GraphAssignment graph_ass) {
+		super.set(variable);
+		this.from = from;
+		this.to = to;
+		assignment = graph_ass;
+	}
+
+	//***********************************************************************************
+	// METHODS
+	//***********************************************************************************
+
+	@Override
+	public void apply() throws ContradictionException {
+		if (branch == 1) {
+			if (to == -1) {
+				assignment.apply(var, from, this);
+			} else {
+				assignment.apply(var, from, to, this);
+			}
+		} else if (branch == 2) {
+			if (to == -1) {
+				assignment.unapply(var, from, this);
+			} else {
+				assignment.unapply(var, from, to, this);
+			}
+		}
+	}
+
+	@Override
+	public void free() {
+		poolManager.returnE(this);
+	}
+
+	@Override
+	public String toString() {
+		if (to == -1) {
+			return " node " + from + assignment.toString();
+		}
+		return " arc (" + from + "," + to + ")" + assignment.toString();
+	}
+}

--- a/solver/src/main/java/org/chocosolver/solver/search/strategy/decision/GraphDecision.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/strategy/decision/GraphDecision.java
@@ -49,7 +49,7 @@ public class GraphDecision extends Decision<GraphVar> {
 		assignment = graph_ass;
 	}
 
-	public void setArc(GraphVar variable, int from, int to, GraphAssignment graph_ass) {
+	public void setEdge(GraphVar variable, int from, int to, GraphAssignment graph_ass) {
 		super.set(variable);
 		this.from = from;
 		this.to = to;
@@ -87,6 +87,6 @@ public class GraphDecision extends Decision<GraphVar> {
 		if (to == -1) {
 			return " node " + from + assignment.toString();
 		}
-		return " arc (" + from + "," + to + ")" + assignment.toString();
+		return " edge (" + from + "," + to + ")" + assignment.toString();
 	}
 }

--- a/solver/src/main/java/org/chocosolver/solver/search/strategy/selectors/values/GraphArcSelector.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/strategy/selectors/values/GraphArcSelector.java
@@ -1,0 +1,37 @@
+/*
+ * This file is part of choco-solver, http://choco-solver.org/
+ *
+ * Copyright (c) 2021, IMT Atlantique. All rights reserved.
+ *
+ * Licensed under the BSD 4-clause license.
+ *
+ * See LICENSE file in the project root for full license information.
+ */
+package org.chocosolver.solver.search.strategy.selectors.values;
+
+import org.chocosolver.solver.variables.GraphVar;
+import org.chocosolver.util.objects.setDataStructures.ISet;
+
+public abstract class GraphArcSelector<G extends GraphVar> {
+
+	protected G g;
+	protected ISet envNodes;
+
+	protected int from, to;
+
+
+	public GraphArcSelector(G g) {
+		this.g = g;
+		this.envNodes = g.getPotentialNodes();
+	}
+
+	public abstract boolean computeNextArc();
+
+	public int getFrom() {
+		return from;
+	}
+
+	public int getTo() {
+		return to;
+	}
+}

--- a/solver/src/main/java/org/chocosolver/solver/search/strategy/selectors/values/GraphEdgeSelector.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/strategy/selectors/values/GraphEdgeSelector.java
@@ -12,7 +12,7 @@ package org.chocosolver.solver.search.strategy.selectors.values;
 import org.chocosolver.solver.variables.GraphVar;
 import org.chocosolver.util.objects.setDataStructures.ISet;
 
-public abstract class GraphArcSelector<G extends GraphVar> {
+public abstract class GraphEdgeSelector<G extends GraphVar> {
 
 	protected G g;
 	protected ISet envNodes;
@@ -20,12 +20,12 @@ public abstract class GraphArcSelector<G extends GraphVar> {
 	protected int from, to;
 
 
-	public GraphArcSelector(G g) {
+	public GraphEdgeSelector(G g) {
 		this.g = g;
 		this.envNodes = g.getPotentialNodes();
 	}
 
-	public abstract boolean computeNextArc();
+	public abstract boolean computeNextEdge();
 
 	public int getFrom() {
 		return from;

--- a/solver/src/main/java/org/chocosolver/solver/search/strategy/selectors/values/GraphLexArc.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/strategy/selectors/values/GraphLexArc.java
@@ -1,0 +1,40 @@
+/*
+ * This file is part of choco-solver, http://choco-solver.org/
+ *
+ * Copyright (c) 2021, IMT Atlantique. All rights reserved.
+ *
+ * Licensed under the BSD 4-clause license.
+ *
+ * See LICENSE file in the project root for full license information.
+ */
+package org.chocosolver.solver.search.strategy.selectors.values;
+
+import org.chocosolver.solver.variables.GraphVar;
+import org.chocosolver.util.objects.setDataStructures.ISet;
+
+public class GraphLexArc extends GraphArcSelector<GraphVar> {
+
+	public GraphLexArc(GraphVar g) {
+		super(g);
+	}
+
+	@Override
+	public boolean computeNextArc() {
+		ISet envSuc, kerSuc;
+		for (int i : envNodes) {
+			envSuc = g.getPotSuccOrNeighOf(i);
+			kerSuc = g.getMandSuccOrNeighOf(i);
+			if (envSuc.size() != kerSuc.size()) {
+				for (int j : envSuc) {
+					if (!kerSuc.contains(j)) {
+						this.from = i;
+						this.to = j;
+						return true;
+					}
+				}
+			}
+		}
+		this.from = this.to = -1;
+		return false;
+	}
+}

--- a/solver/src/main/java/org/chocosolver/solver/search/strategy/selectors/values/GraphLexEdge.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/strategy/selectors/values/GraphLexEdge.java
@@ -12,18 +12,18 @@ package org.chocosolver.solver.search.strategy.selectors.values;
 import org.chocosolver.solver.variables.GraphVar;
 import org.chocosolver.util.objects.setDataStructures.ISet;
 
-public class GraphLexArc extends GraphArcSelector<GraphVar> {
+public class GraphLexEdge extends GraphEdgeSelector<GraphVar> {
 
-	public GraphLexArc(GraphVar g) {
+	public GraphLexEdge(GraphVar g) {
 		super(g);
 	}
 
 	@Override
-	public boolean computeNextArc() {
+	public boolean computeNextEdge() {
 		ISet envSuc, kerSuc;
 		for (int i : envNodes) {
-			envSuc = g.getPotSuccOrNeighOf(i);
-			kerSuc = g.getMandSuccOrNeighOf(i);
+			envSuc = g.getPotentialSuccessorsOf(i);
+			kerSuc = g.getMandatorySuccessorsOf(i);
 			if (envSuc.size() != kerSuc.size()) {
 				for (int j : envSuc) {
 					if (!kerSuc.contains(j)) {

--- a/solver/src/main/java/org/chocosolver/solver/search/strategy/selectors/values/GraphLexNode.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/strategy/selectors/values/GraphLexNode.java
@@ -1,0 +1,29 @@
+/*
+ * This file is part of choco-solver, http://choco-solver.org/
+ *
+ * Copyright (c) 2021, IMT Atlantique. All rights reserved.
+ *
+ * Licensed under the BSD 4-clause license.
+ *
+ * See LICENSE file in the project root for full license information.
+ */
+package org.chocosolver.solver.search.strategy.selectors.values;
+
+import org.chocosolver.solver.variables.GraphVar;
+
+public class GraphLexNode extends GraphNodeSelector<GraphVar> {
+
+	public GraphLexNode(GraphVar g) {
+		super(g);
+	}
+
+	@Override
+	public int nextNode() {
+		for (int i : envNodes) {
+			if (!kerNodes.contains(i)) {
+				return i;
+			}
+		}
+		return -1;
+	}
+}

--- a/solver/src/main/java/org/chocosolver/solver/search/strategy/selectors/values/GraphNodeSelector.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/strategy/selectors/values/GraphNodeSelector.java
@@ -1,0 +1,27 @@
+/*
+ * This file is part of choco-solver, http://choco-solver.org/
+ *
+ * Copyright (c) 2021, IMT Atlantique. All rights reserved.
+ *
+ * Licensed under the BSD 4-clause license.
+ *
+ * See LICENSE file in the project root for full license information.
+ */
+package org.chocosolver.solver.search.strategy.selectors.values;
+
+import org.chocosolver.solver.variables.GraphVar;
+import org.chocosolver.util.objects.setDataStructures.ISet;
+
+public abstract class GraphNodeSelector<G extends GraphVar> {
+
+	protected G g;
+	protected ISet envNodes, kerNodes;
+
+	public GraphNodeSelector(G g) {
+		this.g = g;
+		this.envNodes = g.getPotentialNodes();
+		this.kerNodes = g.getMandatoryNodes();
+	}
+
+	public abstract int nextNode();
+}

--- a/solver/src/main/java/org/chocosolver/solver/search/strategy/selectors/values/GraphRandomArc.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/strategy/selectors/values/GraphRandomArc.java
@@ -1,0 +1,57 @@
+/*
+ * This file is part of choco-solver, http://choco-solver.org/
+ *
+ * Copyright (c) 2021, IMT Atlantique. All rights reserved.
+ *
+ * Licensed under the BSD 4-clause license.
+ *
+ * See LICENSE file in the project root for full license information.
+ */
+package org.chocosolver.solver.search.strategy.selectors.values;
+
+import gnu.trove.list.array.TIntArrayList;
+import org.chocosolver.solver.variables.GraphVar;
+import org.chocosolver.util.objects.setDataStructures.ISet;
+
+import java.util.Random;
+
+public class GraphRandomArc extends GraphArcSelector<GraphVar> {
+
+	private Random rd;
+	private TIntArrayList pFrom, pTo;
+
+	public GraphRandomArc(GraphVar g, long seed) {
+		super(g);
+		rd = new Random(seed);
+		pFrom = new TIntArrayList();
+		pTo = new TIntArrayList();
+	}
+
+	@Override
+	public boolean computeNextArc() {
+		pFrom.clear();
+		pTo.clear();
+		ISet envSuc, kerSuc;
+		for (int i : envNodes) {
+			envSuc = g.getPotSuccOrNeighOf(i);
+			kerSuc = g.getMandSuccOrNeighOf(i);
+			if (envSuc.size() != kerSuc.size()) {
+				for (int j : envSuc) {
+					if (!kerSuc.contains(j)) {
+						pFrom.add(i);
+						pTo.add(j);
+					}
+				}
+			}
+		}
+		if (pFrom.isEmpty()) {
+			this.from = this.to = -1;
+			return false;
+		} else {
+			int idx = rd.nextInt(pFrom.size());
+			this.from = pFrom.get(idx);
+			this.to = pTo.get(idx);
+			return true;
+		}
+	}
+}

--- a/solver/src/main/java/org/chocosolver/solver/search/strategy/selectors/values/GraphRandomEdge.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/strategy/selectors/values/GraphRandomEdge.java
@@ -15,12 +15,12 @@ import org.chocosolver.util.objects.setDataStructures.ISet;
 
 import java.util.Random;
 
-public class GraphRandomArc extends GraphArcSelector<GraphVar> {
+public class GraphRandomEdge extends GraphEdgeSelector<GraphVar> {
 
 	private Random rd;
 	private TIntArrayList pFrom, pTo;
 
-	public GraphRandomArc(GraphVar g, long seed) {
+	public GraphRandomEdge(GraphVar g, long seed) {
 		super(g);
 		rd = new Random(seed);
 		pFrom = new TIntArrayList();
@@ -28,13 +28,13 @@ public class GraphRandomArc extends GraphArcSelector<GraphVar> {
 	}
 
 	@Override
-	public boolean computeNextArc() {
+	public boolean computeNextEdge() {
 		pFrom.clear();
 		pTo.clear();
 		ISet envSuc, kerSuc;
 		for (int i : envNodes) {
-			envSuc = g.getPotSuccOrNeighOf(i);
-			kerSuc = g.getMandSuccOrNeighOf(i);
+			envSuc = g.getPotentialSuccessorsOf(i);
+			kerSuc = g.getMandatorySuccessorsOf(i);
 			if (envSuc.size() != kerSuc.size()) {
 				for (int j : envSuc) {
 					if (!kerSuc.contains(j)) {

--- a/solver/src/main/java/org/chocosolver/solver/search/strategy/selectors/values/GraphRandomNode.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/strategy/selectors/values/GraphRandomNode.java
@@ -1,0 +1,43 @@
+/*
+ * This file is part of choco-solver, http://choco-solver.org/
+ *
+ * Copyright (c) 2021, IMT Atlantique. All rights reserved.
+ *
+ * Licensed under the BSD 4-clause license.
+ *
+ * See LICENSE file in the project root for full license information.
+ */
+package org.chocosolver.solver.search.strategy.selectors.values;
+
+import org.chocosolver.solver.variables.GraphVar;
+
+import java.util.Random;
+
+public class GraphRandomNode extends GraphNodeSelector<GraphVar> {
+
+	private Random rd;
+
+	public GraphRandomNode(GraphVar g, long seed) {
+		super(g);
+		this.rd = new Random(seed);
+
+	}
+
+	@Override
+	public int nextNode() {
+		int delta = envNodes.size() - kerNodes.size();
+		if (delta != 0) {
+			delta = rd.nextInt(delta);
+			for (int i : envNodes) {
+				if (!kerNodes.contains(i)) {
+					if (delta == 0) {
+						return i;
+					} else {
+						delta--;
+					}
+				}
+			}
+		}
+		return -1;
+	}
+}

--- a/solver/src/main/java/org/chocosolver/solver/search/strategy/strategy/GraphStrategy.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/strategy/strategy/GraphStrategy.java
@@ -1,0 +1,163 @@
+/*
+ * This file is part of choco-solver, http://choco-solver.org/
+ *
+ * Copyright (c) 2021, IMT Atlantique. All rights reserved.
+ *
+ * Licensed under the BSD 4-clause license.
+ *
+ * See LICENSE file in the project root for full license information.
+ */
+package org.chocosolver.solver.search.strategy.strategy;
+
+import org.chocosolver.solver.search.strategy.assignments.GraphAssignment;
+import org.chocosolver.solver.search.strategy.decision.GraphDecision;
+import org.chocosolver.solver.search.strategy.selectors.values.GraphLexArc;
+import org.chocosolver.solver.search.strategy.selectors.values.GraphRandomArc;
+import org.chocosolver.solver.search.strategy.selectors.values.GraphLexNode;
+import org.chocosolver.solver.search.strategy.selectors.values.GraphRandomNode;
+import org.chocosolver.solver.search.strategy.selectors.values.GraphArcSelector;
+import org.chocosolver.solver.search.strategy.selectors.values.GraphNodeSelector;
+import org.chocosolver.solver.variables.GraphVar;
+import org.chocosolver.util.PoolManager;
+
+/**
+ * <br/>
+ *
+ * @author Jean-Guillaume Fages
+ * @since 1 April 2011
+ */
+public class GraphStrategy extends AbstractStrategy<GraphVar> {
+
+	//***********************************************************************************
+	// VARIABLES
+	//***********************************************************************************
+
+	protected GraphVar g;
+	protected GraphNodeSelector nodeStrategy;
+	protected GraphArcSelector arcStrategy;
+	protected NodeArcPriority priority;
+	protected PoolManager<GraphDecision> pool;
+
+	public enum NodeArcPriority {
+		NODES_THEN_ARCS,
+		ARCS
+	}
+
+	//***********************************************************************************
+	// CONSTRUCTORS
+	//***********************************************************************************
+
+	/**
+	 * Dedicated graph branching strategy.
+	 *
+	 * @param g        a graph variable to branch on
+	 * @param ns       strategy over nodes
+	 * @param as       strategy over arcs/edges
+	 * @param priority enables to mention if it should first branch on nodes
+	 */
+	public GraphStrategy(GraphVar g, GraphNodeSelector ns, GraphArcSelector as, NodeArcPriority priority) {
+		super(g);
+		this.g = g;
+		this.nodeStrategy = ns;
+		this.arcStrategy = as;
+		this.priority = priority;
+		pool = new PoolManager<>();
+	}
+
+	/**
+	 * Lexicographic graph branching strategy.
+	 * Branch on nodes then arcs/edges.
+	 * <br>
+	 * <br> node branching:
+	 * Let i be the first node such that
+	 * i in envelope(g) and i not in kernel(g).
+	 * The decision adds i to the kernel of g.
+	 * It is fails, then i is removed from the envelope of g.
+	 * <br>
+	 * arc/edge branching:
+	 * <br> node branching:
+	 * Let (i,j) be the first arc/edge such that
+	 * (i,j) in envelope(g) and (i,j) not in kernel(g).
+	 * The decision adds (i,j) to the kernel of g.
+	 * It is fails, then (i,j) is removed from the envelope of g
+	 *
+	 * @param g a graph variable to branch on
+	 */
+	public GraphStrategy(GraphVar g) {
+		this(g, new GraphLexNode(g), new GraphLexArc(g), NodeArcPriority.NODES_THEN_ARCS);
+	}
+
+	/**
+	 * Random graph branching strategy.
+	 * Alternate randomly node and arc/edge decisions.
+	 * <br>
+	 * <br> node branching:
+	 * Let i be a randomly selected node such that
+	 * i in envelope(g) and i not in kernel(g).
+	 * The decision adds i to the kernel of g.
+	 * It is fails, then i is removed from the envelope of g.
+	 * <br>
+	 * arc/edge branching:
+	 * <br> node branching:
+	 * Let (i,j) be a randomly selected arc/edge arc/edge such that
+	 * (i,j) in envelope(g) and (i,j) not in kernel(g).
+	 * The decision adds (i,j) to the kernel of g.
+	 * It is fails, then (i,j) is removed from the envelope of g
+	 *
+	 * @param g    a graph variable to branch on
+	 * @param seed randomness seed
+	 */
+	public GraphStrategy(GraphVar g, long seed) {
+		this(g, new GraphRandomNode(g, seed), new GraphRandomArc(g, seed), NodeArcPriority.NODES_THEN_ARCS);
+	}
+
+	//***********************************************************************************
+	// METHODS
+	//***********************************************************************************
+
+	@Override
+	public boolean init() {
+		return true;
+	}
+
+	@Override
+	public GraphDecision getDecision() {
+		if (g.isInstantiated()) {
+			return null;
+		}
+		GraphDecision dec = pool.getE();
+		if (dec == null) {
+			dec = new GraphDecision(pool);
+		}
+		switch (priority) {
+			case NODES_THEN_ARCS:
+				int node = nextNode();
+				if (node != -1) {
+					dec.setNode(g, node, GraphAssignment.graph_enforcer);
+				} else {
+					if (arcStrategy == null) {
+						return null;
+					}
+					nextArc();
+					dec.setArc(g, arcStrategy.getFrom(), arcStrategy.getTo(), GraphAssignment.graph_enforcer);
+				}
+				break;
+			case ARCS:
+			default:
+				if (!nextArc()) {
+					return null;
+				}
+				dec.setArc(g, arcStrategy.getFrom(), arcStrategy.getTo(), GraphAssignment.graph_enforcer);
+				break;
+		}
+		return dec;
+	}
+
+	public int nextNode() {
+		return nodeStrategy.nextNode();
+	}
+
+	public boolean nextArc() {
+		return arcStrategy.computeNextArc();
+	}
+}

--- a/solver/src/main/java/org/chocosolver/solver/variables/DirectedGraphVar.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/DirectedGraphVar.java
@@ -10,56 +10,11 @@
 package org.chocosolver.solver.variables;
 
 import org.chocosolver.util.objects.graphs.DirectedGraph;
-import org.chocosolver.util.objects.setDataStructures.ISet;
 
 /**
  * Interface defining a directed graph variable
  */
 public interface DirectedGraphVar<E extends DirectedGraph> extends GraphVar<E> {
-
-    /**
-     * Get the set of successors of vertex 'idx' in the lower bound graph
-     * (mandatory outgoing arcs)
-     *
-     * @param idx a vertex
-     * @return The set of successors of 'idx' in LB
-     */
-    default ISet getMandSuccOf(int idx) {
-        return getMandSuccOrNeighOf(idx);
-    }
-
-    /**
-     * Get the set of predecessors of vertex 'idx' in the lower bound graph
-     * (mandatory ingoing arcs)
-     *
-     * @param idx a vertex
-     * @return The set of predecessors of 'idx' in LB
-     */
-    default ISet getMandPredOf(int idx) {
-        return getMandPredOrNeighOf(idx);
-    }
-
-    /**
-     * Get the set of predecessors of vertex 'idx'
-     * in the upper bound graph (potential ingoing arcs)
-     *
-     * @param idx a vertex
-     * @return The set of predecessors of 'idx' in UB
-     */
-    default ISet getPotPredOf(int idx) {
-        return getPotPredOrNeighOf(idx);
-    }
-
-    /**
-     * Get the set of successors of vertex 'idx'
-     * in the upper bound graph (potential outgoing arcs)
-     *
-     * @param idx a vertex
-     * @return The set of successors of 'idx' in UB
-     */
-    default ISet getPotSuccOf(int idx) {
-        return getPotSuccOrNeighOf(idx);
-    }
 
     /**
      * Retrieves the current value of the variable if instantiated, otherwise the lower bound (kernel).

--- a/solver/src/main/java/org/chocosolver/solver/variables/DirectedGraphVar.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/DirectedGraphVar.java
@@ -61,6 +61,16 @@ public interface DirectedGraphVar<E extends DirectedGraph> extends GraphVar<E> {
         return getPotSuccOrNeighOf(idx);
     }
 
+    /**
+     * Retrieves the current value of the variable if instantiated, otherwise the lower bound (kernel).
+     *
+     * @return the current value (or kernel if not yet instantiated).
+     */
+    default E getValue(){
+        assert isInstantiated() : getName() + " not instantiated";
+        return getLB();
+    }
+
     @Override
     default boolean isDirected() {
         return true;

--- a/solver/src/main/java/org/chocosolver/solver/variables/DirectedGraphVar.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/DirectedGraphVar.java
@@ -1,0 +1,68 @@
+/*
+ * This file is part of choco-solver, http://choco-solver.org/
+ *
+ * Copyright (c) 2021, IMT Atlantique. All rights reserved.
+ *
+ * Licensed under the BSD 4-clause license.
+ *
+ * See LICENSE file in the project root for full license information.
+ */
+package org.chocosolver.solver.variables;
+
+import org.chocosolver.util.objects.graphs.DirectedGraph;
+import org.chocosolver.util.objects.setDataStructures.ISet;
+
+/**
+ * Interface defining a directed graph variable
+ */
+public interface DirectedGraphVar<E extends DirectedGraph> extends GraphVar<E> {
+
+    /**
+     * Get the set of successors of vertex 'idx' in the lower bound graph
+     * (mandatory outgoing arcs)
+     *
+     * @param idx a vertex
+     * @return The set of successors of 'idx' in LB
+     */
+    default ISet getMandSuccOf(int idx) {
+        return getMandSuccOrNeighOf(idx);
+    }
+
+    /**
+     * Get the set of predecessors of vertex 'idx' in the lower bound graph
+     * (mandatory ingoing arcs)
+     *
+     * @param idx a vertex
+     * @return The set of predecessors of 'idx' in LB
+     */
+    default ISet getMandPredOf(int idx) {
+        return getMandPredOrNeighOf(idx);
+    }
+
+    /**
+     * Get the set of predecessors of vertex 'idx'
+     * in the upper bound graph (potential ingoing arcs)
+     *
+     * @param idx a vertex
+     * @return The set of predecessors of 'idx' in UB
+     */
+    default ISet getPotPredOf(int idx) {
+        return getPotPredOrNeighOf(idx);
+    }
+
+    /**
+     * Get the set of successors of vertex 'idx'
+     * in the upper bound graph (potential outgoing arcs)
+     *
+     * @param idx a vertex
+     * @return The set of successors of 'idx' in UB
+     */
+    default ISet getPotSuccOf(int idx) {
+        return getPotSuccOrNeighOf(idx);
+    }
+
+    @Override
+    default boolean isDirected() {
+        return true;
+    }
+}

--- a/solver/src/main/java/org/chocosolver/solver/variables/GraphVar.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/GraphVar.java
@@ -1,0 +1,190 @@
+/*
+ * This file is part of choco-solver, http://choco-solver.org/
+ *
+ * Copyright (c) 2021, IMT Atlantique. All rights reserved.
+ *
+ * Licensed under the BSD 4-clause license.
+ *
+ * See LICENSE file in the project root for full license information.
+ */
+package org.chocosolver.solver.variables;
+
+import org.chocosolver.solver.ICause;
+import org.chocosolver.solver.exception.ContradictionException;
+import org.chocosolver.solver.variables.delta.GraphDelta;
+import org.chocosolver.solver.variables.delta.monitor.GraphDeltaMonitor;
+import org.chocosolver.util.objects.graphs.IGraph;
+import org.chocosolver.util.objects.setDataStructures.ISet;
+
+/**
+ * A Graph Variable is defined by a domain which is a graph interval [GLB, GUB].
+ * An instantiation of a graph variable is a graph composed of vertices (or nodes) and arcs (or edges, or links).
+ * GLB is the kernel graph (or lower bound), that must be a subgraph of any instantiation.
+ * GUB is the envelope graph (or upper bound), such that any instantiation is a subgraph of it.
+ */
+public interface GraphVar extends Variable{
+
+    /**
+     * Get GraphVar lower bound (or kernel): the graph which is a subgraph of any instantiation.
+     * @return The lower bound (or kernel) graph of this GraphVar.
+     */
+    IGraph getLB();
+
+    /**
+     * Get GraphVar upper bound (or envelope): any instantiation of this GraphVar is a subgraph of the upper bound.
+     * @return The upper bound (or envelope) graph of this GraphVar.
+     */
+    IGraph getUB();
+
+    /**
+     * Get the SetVar representing the nodes of the GraphVar.
+     * @return A SetVar representing the nodes of the GraphVar?
+     */
+    SetVar getNodesSetVar();
+
+    /**
+     * Adds a node to the lower bound graph
+     *
+     * @param node node's index
+     * @param cause cause of node addition
+     * @return true iff the node has been added to the lower bound
+     */
+    boolean enforceNode(int node, ICause cause) throws ContradictionException;
+
+    /**
+     * Removes a node from the upper bound graph
+     *
+     * @param node node's index
+     * @param cause cause of node removal
+     * @return true iff the node has been removed from the upper bound
+     */
+    boolean removeNode(int node, ICause cause) throws ContradictionException;
+
+    /**
+     * Adds arc (or edge in case of undirected graph variable) (x,y) in the lower bound
+     *
+     * @param x     node's index
+     * @param y     node's index
+     * @param cause cause of arc addition
+     * @return true iff the arc has been add to the lower bound
+     * @throws ContradictionException
+     */
+    boolean enforceArc(int x, int y, ICause cause) throws ContradictionException;
+
+    /**
+     * Removes arc (or edge in case of undirected graph variable) (x,y) from the upper bound
+     *
+     * @param x node's index
+     * @param y node's index
+     * @param cause cause of arc removal
+     * @return true iff the arc has been removed from the upper bound
+     * @throws ContradictionException if the arc was mandatory
+     */
+    boolean removeArc(int x, int y, ICause cause) throws ContradictionException;
+
+    /**
+     * Get the set of successors (if directed) or neighbors (if undirected) of vertex 'node'
+     * in the lower bound graph (mandatory outgoing arcs)
+     *
+     * @param node a vertex
+     * @return The set of successors (if directed) or neighbors (if undirected) of 'node' in LB
+     */
+    default ISet getMandSuccOrNeighOf(int node) {
+        return getLB().getSuccOrNeighOf(node);
+    }
+
+    /**
+     * Get the set of successors (if directed) or neighbors (if undirected) of vertex 'node'
+     * in the upper bound graph (potential outgoing arcs)
+     *
+     * @param node a vertex
+     * @return The set of successors (if directed) or neighbors (if undirected) of 'node' in UB
+     */
+    default ISet getPotSuccOrNeighOf(int node) {
+        return getUB().getSuccOrNeighOf(node);
+    }
+
+    /**
+     * Get the set of predecessors (if directed) or neighbors (if undirected) of vertex 'node'
+     * in the lower bound graph (mandatory ingoing arcs)
+     *
+     * @param node a vertex
+     * @return The set of predecessors (if directed) or neighbors (if undirected) of 'node' in LB
+     */
+    default ISet getMandPredOrNeighOf(int node) {
+        return getLB().getPredOrNeighOf(node);
+    }
+
+    /**
+     * Get the set of predecessors (if directed) or neighbors (if undirected) of vertex 'node'
+     * in the upper bound graph (potential ingoing arcs)
+     *
+     * @param node a vertex
+     * @return The set of predecessors (if directed) or neighbors (if undirected) of 'node' in UB
+     */
+    default ISet getPotPredOrNeighOf(int node) {
+        return getUB().getPredOrNeighOf(node);
+    }
+
+    /**
+     * @return the maximum number of node the graph variable may have.
+     * Nodes are comprised in the interval [0,getNbMaxNodes()]
+     * Therefore, any vertex index should be strictly lower than getNbMaxNodes()
+     */
+    int getNbMaxNodes();
+
+    /**
+     * @return the node set of the lower bound graph,
+     * i.e. nodes that belong to every solution
+     */
+    default ISet getMandatoryNodes() {
+        return getLB().getNodes();
+    }
+
+    /**
+     * @return the node set of the upper bound graph,
+     * i.e. nodes that may belong to one solution
+     */
+    default ISet getPotentialNodes() {
+        return getUB().getNodes();
+    }
+
+    /**
+     * @return true iff the graph is directed. It is undirected otherwise.
+     */
+    boolean isDirected();
+
+    /**
+     * Instantiates <code>this</code> to value given in parameter.
+     * This method is not supposed to be used except for restoring solutions.
+     *
+     * @param value value of <code>this</code>
+     * @param cause
+     * @throws ContradictionException
+     */
+    void instantiateTo(IGraph value, ICause cause) throws ContradictionException;
+
+    /**
+     * Retrieves the current value of the variable if instantiated, otherwise the lower bound (kernel).
+     *
+     * @return the current value (or kernel if not yet instantiated).
+     */
+    default IGraph getValue(){
+        assert isInstantiated() : getName() + " not instantiated";
+        return getLB();
+    }
+
+    @Override
+    GraphDelta getDelta();
+
+    /**
+     * Make the propagator 'prop' have an incremental filtering w.r.t. this graph variable
+     *
+     * @param propagator A propagator involving this graph variable
+     * @return A new instance of GraphDeltaMonitor to make incremental propagators
+     */
+    default GraphDeltaMonitor monitorDelta(ICause propagator) {
+        createDelta();
+        return new GraphDeltaMonitor(getDelta(), propagator);
+    }
+}

--- a/solver/src/main/java/org/chocosolver/solver/variables/GraphVar.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/GraphVar.java
@@ -22,19 +22,19 @@ import org.chocosolver.util.objects.setDataStructures.ISet;
  * GLB is the kernel graph (or lower bound), that must be a subgraph of any instantiation.
  * GUB is the envelope graph (or upper bound), such that any instantiation is a subgraph of it.
  */
-public interface GraphVar extends Variable{
+public interface GraphVar<E extends IGraph> extends Variable {
 
     /**
      * Get GraphVar lower bound (or kernel): the graph which is a subgraph of any instantiation.
      * @return The lower bound (or kernel) graph of this GraphVar.
      */
-    IGraph getLB();
+    E getLB();
 
     /**
      * Get GraphVar upper bound (or envelope): any instantiation of this GraphVar is a subgraph of the upper bound.
      * @return The upper bound (or envelope) graph of this GraphVar.
      */
-    IGraph getUB();
+    E getUB();
 
     /**
      * Get the SetVar representing the nodes of the GraphVar.
@@ -162,14 +162,14 @@ public interface GraphVar extends Variable{
      * @param cause
      * @throws ContradictionException
      */
-    void instantiateTo(IGraph value, ICause cause) throws ContradictionException;
+    void instantiateTo(E value, ICause cause) throws ContradictionException;
 
     /**
      * Retrieves the current value of the variable if instantiated, otherwise the lower bound (kernel).
      *
      * @return the current value (or kernel if not yet instantiated).
      */
-    default IGraph getValue(){
+    default E getValue(){
         assert isInstantiated() : getName() + " not instantiated";
         return getLB();
     }

--- a/solver/src/main/java/org/chocosolver/solver/variables/GraphVar.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/GraphVar.java
@@ -164,10 +164,7 @@ public interface GraphVar<E extends IGraph> extends Variable {
      *
      * @return the current value (or kernel if not yet instantiated).
      */
-    default E getValue(){
-        assert isInstantiated() : getName() + " not instantiated";
-        return getLB();
-    }
+    E getValue();
 
     @Override
     GraphDelta getDelta();

--- a/solver/src/main/java/org/chocosolver/solver/variables/GraphVar.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/GraphVar.java
@@ -12,6 +12,7 @@ package org.chocosolver.solver.variables;
 import org.chocosolver.solver.ICause;
 import org.chocosolver.solver.exception.ContradictionException;
 import org.chocosolver.solver.variables.delta.GraphDelta;
+import org.chocosolver.solver.variables.delta.IGraphDeltaMonitor;
 import org.chocosolver.solver.variables.delta.monitor.GraphDeltaMonitor;
 import org.chocosolver.util.objects.graphs.IGraph;
 import org.chocosolver.util.objects.setDataStructures.ISet;
@@ -177,7 +178,7 @@ public interface GraphVar<E extends IGraph> extends Variable {
      * @param propagator A propagator involving this graph variable
      * @return A new instance of GraphDeltaMonitor to make incremental propagators
      */
-    default GraphDeltaMonitor monitorDelta(ICause propagator) {
+    default IGraphDeltaMonitor monitorDelta(ICause propagator) {
         createDelta();
         return new GraphDeltaMonitor(getDelta(), propagator);
     }

--- a/solver/src/main/java/org/chocosolver/solver/variables/GraphVar.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/GraphVar.java
@@ -37,7 +37,7 @@ import org.chocosolver.util.objects.setDataStructures.ISet;
  *      `getPotentialNeighborsOf` are available. Note that an undirected graph is equivalent to a directed graph
  *      with couples of opposite directed edges. Thus, the neighbors of a node in an undirected graph are both
  *      successors and predecessors, and this is why these methods are equivalent to `getMandatoryNeighbors` and
- *      `getPotentialSuccessorsOf` in the case of an undirected graph. To encourage unambiguous use and facilitate
+ *      `getPotentialNeighborssOf` in the case of an undirected graph. To encourage unambiguous use and facilitate
  *      code reading, the successors and predecessors related method have been defined as deprecated in explicit uses
  *      of UndirectedGraphs.
  *

--- a/solver/src/main/java/org/chocosolver/solver/variables/GraphVar.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/GraphVar.java
@@ -19,7 +19,7 @@ import org.chocosolver.util.objects.setDataStructures.ISet;
 
 /**
  * A Graph Variable is defined by a domain which is a graph interval [GLB, GUB].
- * An instantiation of a graph variable is a graph composed of vertices (or nodes) and arcs (or edges, or links).
+ * An instantiation of a graph variable is a graph composed of nodes and edges (directed or not).
  * GLB is the kernel graph (or lower bound), that must be a subgraph of any instantiation.
  * GUB is the envelope graph (or upper bound), such that any instantiation is a subgraph of it.
  */
@@ -56,69 +56,69 @@ public interface GraphVar<E extends IGraph> extends Variable {
     boolean removeNode(int node, ICause cause) throws ContradictionException;
 
     /**
-     * Adds arc (or edge in case of undirected graph variable) (x,y) in the lower bound
+     * Adds edge (directed directed graph variable) (x,y) in the lower bound
      *
      * @param x     node's index
      * @param y     node's index
-     * @param cause cause of arc addition
-     * @return true iff the arc has been add to the lower bound
+     * @param cause cause of edge addition
+     * @return true iff the edge has been add to the lower bound
      * @throws ContradictionException
      */
-    boolean enforceArc(int x, int y, ICause cause) throws ContradictionException;
+    boolean enforceEdge(int x, int y, ICause cause) throws ContradictionException;
 
     /**
-     * Removes arc (or edge in case of undirected graph variable) (x,y) from the upper bound
+     * Removes edge (directed in case of directed graph variable) (x,y) from the upper bound
      *
      * @param x node's index
      * @param y node's index
-     * @param cause cause of arc removal
-     * @return true iff the arc has been removed from the upper bound
-     * @throws ContradictionException if the arc was mandatory
+     * @param cause cause of edge removal
+     * @return true iff the edge has been removed from the upper bound
+     * @throws ContradictionException if the edge was mandatory
      */
-    boolean removeArc(int x, int y, ICause cause) throws ContradictionException;
+    boolean removeEdge(int x, int y, ICause cause) throws ContradictionException;
 
     /**
      * Get the set of successors (if directed) or neighbors (if undirected) of vertex 'node'
-     * in the lower bound graph (mandatory outgoing arcs)
+     * in the lower bound graph (mandatory outgoing edges)
      *
      * @param node a vertex
      * @return The set of successors (if directed) or neighbors (if undirected) of 'node' in LB
      */
-    default ISet getMandSuccOrNeighOf(int node) {
-        return getLB().getSuccOrNeighOf(node);
+    default ISet getMandatorySuccessorsOf(int node) {
+        return getLB().getSuccessorsOf(node);
     }
 
     /**
      * Get the set of successors (if directed) or neighbors (if undirected) of vertex 'node'
-     * in the upper bound graph (potential outgoing arcs)
+     * in the upper bound graph (potential outgoing edges)
      *
      * @param node a vertex
      * @return The set of successors (if directed) or neighbors (if undirected) of 'node' in UB
      */
-    default ISet getPotSuccOrNeighOf(int node) {
-        return getUB().getSuccOrNeighOf(node);
+    default ISet getPotentialSuccessorsOf(int node) {
+        return getUB().getSuccessorsOf(node);
     }
 
     /**
      * Get the set of predecessors (if directed) or neighbors (if undirected) of vertex 'node'
-     * in the lower bound graph (mandatory ingoing arcs)
+     * in the lower bound graph (mandatory ingoing edges)
      *
      * @param node a vertex
      * @return The set of predecessors (if directed) or neighbors (if undirected) of 'node' in LB
      */
-    default ISet getMandPredOrNeighOf(int node) {
-        return getLB().getPredOrNeighOf(node);
+    default ISet getMandatoryPredecessorsOf(int node) {
+        return getLB().getPredecessorsOf(node);
     }
 
     /**
      * Get the set of predecessors (if directed) or neighbors (if undirected) of vertex 'node'
-     * in the upper bound graph (potential ingoing arcs)
+     * in the upper bound graph (potential ingoing edges)
      *
      * @param node a vertex
      * @return The set of predecessors (if directed) or neighbors (if undirected) of 'node' in UB
      */
-    default ISet getPotPredOrNeighOf(int node) {
-        return getUB().getPredOrNeighOf(node);
+    default ISet getPotentialPredecessorOf(int node) {
+        return getUB().getPredecessorsOf(node);
     }
 
     /**

--- a/solver/src/main/java/org/chocosolver/solver/variables/GraphVar.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/GraphVar.java
@@ -22,6 +22,29 @@ import org.chocosolver.util.objects.setDataStructures.ISet;
  * An instantiation of a graph variable is a graph composed of nodes and edges (directed or not).
  * GLB is the kernel graph (or lower bound), that must be a subgraph of any instantiation.
  * GUB is the envelope graph (or upper bound), such that any instantiation is a subgraph of it.
+ *
+ * --- GRAPH API REFACTORING 04/03/2021 ---
+ *
+ * In accordance with IGraph:
+ *
+ * - The semantic distinction between arcs and edges has been removed for more clarity. If the graph is undirected,
+ *      edges are undirected, if the graph is directed, the graph is directed. Methods related to edges are
+ *      `enforceEdge` and `removeEdge`.
+ *
+ * - The object model is such that the more abstract interface specifies directed graph variable accessors on edges,
+ *      `getMandatorySuccessorsOf`, `getPotentialSuccessorsOf`, `getMandatoryPredecessorsOf`, and
+ *      `getPotentialPredecessorsOf`. When the graph is undirected, the methods `getMandatoryNeighborsOf` and
+ *      `getPotentialNeighborsOf` are available. Note that an undirected graph is equivalent to a directed graph
+ *      with couples of opposite directed edges. Thus, the neighbors of a node in an undirected graph are both
+ *      successors and predecessors, and this is why these methods are equivalent to `getMandatoryNeighbors` and
+ *      `getPotentialSuccessorsOf` in the case of an undirected graph. To encourage unambiguous use and facilitate
+ *      code reading, the successors and predecessors related method have been defined as deprecated in explicit uses
+ *      of UndirectedGraphs.
+ *
+ *  - The possibility to chose (in constructors) and get the set data structure for nodes has also been added,
+ *      as it was only implemented for neighbors: `getNodeSetType` and `getEdgeSetType`. The previous default behaviour
+ *      has been conserved with default constructors.
+ *
  */
 public interface GraphVar<E extends IGraph> extends Variable {
 

--- a/solver/src/main/java/org/chocosolver/solver/variables/GraphVar.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/GraphVar.java
@@ -37,12 +37,6 @@ public interface GraphVar<E extends IGraph> extends Variable {
     E getUB();
 
     /**
-     * Get the SetVar representing the nodes of the GraphVar.
-     * @return A SetVar representing the nodes of the GraphVar?
-     */
-    SetVar getNodesSetVar();
-
-    /**
      * Adds a node to the lower bound graph
      *
      * @param node node's index

--- a/solver/src/main/java/org/chocosolver/solver/variables/GraphVar.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/GraphVar.java
@@ -18,10 +18,10 @@ import org.chocosolver.util.objects.graphs.IGraph;
 import org.chocosolver.util.objects.setDataStructures.ISet;
 
 /**
- * A Graph Variable is defined by a domain which is a graph interval [GLB, GUB].
+ * A Graph Variable is defined by a domain which is a graph interval [LB, UB].
  * An instantiation of a graph variable is a graph composed of nodes and edges (directed or not).
- * GLB is the kernel graph (or lower bound), that must be a subgraph of any instantiation.
- * GUB is the envelope graph (or upper bound), such that any instantiation is a subgraph of it.
+ * LB is the kernel graph (or lower bound), that must be a subgraph of any instantiation.
+ * UB is the envelope graph (or upper bound), such that any instantiation is a subgraph of it.
  *
  * --- GRAPH API REFACTORING 04/03/2021 ---
  *

--- a/solver/src/main/java/org/chocosolver/solver/variables/IVariableFactory.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/IVariableFactory.java
@@ -14,6 +14,8 @@ import org.chocosolver.solver.Model;
 import org.chocosolver.solver.Settings;
 import org.chocosolver.solver.exception.SolverException;
 import org.chocosolver.solver.variables.impl.*;
+import org.chocosolver.util.objects.graphs.DirectedGraph;
+import org.chocosolver.util.objects.graphs.UndirectedGraph;
 import org.chocosolver.util.objects.setDataStructures.SetType;
 import org.chocosolver.util.tools.ArrayUtils;
 import org.chocosolver.util.tools.VariableUtils;
@@ -819,6 +821,37 @@ public interface IVariableFactory extends ISelf<Model> {
         return vars;
     }
 
+    //*************************************************************************************
+    // GRAPH VARIABLES
+    //*************************************************************************************
+
+    /**
+     * Creates an undirected graph variable, taking its values in the graph domain [LB, UB].
+     * An instantiation of a graph variable is a graph composed of nodes and edges.
+     * LB is the kernel graph (or lower bound), that must be a subgraph of any instantiation.
+     * UB is the envelope graph (or upper bound), such that any instantiation is a subgraph of it.
+     * @param name Name of the variable
+     * @param LB The lower bound graph (or kernel)
+     * @param UB The upper bound graph (or envelope)
+     * @return An undirected graph variable taking its values in the graph domain [LB, UB].
+     */
+    default UndirectedGraphVar undirectedGraphVar(String name, UndirectedGraph LB, UndirectedGraph UB) {
+        return new UndirectedGraphVarImpl(name, ref(), LB, UB);
+    }
+
+    /**
+     * Creates a directed graph variable, taking its values in the graph domain [LB, UB].
+     * An instantiation of a graph variable is a graph composed of nodes and edges.
+     * LB is the kernel graph (or lower bound), that must be a subgraph of any instantiation.
+     * UB is the envelope graph (or upper bound), such that any instantiation is a subgraph of it.
+     * @param name Name of the variable
+     * @param LB The lower bound graph (or kernel)
+     * @param UB The upper bound graph (or envelope)
+     * @return A directed graph variable taking its values in the graph domain [LB, UB].
+     */
+    default DirectedGraphVar directedGraphVar(String name, DirectedGraph LB, DirectedGraph UB) {
+        return new DirectedGraphVarImpl(name, ref(), LB, UB);
+    }
 
     //*************************************************************************************
     // UTILS

--- a/solver/src/main/java/org/chocosolver/solver/variables/IViewFactory.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/IViewFactory.java
@@ -451,7 +451,45 @@ public interface IViewFactory extends ISelf<Model> {
     }
 
     //*************************************************************************************
-    // SET VARIABLES
+    // SET VARIABLES OVER GRAPH VARIABLES
     //*************************************************************************************
 
+    /**
+     * Creates a set view over the set of nodes of a graph variable.
+     * @param g observed graph variable
+     * @return a set view over the set of nodes of a graph variable
+     */
+    default SetVar graphNodeSetView(GraphVar g) {
+        return new GraphNodeSetView(g);
+    }
+
+    /**
+     * Creates a set view over the set of successors of a node of a directed graph variable.
+     * @param g observed graph variable
+     * @param node observed node
+     * @return a set view over the set of successors of a node of a directed graph variable.
+     */
+    default SetVar graphSuccessorsSetView(DirectedGraphVar g, int node) {
+        return new GraphSuccessorsSetView(g, node);
+    }
+
+    /**
+     * Creates a set view over the set of predecessors of a node of a directed graph variable.
+     * @param g observed graph variable
+     * @param node observed node
+     * @return a set view over the set of predecessors of a node of a directed graph variable.
+     */
+    default SetVar graphPredecessorsSetView(DirectedGraphVar g, int node) {
+        return new GraphPredecessorsSetView(g, node);
+    }
+
+    /**
+     * Creates a set view over the set of neighbors of a node of an undirected graph variable.
+     * @param g observed graph variable
+     * @param node observed node
+     * @return a set view over the set of neighbors of a node of an udirected graph variable.
+     */
+    default SetVar graphNeighborsSetView(UndirectedGraphVar g, int node) {
+        return new GraphSuccessorsSetView(g, node);
+    }
 }

--- a/solver/src/main/java/org/chocosolver/solver/variables/SetVar.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/SetVar.java
@@ -11,7 +11,10 @@ package org.chocosolver.solver.variables;
 
 import org.chocosolver.solver.ICause;
 import org.chocosolver.solver.exception.ContradictionException;
+import org.chocosolver.solver.variables.delta.ISetDelta;
 import org.chocosolver.solver.variables.delta.ISetDeltaMonitor;
+import org.chocosolver.solver.variables.delta.monitor.SetDeltaMonitor;
+import org.chocosolver.util.iterators.EvtScheduler;
 import org.chocosolver.util.objects.setDataStructures.ISet;
 
 /**
@@ -122,11 +125,16 @@ public interface SetVar extends Variable {
 		return getLB();
 	}
 
+	ISetDelta getDelta();
+
     /**
      * Allow propagator to monitor element removal/enforcing of this
      *
      * @param propagator observer
      * @return a new SetDeltaMonitor
      */
-	ISetDeltaMonitor monitorDelta(ICause propagator);
+	default ISetDeltaMonitor monitorDelta(ICause propagator) {
+		createDelta();
+		return new SetDeltaMonitor(getDelta(), propagator);
+	}
 }

--- a/solver/src/main/java/org/chocosolver/solver/variables/UndirectedGraphVar.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/UndirectedGraphVar.java
@@ -24,8 +24,8 @@ public interface UndirectedGraphVar<E extends UndirectedGraph> extends GraphVar<
      * @param idx a vertex
      * @return The set of neighbors of 'idx' in LB
      */
-    default ISet getMandNeighOf(int idx) {
-        return getMandSuccOrNeighOf(idx);
+    default ISet getMandatoryNeighborsOf(int idx) {
+        return getLB().getNeighborsOf(idx);
     }
 
     /**
@@ -35,8 +35,44 @@ public interface UndirectedGraphVar<E extends UndirectedGraph> extends GraphVar<
      * @param idx a vertex
      * @return The set of neighbors of 'idx' in UB
      */
-    default ISet getPotNeighOf(int idx) {
-        return getPotSuccOrNeighOf(idx);
+    default ISet getPotentialNeighborsOf(int idx) {
+        return getUB().getNeighborsOf(idx);
+    }
+
+    /**
+     * @deprecated For an undirected graph, this method is equivalent to getMandatoryNeighborsOf.
+     */
+    @Deprecated
+    @Override
+    default ISet getMandatorySuccessorsOf(int node) {
+        return GraphVar.super.getMandatorySuccessorsOf(node);
+    }
+
+    /**
+     * @deprecated For an undirected graph, this method is equivalent to getPotentialNeighborsOf.
+     */
+    @Deprecated
+    @Override
+    default ISet getPotentialSuccessorsOf(int node) {
+        return GraphVar.super.getPotentialSuccessorsOf(node);
+    }
+
+    /**
+     * @deprecated For an undirected graph, this method is equivalent to getMandatoryNeighborsOf.
+     */
+    @Deprecated
+    @Override
+    default ISet getMandatoryPredecessorsOf(int node) {
+        return GraphVar.super.getMandatoryPredecessorsOf(node);
+    }
+
+    /**
+     * @deprecated For an undirected graph, this method is equivalent to getPotentialNeighborsOf.
+     */
+    @Deprecated
+    @Override
+    default ISet getPotentialPredecessorOf(int node) {
+        return GraphVar.super.getPotentialPredecessorOf(node);
     }
 
     /**

--- a/solver/src/main/java/org/chocosolver/solver/variables/UndirectedGraphVar.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/UndirectedGraphVar.java
@@ -1,0 +1,46 @@
+/*
+ * This file is part of choco-solver, http://choco-solver.org/
+ *
+ * Copyright (c) 2021, IMT Atlantique. All rights reserved.
+ *
+ * Licensed under the BSD 4-clause license.
+ *
+ * See LICENSE file in the project root for full license information.
+ */
+package org.chocosolver.solver.variables;
+
+import org.chocosolver.util.objects.graphs.UndirectedGraph;
+import org.chocosolver.util.objects.setDataStructures.ISet;
+
+/**
+ * Interface defining an undirected graph variable
+ */
+public interface UndirectedGraphVar<E extends UndirectedGraph> extends GraphVar<E> {
+
+    /**
+     * Get the set of neighbors of vertex 'idx' in the lower bound graph
+     * (mandatory incident edges)
+     *
+     * @param idx a vertex
+     * @return The set of neighbors of 'idx' in LB
+     */
+    default ISet getMandNeighOf(int idx) {
+        return getMandSuccOrNeighOf(idx);
+    }
+
+    /**
+     * Get the set of neighbors of vertex 'idx' in the upper bound graph
+     * (potential incident edges)
+     *
+     * @param idx a vertex
+     * @return The set of neighbors of 'idx' in UB
+     */
+    default ISet getPotNeighOf(int idx) {
+        return getPotSuccOrNeighOf(idx);
+    }
+
+    @Override
+    default boolean isDirected() {
+        return false;
+    }
+}

--- a/solver/src/main/java/org/chocosolver/solver/variables/UndirectedGraphVar.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/UndirectedGraphVar.java
@@ -39,6 +39,16 @@ public interface UndirectedGraphVar<E extends UndirectedGraph> extends GraphVar<
         return getPotSuccOrNeighOf(idx);
     }
 
+    /**
+     * Retrieves the current value of the variable if instantiated, otherwise the lower bound (kernel).
+     *
+     * @return the current value (or kernel if not yet instantiated).
+     */
+    default E getValue(){
+        assert isInstantiated() : getName() + " not instantiated";
+        return getLB();
+    }
+
     @Override
     default boolean isDirected() {
         return false;

--- a/solver/src/main/java/org/chocosolver/solver/variables/Variable.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/Variable.java
@@ -72,6 +72,11 @@ public interface Variable extends Identity, Comparable<Variable> {
     int REAL = 1 << 6;
 
     /**
+     * Kind of variable: graph.
+     */
+    int GRAPH = 1 << 7;
+
+    /**
      * Mask to get the kind of a variable.
      */
     int KIND = (1 << 10) - 1 - TYPE;

--- a/solver/src/main/java/org/chocosolver/solver/variables/delta/GraphDelta.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/delta/GraphDelta.java
@@ -1,0 +1,74 @@
+/*
+ * This file is part of choco-solver, http://choco-solver.org/
+ *
+ * Copyright (c) 2021, IMT Atlantique. All rights reserved.
+ *
+ * Licensed under the BSD 4-clause license.
+ *
+ * See LICENSE file in the project root for full license information.
+ */
+package org.chocosolver.solver.variables.delta;
+
+import org.chocosolver.memory.IEnvironment;
+import org.chocosolver.solver.ICause;
+import org.chocosolver.solver.search.loop.TimeStampedObject;
+
+public class GraphDelta extends TimeStampedObject implements IDelta {
+
+	//NR NE AR AE : NodeRemoved NodeEnforced ArcRemoved ArcEnforced
+	public final static int NR = 0;
+	public final static int NE = 1;
+	public final static int AR_TAIL = 2;
+	public final static int AR_HEAD = 3;
+	public final static int AE_TAIL = 4;
+	public final static int AE_HEAD = 5;
+	public final static int NB = 6;
+
+	//***********************************************************************************
+	// VARIABLES
+	//***********************************************************************************
+
+	private IEnumDelta[] deltaOfType;
+
+	//***********************************************************************************
+	// CONSTRUCTORS
+	//***********************************************************************************
+
+	public GraphDelta(IEnvironment environment) {
+		super(environment);
+		deltaOfType = new IEnumDelta[NB];
+		for (int i = 0; i < NB; i++) {
+			deltaOfType[i] = new EnumDelta(environment);
+		}
+	}
+
+	//***********************************************************************************
+	// METHODS
+	//***********************************************************************************
+
+	public int getSize(int i) {
+		return deltaOfType[i].size();
+	}
+
+	public void add(int element, int type, ICause cause) {
+		lazyClear();
+		deltaOfType[type].add(element, cause);
+	}
+
+	public void lazyClear() {
+		if (needReset()) {
+			for (int i = 0; i < NB; i++) {
+				deltaOfType[i].lazyClear();
+			}
+			resetStamp();
+		}
+	}
+
+	public int get(int index, int type) {
+		return deltaOfType[type].get(index);
+	}
+
+	public ICause getCause(int index, int type) {
+		return deltaOfType[type].getCause(index);
+	}
+}

--- a/solver/src/main/java/org/chocosolver/solver/variables/delta/GraphDelta.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/delta/GraphDelta.java
@@ -13,16 +13,11 @@ import org.chocosolver.memory.IEnvironment;
 import org.chocosolver.solver.ICause;
 import org.chocosolver.solver.search.loop.TimeStampedObject;
 
-public class GraphDelta extends TimeStampedObject implements IDelta {
-
-	//NR NE AR AE : NodeRemoved NodeEnforced ArcRemoved ArcEnforced
-	public final static int NR = 0;
-	public final static int NE = 1;
-	public final static int AR_TAIL = 2;
-	public final static int AR_HEAD = 3;
-	public final static int AE_TAIL = 4;
-	public final static int AE_HEAD = 5;
-	public final static int NB = 6;
+/**
+ * Implementation of graph variable delta
+ * Adapted from choco-graph GraphDelta class - original author: Jean-Guillaume Fage.
+ */
+public class GraphDelta extends TimeStampedObject implements IGraphDelta {
 
 	//***********************************************************************************
 	// VARIABLES

--- a/solver/src/main/java/org/chocosolver/solver/variables/delta/IGraphDelta.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/delta/IGraphDelta.java
@@ -1,0 +1,36 @@
+/*
+ * This file is part of choco-solver, http://choco-solver.org/
+ *
+ * Copyright (c) 2021, IMT Atlantique. All rights reserved.
+ *
+ * Licensed under the BSD 4-clause license.
+ *
+ * See LICENSE file in the project root for full license information.
+ */
+package org.chocosolver.solver.variables.delta;
+
+import org.chocosolver.solver.ICause;
+
+/**
+ * Interface of graph variable delta
+ * Adapted from choco-graph GraphDelta class - original authors: Jean-Guillaume Fages and Charles Prud'homme.
+ */
+public interface IGraphDelta extends IDelta {
+
+    //NR NE AR AE : NodeRemoved NodeEnforced ArcRemoved ArcEnforced
+    public final static int NR = 0;
+    public final static int NE = 1;
+    public final static int AR_TAIL = 2;
+    public final static int AR_HEAD = 3;
+    public final static int AE_TAIL = 4;
+    public final static int AE_HEAD = 5;
+    public final static int NB = 6;
+
+    int getSize(int i);
+
+    void add(int element, int type, ICause cause);
+
+    int get(int index, int type);
+
+    ICause getCause(int index, int type);
+}

--- a/solver/src/main/java/org/chocosolver/solver/variables/delta/IGraphDelta.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/delta/IGraphDelta.java
@@ -17,14 +17,13 @@ import org.chocosolver.solver.ICause;
  */
 public interface IGraphDelta extends IDelta {
 
-    //NR NE AR AE : NodeRemoved NodeEnforced ArcRemoved ArcEnforced
-    public final static int NR = 0;
-    public final static int NE = 1;
-    public final static int AR_TAIL = 2;
-    public final static int AR_HEAD = 3;
-    public final static int AE_TAIL = 4;
-    public final static int AE_HEAD = 5;
-    public final static int NB = 6;
+    int NODE_REMOVED = 0;
+    int NODE_ENFORCED = 1;
+    int EDGE_REMOVED_TAIL = 2;
+    int EDGE_REMOVED_HEAD = 3;
+    int EDGE_ENFORCED_TAIL = 4;
+    int EDGE_ENFORCED_HEAD = 5;
+    int NB = 6;
 
     int getSize(int i);
 

--- a/solver/src/main/java/org/chocosolver/solver/variables/delta/IGraphDeltaMonitor.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/delta/IGraphDeltaMonitor.java
@@ -1,3 +1,12 @@
+/*
+ * This file is part of choco-solver, http://choco-solver.org/
+ *
+ * Copyright (c) 2021, IMT Atlantique. All rights reserved.
+ *
+ * Licensed under the BSD 4-clause license.
+ *
+ * See LICENSE file in the project root for full license information.
+ */
 package org.chocosolver.solver.variables.delta;
 
 import org.chocosolver.solver.exception.ContradictionException;
@@ -21,11 +30,11 @@ public interface IGraphDeltaMonitor {
     void forEachNode(IntProcedure proc, GraphEventType evt) throws ContradictionException;
 
     /**
-     * Applies proc to every arc which has just been removed or enforced, depending on evt.
+     * Applies proc to every edge which has just been removed or enforced, depending on evt.
      *
-     * @param proc an incremental procedure over arcs
-     * @param evt  either ENFORCEARC or REMOVEARC
+     * @param proc an incremental procedure over edges
+     * @param evt  either ENFORCE_EDGE or REMOVE_EDGE
      * @throws ContradictionException if a failure occurs
      */
-    void forEachArc(PairProcedure proc, GraphEventType evt) throws ContradictionException;
+    void forEachEdge(PairProcedure proc, GraphEventType evt) throws ContradictionException;
 }

--- a/solver/src/main/java/org/chocosolver/solver/variables/delta/IGraphDeltaMonitor.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/delta/IGraphDeltaMonitor.java
@@ -1,0 +1,30 @@
+package org.chocosolver.solver.variables.delta;
+
+import org.chocosolver.solver.exception.ContradictionException;
+import org.chocosolver.solver.variables.events.GraphEventType;
+import org.chocosolver.util.procedure.IntProcedure;
+import org.chocosolver.util.procedure.PairProcedure;
+
+/**
+ * Interface for Graph Delta Monitor.
+ */
+public interface IGraphDeltaMonitor {
+
+    /**
+     * Applies proc to every vertex which has just been removed or enforced, depending on evt.
+     *
+     * @param proc an incremental procedure over vertices
+     * @param evt  either ENFORCENODE or REMOVENODE
+     * @throws ContradictionException if a failure occurs
+     */
+    void forEachNode(IntProcedure proc, GraphEventType evt) throws ContradictionException;
+
+    /**
+     * Applies proc to every arc which has just been removed or enforced, depending on evt.
+     *
+     * @param proc an incremental procedure over arcs
+     * @param evt  either ENFORCEARC or REMOVEARC
+     * @throws ContradictionException if a failure occurs
+     */
+    void forEachArc(PairProcedure proc, GraphEventType evt) throws ContradictionException;
+}

--- a/solver/src/main/java/org/chocosolver/solver/variables/delta/IGraphDeltaMonitor.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/delta/IGraphDeltaMonitor.java
@@ -7,6 +7,7 @@ import org.chocosolver.util.procedure.PairProcedure;
 
 /**
  * Interface for Graph Delta Monitor.
+ * Adapted from choco-graph. Original authors: Jean-Guillaume Fages and Charles Prud'homme.
  */
 public interface IGraphDeltaMonitor {
 

--- a/solver/src/main/java/org/chocosolver/solver/variables/delta/monitor/GraphDeltaMonitor.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/delta/monitor/GraphDeltaMonitor.java
@@ -10,6 +10,7 @@
 package org.chocosolver.solver.variables.delta.monitor;
 
 import org.chocosolver.solver.variables.delta.GraphDelta;
+import org.chocosolver.solver.variables.delta.IGraphDeltaMonitor;
 import org.chocosolver.solver.variables.events.GraphEventType;
 import org.chocosolver.solver.ICause;
 import org.chocosolver.solver.exception.ContradictionException;
@@ -23,7 +24,7 @@ import org.chocosolver.util.procedure.PairProcedure;
  * @author Charles Prud'homme
  * @since 07/12/11
  */
-public class GraphDeltaMonitor extends TimeStampedObject {
+public class GraphDeltaMonitor extends TimeStampedObject implements IGraphDeltaMonitor {
 
 	private final GraphDelta delta;
 	private int[] first; // references, in variable delta value to propagate, to un propagated values

--- a/solver/src/main/java/org/chocosolver/solver/variables/delta/monitor/GraphDeltaMonitor.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/delta/monitor/GraphDeltaMonitor.java
@@ -1,0 +1,116 @@
+/*
+ * This file is part of choco-solver, http://choco-solver.org/
+ *
+ * Copyright (c) 2021, IMT Atlantique. All rights reserved.
+ *
+ * Licensed under the BSD 4-clause license.
+ *
+ * See LICENSE file in the project root for full license information.
+ */
+package org.chocosolver.solver.variables.delta.monitor;
+
+import org.chocosolver.solver.variables.delta.GraphDelta;
+import org.chocosolver.solver.variables.events.GraphEventType;
+import org.chocosolver.solver.ICause;
+import org.chocosolver.solver.exception.ContradictionException;
+import org.chocosolver.solver.search.loop.TimeStampedObject;
+import org.chocosolver.util.procedure.IntProcedure;
+import org.chocosolver.util.procedure.PairProcedure;
+
+/**
+ * <br/>
+ *
+ * @author Charles Prud'homme
+ * @since 07/12/11
+ */
+public class GraphDeltaMonitor extends TimeStampedObject {
+
+	private final GraphDelta delta;
+	private int[] first; // references, in variable delta value to propagate, to un propagated values
+	private int[] frozenFirst, frozenLast; // same as previous while the recorder is frozen, to allow "concurrent modifications"
+	private ICause propagator;
+
+	public GraphDeltaMonitor(GraphDelta delta, ICause propagator) {
+		super(delta.getEnvironment());
+		this.delta = delta;
+		this.first = new int[4];
+		this.frozenFirst = new int[4];
+		this.frozenLast = new int[4];
+		this.propagator = propagator;
+	}
+
+	public void freeze() {
+		if (needReset()) {
+			for (int i = 0; i < 4; i++) {
+				first[i] = 0;
+			}
+			resetStamp();
+		}
+		for (int i = 0; i < 3; i++) {
+			frozenFirst[i] = first[i]; // freeze indices
+			first[i] = frozenLast[i] = delta.getSize(i);
+		}
+		frozenFirst[3] = first[3]; // freeze indices
+		first[3] = frozenLast[3] = delta.getSize(GraphDelta.AE_TAIL);
+	}
+
+	public void unfreeze() {
+		delta.lazyClear();    // fix 27/07/12
+		resetStamp();
+		for (int i = 0; i < 3; i++) {
+			first[i] = delta.getSize(i);
+		}
+		first[3] = delta.getSize(GraphDelta.AE_TAIL);
+	}
+
+	/**
+	 * Applies proc to every vertex which has just been removed or enforced, depending on evt.
+	 * @param proc    an incremental procedure over vertices
+	 * @param evt    either ENFORCENODE or REMOVENODE
+	 * @throws ContradictionException if a failure occurs
+	 */
+	public void forEachNode(IntProcedure proc, GraphEventType evt) throws ContradictionException {
+		int type;
+		if (evt == GraphEventType.REMOVE_NODE) {
+			type = GraphDelta.NR;
+			for (int i = frozenFirst[type]; i < frozenLast[type]; i++) {
+				if (delta.getCause(i, type) != propagator) {
+					proc.execute(delta.get(i, type));
+				}
+			}
+		} else if (evt == GraphEventType.ADD_NODE) {
+			type = GraphDelta.NE;
+			for (int i = frozenFirst[type]; i < frozenLast[type]; i++) {
+				if (delta.getCause(i, type) != propagator) {
+					proc.execute(delta.get(i, type));
+				}
+			}
+		} else {
+			throw new UnsupportedOperationException();
+		}
+	}
+
+	/**
+	 * Applies proc to every arc which has just been removed or enforced, depending on evt.
+	 * @param proc    an incremental procedure over arcs
+	 * @param evt    either ENFORCEARC or REMOVEARC
+	 * @throws ContradictionException if a failure occurs
+	 */
+	public void forEachArc(PairProcedure proc, GraphEventType evt) throws ContradictionException {
+		if (evt == GraphEventType.REMOVE_ARC) {
+			for (int i = frozenFirst[2]; i < frozenLast[2]; i++) {
+				if (delta.getCause(i, GraphDelta.AR_TAIL) != propagator) {
+					proc.execute(delta.get(i, GraphDelta.AR_TAIL), delta.get(i, GraphDelta.AR_HEAD));
+				}
+			}
+		} else if (evt == GraphEventType.ADD_ARC) {
+			for (int i = frozenFirst[3]; i < frozenLast[3]; i++) {
+				if (delta.getCause(i, GraphDelta.AE_TAIL) != propagator) {
+					proc.execute(delta.get(i, GraphDelta.AE_TAIL), delta.get(i, GraphDelta.AE_HEAD));
+				}
+			}
+		} else {
+			throw new UnsupportedOperationException();
+		}
+	}
+}

--- a/solver/src/main/java/org/chocosolver/solver/variables/delta/monitor/GraphDeltaMonitor.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/delta/monitor/GraphDeltaMonitor.java
@@ -53,7 +53,7 @@ public class GraphDeltaMonitor extends TimeStampedObject implements IGraphDeltaM
 		for (int i = 0; i < 3; i++) {
 			this.last[i] = delta.getSize(i);
 		}
-		this.last[3] = delta.getSize(IGraphDelta.AE_TAIL);
+		this.last[3] = delta.getSize(IGraphDelta.EDGE_ENFORCED_TAIL);
 	}
 
 	/**
@@ -66,9 +66,9 @@ public class GraphDeltaMonitor extends TimeStampedObject implements IGraphDeltaM
 		freeze();
 		int type;
 		if (evt == GraphEventType.REMOVE_NODE) {
-			type = IGraphDelta.NR;
+			type = IGraphDelta.NODE_REMOVED;
 		} else if (evt == GraphEventType.ADD_NODE) {
-			type = IGraphDelta.NE;
+			type = IGraphDelta.NODE_ENFORCED;
 		} else {
 			throw new UnsupportedOperationException("The event in parameter should be ADD_NODE or REMOVE_NODE");
 		}
@@ -81,26 +81,26 @@ public class GraphDeltaMonitor extends TimeStampedObject implements IGraphDeltaM
 	}
 
 	/**
-	 * Applies proc to every arc which has just been removed or enforced, depending on evt.
-	 * @param proc    an incremental procedure over arcs
-	 * @param evt    either ENFORCEARC or REMOVEARC
+	 * Applies proc to every edge which has just been removed or enforced, depending on evt.
+	 * @param proc    an incremental procedure over edges
+	 * @param evt    either ENFORCE_EDGE or REMOVE_EDGE
 	 * @throws ContradictionException if a failure occurs
 	 */
-	public void forEachArc(PairProcedure proc, GraphEventType evt) throws ContradictionException {
+	public void forEachEdge(PairProcedure proc, GraphEventType evt) throws ContradictionException {
 		freeze();
 		int idx;
 		int tailType;
 		int headType;
-		if (evt == GraphEventType.REMOVE_ARC) {
+		if (evt == GraphEventType.REMOVE_EDGE) {
 			idx = 2;
-			tailType = IGraphDelta.AR_TAIL;
-			headType = IGraphDelta.AR_HEAD;
-		} else if (evt == GraphEventType.ADD_ARC) {
+			tailType = IGraphDelta.EDGE_REMOVED_TAIL;
+			headType = IGraphDelta.EDGE_REMOVED_HEAD;
+		} else if (evt == GraphEventType.ADD_EDGE) {
 			idx = 3;
-			tailType = IGraphDelta.AE_TAIL;
-			headType = IGraphDelta.AE_HEAD;
+			tailType = IGraphDelta.EDGE_ENFORCED_TAIL;
+			headType = IGraphDelta.EDGE_ENFORCED_HEAD;
 		} else {
-			throw new UnsupportedOperationException("The event in parameter should be ADD_ARC or REMOVE_ARC");
+			throw new UnsupportedOperationException("The event in parameter should be ADD_EDGE or REMOVE_EDGE");
 		}
 		while (first[idx] < last[idx]) {
 			if (delta.getCause(first[idx], tailType) != propagator) {

--- a/solver/src/main/java/org/chocosolver/solver/variables/events/GraphEventType.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/events/GraphEventType.java
@@ -1,0 +1,68 @@
+/*
+ * This file is part of choco-solver, http://choco-solver.org/
+ *
+ * Copyright (c) 2021, IMT Atlantique. All rights reserved.
+ *
+ * Licensed under the BSD 4-clause license.
+ *
+ * See LICENSE file in the project root for full license information.
+ */
+package org.chocosolver.solver.variables.events;
+
+/**
+ * Fine events for a graph variable
+ * @author Jean-Guillaume Fages, Charles Prud'homme
+ */
+public enum GraphEventType implements IEventType {
+
+	VOID(0),
+	REMOVE_NODE(1),
+	ADD_NODE(2),
+	REMOVE_ARC(4),
+	ADD_ARC(8);
+
+	//***********************************************************************************
+	// VARIABLES
+	//***********************************************************************************
+
+	private final int mask;
+
+	//***********************************************************************************
+	// CONSTRUCTORS
+	//***********************************************************************************
+
+	GraphEventType(int mask) {
+		this.mask = mask;
+	}
+
+	//***********************************************************************************
+	// METHODS
+	//***********************************************************************************
+
+	public int getMask() {
+		return mask;
+	}
+
+	public int getStrengthenedMask() {
+		return getMask();
+	}
+
+	//******************************************************************************************************************
+	//******************************************************************************************************************
+
+	public static boolean isAddNode(int mask) {
+		return (mask & ADD_NODE.mask) != 0;
+	}
+
+	public static boolean isAddArc(int mask) {
+		return (mask & ADD_ARC.mask) != 0;
+	}
+
+	public static boolean isRemNode(int mask) {
+		return (mask & REMOVE_NODE.mask) != 0;
+	}
+
+	public static boolean isRemArc(int mask) {
+		return (mask & REMOVE_ARC.mask) != 0;
+	}
+}

--- a/solver/src/main/java/org/chocosolver/solver/variables/events/GraphEventType.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/events/GraphEventType.java
@@ -18,8 +18,8 @@ public enum GraphEventType implements IEventType {
 	VOID(0),
 	REMOVE_NODE(1),
 	ADD_NODE(2),
-	REMOVE_ARC(4),
-	ADD_ARC(8);
+	REMOVE_EDGE(4),
+	ADD_EDGE(8);
 
 	//***********************************************************************************
 	// VARIABLES
@@ -42,27 +42,5 @@ public enum GraphEventType implements IEventType {
 	public int getMask() {
 		return mask;
 	}
-
-	public int getStrengthenedMask() {
-		return getMask();
-	}
-
-	//******************************************************************************************************************
-	//******************************************************************************************************************
-
-	public static boolean isAddNode(int mask) {
-		return (mask & ADD_NODE.mask) != 0;
-	}
-
-	public static boolean isAddArc(int mask) {
-		return (mask & ADD_ARC.mask) != 0;
-	}
-
-	public static boolean isRemNode(int mask) {
-		return (mask & REMOVE_NODE.mask) != 0;
-	}
-
-	public static boolean isRemArc(int mask) {
-		return (mask & REMOVE_ARC.mask) != 0;
-	}
+	
 }

--- a/solver/src/main/java/org/chocosolver/solver/variables/impl/AbstractGraphVar.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/impl/AbstractGraphVar.java
@@ -1,0 +1,272 @@
+/*
+ * This file is part of choco-solver, http://choco-solver.org/
+ *
+ * Copyright (c) 2021, IMT Atlantique. All rights reserved.
+ *
+ * Licensed under the BSD 4-clause license.
+ *
+ * See LICENSE file in the project root for full license information.
+ */
+package org.chocosolver.solver.variables.impl;
+
+import org.chocosolver.solver.variables.GraphVar;
+import org.chocosolver.solver.variables.delta.GraphDelta;
+import org.chocosolver.solver.ICause;
+import org.chocosolver.solver.Model;
+import org.chocosolver.solver.exception.ContradictionException;
+import org.chocosolver.solver.variables.events.GraphEventType;
+import org.chocosolver.solver.variables.impl.scheduler.GraphEvtScheduler;
+import org.chocosolver.util.iterators.EvtScheduler;
+import org.chocosolver.util.objects.graphs.IGraph;
+import org.chocosolver.util.objects.setDataStructures.ISet;
+
+public abstract class AbstractGraphVar<E extends IGraph> extends AbstractVariable implements GraphVar<E> {
+
+	//////////////////////////////// GRAPH PART /////////////////////////////////////////
+	//***********************************************************************************
+	// VARIABLES
+	//***********************************************************************************
+
+	protected E UB, LB;
+	protected GraphDelta delta;
+	protected int n;
+	///////////// Attributes related to Variable ////////////
+	protected boolean reactOnModification;
+
+	//***********************************************************************************
+	// CONSTRUCTORS
+	//***********************************************************************************
+
+	/**
+	 * Creates a graph variable
+	 *
+	 * @param solver
+	 */
+	protected AbstractGraphVar(String name, Model solver, E LB, E UB) {
+		super(name, solver);
+		this.LB = LB;
+		this.UB = UB;
+		this.n = UB.getNbMaxNodes();
+		assert n == LB.getNbMaxNodes();
+	}
+
+	//***********************************************************************************
+	// METHODS
+	//***********************************************************************************
+
+	@Override
+	public boolean isInstantiated() {
+		if (getPotentialNodes().size() != getMandatoryNodes().size()) {
+			return false;
+		}
+		ISet suc;
+		for (int i : getUB().getNodes()) {
+			suc = UB.getSuccOrNeighOf(i);
+			if (suc.size() != getLB().getSuccOrNeighOf(i).size()) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	/**
+	 * Remove node x from the domain
+	 * Removes x from the upper bound graph
+	 *
+	 * @param x     node's index
+	 * @param cause algorithm which is related to the removal
+	 * @return true iff the removal has an effect
+	 */
+	public boolean removeNode(int x, ICause cause) throws ContradictionException {
+		assert cause != null;
+		assert (x >= 0 && x < n);
+		if (LB.getNodes().contains(x)) {
+			this.contradiction(cause, "remove mandatory node");
+			return true;
+		} else if (!UB.getNodes().contains(x)) {
+			return false;
+		}
+		ISet nei = UB.getSuccOrNeighOf(x);
+		for (int i : nei) {
+			removeArc(x, i, cause);
+		}
+		nei = UB.getPredOrNeighOf(x);
+		for (int i : nei) {
+			removeArc(i, x, cause);
+		}
+		if (UB.removeNode(x)) {
+			if (reactOnModification) {
+				delta.add(x, GraphDelta.NR, cause);
+			}
+			GraphEventType e = GraphEventType.REMOVE_NODE;
+			notifyPropagators(e, cause);
+			return true;
+		}
+		return false;
+	}
+
+	/**
+	 * Enforce the node x to belong to any solution
+	 * Adds x to the lower bound graph
+	 *
+	 * @param x     node's index
+	 * @param cause algorithm which is related to the modification
+	 * @return true iff the enforcing has an effect
+	 */
+	public boolean enforceNode(int x, ICause cause) throws ContradictionException {
+		assert cause != null;
+		assert (x >= 0 && x < n);
+		if (UB.getNodes().contains(x)) {
+			if (LB.addNode(x)) {
+				if (reactOnModification) {
+					delta.add(x, GraphDelta.NE, cause);
+				}
+				GraphEventType e = GraphEventType.ADD_NODE;
+				notifyPropagators(e, cause);
+				return true;
+			}
+			return false;
+		}
+		this.contradiction(cause, "enforce node which is not in the domain");
+		return true;
+	}
+
+	//***********************************************************************************
+	// ACCESSORS
+	//***********************************************************************************
+
+	/**
+	 * @return the lower bound graph (having mandatory nodes and arcs)
+	 */
+	public E getLB() {
+		return LB;
+	}
+
+	/**
+	 * @return the upper bound graph (having possible nodes and arcs)
+	 */
+	public E getUB() {
+		return UB;
+	}
+
+	/**
+	 * @return the maximum number of node the graph variable may have.
+	 * Nodes are comprised in the interval [0,getNbMaxNodes()]
+	 * Therefore, any vertex should be strictly lower than getNbMaxNodes()
+	 */
+	public int getNbMaxNodes() {
+		return n;
+	}
+
+	//***********************************************************************************
+	// VARIABLE STUFF
+	//***********************************************************************************
+
+
+	@Override
+	public GraphDelta getDelta() {
+		return delta;
+	}
+
+	@Override
+	public int getTypeAndKind() {
+		return VAR | GRAPH;
+	}
+
+	@Override
+	public EvtScheduler createScheduler() {
+		return new GraphEvtScheduler();
+	}
+
+	@Override
+	public String toString() {
+		StringBuilder sb = new StringBuilder();
+		sb.append("graph_var ").append(getName());
+		if (isInstantiated()) {
+			sb.append("\nValue: \n");
+			sb.append(UB.toString());
+		} else {
+			sb.append("\nUpper bound: \n");
+			sb.append(UB.toString());
+			sb.append("\nLower bound: \n");
+			sb.append(LB.toString());
+		}
+		return sb.toString();
+	}
+
+	@Override
+	public void createDelta() {
+		if (!reactOnModification) {
+			reactOnModification = true;
+			delta = new GraphDelta(getEnvironment());
+		}
+	}
+
+	//***********************************************************************************
+	// SOLUTIONS : STORE AND RESTORE
+	//***********************************************************************************
+
+	/**
+	 * Instantiates <code>this</code> to value which represents an adjacency
+	 * matrix plus a set of nodes (last row of the matrix).
+	 * This method is not supposed to be used except for restoring solutions.
+	 *
+	 * @param value value of <code>this</code>
+	 * @param cause
+	 * @throws ContradictionException if the arc was mandatory
+	 */
+	public void instantiateTo(boolean[][] value, ICause cause) throws ContradictionException {
+		int n = value.length - 1;
+		for (int i = 0; i < n; i++) {
+			if (value[n][i]) {//nodes
+				enforceNode(i, cause);
+			} else {
+				removeNode(i, cause);
+			}
+			for (int j = 0; j < n; j++) {
+				if (value[i][j]) {//arcs
+					enforceArc(i, j, cause);
+				} else {
+					removeArc(i, j, cause);
+				}
+			}
+		}
+	}
+
+	//***********************************************************************************
+	// GraphViz
+	//***********************************************************************************
+
+	/**
+	 * Export domain to graphviz format, see http://www.webgraphviz.com/
+	 * Mandatory elements are in red whereas potential elements are in black
+	 *
+	 * @return a String encoding the domain of the variable
+	 */
+	public String graphVizExport() {
+		boolean directed = isDirected();
+		String arc = directed ? " -> " : " -- ";
+		StringBuilder sb = new StringBuilder();
+		sb.append(directed ? "digraph " : "graph ").append(getName() + "{\n");
+		sb.append("node [color = red, fontcolor=red]; ");
+		for (int i : getMandatoryNodes()) sb.append(i + " ");
+		sb.append(";\n");
+		for (int i : getMandatoryNodes()) {
+			for (int j : getMandSuccOrNeighOf(i)) {
+				if (directed || i < j) sb.append(i + arc + j + " [color=red] ;\n");
+			}
+		}
+		if (getMandatoryNodes().size() < getPotentialNodes().size()) {
+			sb.append("node [color = black, fontcolor=black]; ");
+			for (int i : getPotentialNodes()) if (!getMandatoryNodes().contains(i)) sb.append(i + " ");
+			sb.append(";\n");
+		}
+		for (int i : getPotentialNodes()) {
+			for (int j : getPotSuccOrNeighOf(i)) {
+				if ((directed || i < j) && !getMandSuccOrNeighOf(i).contains(j)) sb.append(i + arc + j + " ;\n");
+			}
+		}
+		sb.append("}");
+		return sb.toString();
+	}
+}

--- a/solver/src/main/java/org/chocosolver/solver/variables/impl/AbstractGraphVar.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/impl/AbstractGraphVar.java
@@ -206,6 +206,46 @@ public abstract class AbstractGraphVar<E extends IGraph> extends AbstractVariabl
 	// SOLUTIONS : STORE AND RESTORE
 	//***********************************************************************************
 
+	@Override
+	public void instantiateTo(E value, ICause cause) throws ContradictionException {
+		ISet nodes = value.getNodes();
+		for (int i = 0; i < n; i++) {
+			if (nodes.contains(i)) {
+				enforceNode(i, cause);
+			} else {
+				removeNode(i, cause);
+			}
+		}
+		for (int i = 0; i < n; i++) {
+			for (int j = 0; j < n; i++) {
+				if (nodes.contains(i) && nodes.contains(j)) {
+					if (value.getSuccOrNeighOf(i).contains(j)) {
+						enforceArc(i, j, cause);
+					} else {
+						removeArc(i, j, cause);
+					}
+				}
+			}
+		}
+	}
+
+	/**
+	 * @return the value of the graph variable represented through an adjacency matrix
+	 * plus a set of nodes (last row of the matrix).
+	 * This method is not supposed to be used except for restoring solutions.
+	 */
+	public boolean[][] getValueAsBoolMatrix() {
+		int n = getUB().getNbMaxNodes();
+		boolean[][] vals = new boolean[n + 1][n];
+		for (int i : getLB().getNodes()) {
+			for (int j : getLB().getSuccOrNeighOf(i)) {
+				vals[i][j] = true; // arc in
+			}
+			vals[n][i] = true; // node in
+		}
+		return vals;
+	}
+
 	/**
 	 * Instantiates <code>this</code> to value which represents an adjacency
 	 * matrix plus a set of nodes (last row of the matrix).

--- a/solver/src/main/java/org/chocosolver/solver/variables/impl/DirectedGraphVarImpl.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/impl/DirectedGraphVarImpl.java
@@ -9,17 +9,17 @@
  */
 package org.chocosolver.solver.variables.impl;
 
-import org.chocosolver.solver.variables.UndirectedGraphVar;
+import org.chocosolver.solver.variables.DirectedGraphVar;
 import org.chocosolver.solver.variables.delta.GraphDelta;
 import org.chocosolver.solver.ICause;
 import org.chocosolver.solver.Model;
 import org.chocosolver.solver.exception.ContradictionException;
 import org.chocosolver.solver.variables.events.GraphEventType;
-import org.chocosolver.util.objects.graphs.UndirectedGraph;
+import org.chocosolver.util.objects.graphs.DirectedGraph;
 
-public class UndirectedGraphVarImpl<E extends UndirectedGraph> extends AbstractGraphVar<E> implements UndirectedGraphVar<E> {
+public class DirectedGraphVarImpl<E extends DirectedGraph> extends AbstractGraphVar<E> implements DirectedGraphVar<E> {
 
-	//////////////////////////////// GRAPH PART /////////////////////////////////////////
+	////////////////////////////////// GRAPH PART ///////////////////////////////////////
 
 	//***********************************************************************************
 	// CONSTRUCTORS
@@ -33,7 +33,7 @@ public class UndirectedGraphVarImpl<E extends UndirectedGraph> extends AbstractG
 	 * @param LB
 	 * @param UB
 	 */
-	public UndirectedGraphVarImpl(String name, Model solver, E LB, E UB) {
+	public DirectedGraphVarImpl(String name, Model solver, E LB, E UB) {
 		super(name, solver, LB, UB);
 	}
 
@@ -44,11 +44,11 @@ public class UndirectedGraphVarImpl<E extends UndirectedGraph> extends AbstractG
 	@Override
 	public boolean removeArc(int x, int y, ICause cause) throws ContradictionException {
 		assert cause != null;
-		if (LB.edgeExists(x, y)) {
-			this.contradiction(cause, "remove mandatory arc");
+		if (LB.arcExists(x, y)) {
+			this.contradiction(cause, "remove mandatory arc " + x + "->" + y);
 			return false;
 		}
-		if (UB.removeEdge(x, y)) {
+		if (UB.removeArc(x, y)) {
 			if (reactOnModification) {
 				delta.add(x, GraphDelta.AR_TAIL, cause);
 				delta.add(y, GraphDelta.AR_HEAD, cause);
@@ -65,8 +65,8 @@ public class UndirectedGraphVarImpl<E extends UndirectedGraph> extends AbstractG
 		assert cause != null;
 		enforceNode(x, cause);
 		enforceNode(y, cause);
-		if (UB.edgeExists(x, y)) {
-			if (LB.addEdge(x, y)) {
+		if (UB.arcExists(x, y)) {
+			if (LB.addArc(x, y)) {
 				if (reactOnModification) {
 					delta.add(x, GraphDelta.AE_TAIL, cause);
 					delta.add(y, GraphDelta.AE_HEAD, cause);

--- a/solver/src/main/java/org/chocosolver/solver/variables/impl/DirectedGraphVarImpl.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/impl/DirectedGraphVarImpl.java
@@ -42,18 +42,18 @@ public class DirectedGraphVarImpl<E extends DirectedGraph> extends AbstractGraph
 	//***********************************************************************************
 
 	@Override
-	public boolean removeArc(int x, int y, ICause cause) throws ContradictionException {
+	public boolean removeEdge(int x, int y, ICause cause) throws ContradictionException {
 		assert cause != null;
-		if (LB.arcExists(x, y)) {
-			this.contradiction(cause, "remove mandatory arc " + x + "->" + y);
+		if (LB.containsEdge(x, y)) {
+			this.contradiction(cause, "remove mandatory edge " + x + "->" + y);
 			return false;
 		}
-		if (UB.removeArc(x, y)) {
+		if (UB.removeEdge(x, y)) {
 			if (reactOnModification) {
-				delta.add(x, GraphDelta.AR_TAIL, cause);
-				delta.add(y, GraphDelta.AR_HEAD, cause);
+				delta.add(x, GraphDelta.EDGE_REMOVED_TAIL, cause);
+				delta.add(y, GraphDelta.EDGE_REMOVED_HEAD, cause);
 			}
-			GraphEventType e = GraphEventType.REMOVE_ARC;
+			GraphEventType e = GraphEventType.REMOVE_EDGE;
 			notifyPropagators(e, cause);
 			return true;
 		}
@@ -61,23 +61,23 @@ public class DirectedGraphVarImpl<E extends DirectedGraph> extends AbstractGraph
 	}
 
 	@Override
-	public boolean enforceArc(int x, int y, ICause cause) throws ContradictionException {
+	public boolean enforceEdge(int x, int y, ICause cause) throws ContradictionException {
 		assert cause != null;
 		enforceNode(x, cause);
 		enforceNode(y, cause);
-		if (UB.arcExists(x, y)) {
-			if (LB.addArc(x, y)) {
+		if (UB.containsEdge(x, y)) {
+			if (LB.addEdge(x, y)) {
 				if (reactOnModification) {
-					delta.add(x, GraphDelta.AE_TAIL, cause);
-					delta.add(y, GraphDelta.AE_HEAD, cause);
+					delta.add(x, GraphDelta.EDGE_ENFORCED_TAIL, cause);
+					delta.add(y, GraphDelta.EDGE_ENFORCED_HEAD, cause);
 				}
-				GraphEventType e = GraphEventType.ADD_ARC;
+				GraphEventType e = GraphEventType.ADD_EDGE;
 				notifyPropagators(e, cause);
 				return true;
 			}
 			return false;
 		}
-		this.contradiction(cause, "enforce arc which is not in the domain");
+		this.contradiction(cause, "enforce edge which is not in the domain");
 		return false;
 	}
 }

--- a/solver/src/main/java/org/chocosolver/solver/variables/impl/SetVarImpl.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/impl/SetVarImpl.java
@@ -275,10 +275,4 @@ public class SetVarImpl extends AbstractVariable implements SetVar {
             delta = new SetDelta(model.getEnvironment());
         }
     }
-
-    @Override
-    public SetDeltaMonitor monitorDelta(ICause propagator) {
-        createDelta();
-        return new SetDeltaMonitor(delta, propagator);
-    }
 }

--- a/solver/src/main/java/org/chocosolver/solver/variables/impl/UndirectedGraphVarImpl.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/impl/UndirectedGraphVarImpl.java
@@ -1,0 +1,110 @@
+/*
+ * This file is part of choco-solver, http://choco-solver.org/
+ *
+ * Copyright (c) 2021, IMT Atlantique. All rights reserved.
+ *
+ * Licensed under the BSD 4-clause license.
+ *
+ * See LICENSE file in the project root for full license information.
+ */
+package org.chocosolver.solver.variables.impl;
+
+import org.chocosolver.solver.variables.delta.GraphDelta;
+import org.chocosolver.solver.ICause;
+import org.chocosolver.solver.Model;
+import org.chocosolver.solver.exception.ContradictionException;
+import org.chocosolver.solver.variables.events.GraphEventType;
+import org.chocosolver.util.objects.graphs.UndirectedGraph;
+import org.chocosolver.util.objects.setDataStructures.ISet;
+
+public class UndirectedGraphVarImpl extends AbstractGraphVar<UndirectedGraph> {
+
+	//////////////////////////////// GRAPH PART /////////////////////////////////////////
+
+	//***********************************************************************************
+	// CONSTRUCTORS
+	//***********************************************************************************
+
+	/**
+	 * Creates a graph variable
+	 *
+	 * @param name
+	 * @param solver
+	 * @param LB
+	 * @param UB
+	 */
+	public UndirectedGraphVarImpl(String name, Model solver, UndirectedGraph LB, UndirectedGraph UB) {
+		super(name, solver, LB, UB);
+	}
+
+	//***********************************************************************************
+	// METHODS
+	//***********************************************************************************
+
+	@Override
+	public boolean removeArc(int x, int y, ICause cause) throws ContradictionException {
+		assert cause != null;
+		if (LB.edgeExists(x, y)) {
+			this.contradiction(cause, "remove mandatory arc");
+			return false;
+		}
+		if (UB.removeEdge(x, y)) {
+			if (reactOnModification) {
+				delta.add(x, GraphDelta.AR_TAIL, cause);
+				delta.add(y, GraphDelta.AR_HEAD, cause);
+			}
+			GraphEventType e = GraphEventType.REMOVE_ARC;
+			notifyPropagators(e, cause);
+			return true;
+		}
+		return false;
+	}
+
+	@Override
+	public boolean enforceArc(int x, int y, ICause cause) throws ContradictionException {
+		assert cause != null;
+		enforceNode(x, cause);
+		enforceNode(y, cause);
+		if (UB.edgeExists(x, y)) {
+			if (LB.addEdge(x, y)) {
+				if (reactOnModification) {
+					delta.add(x, GraphDelta.AE_TAIL, cause);
+					delta.add(y, GraphDelta.AE_HEAD, cause);
+				}
+				GraphEventType e = GraphEventType.ADD_ARC;
+				notifyPropagators(e, cause);
+				return true;
+			}
+			return false;
+		}
+		this.contradiction(cause, "enforce arc which is not in the domain");
+		return false;
+	}
+
+	/**
+	 * Get the set of neighbors of vertex 'idx' in the lower bound graph
+	 * (mandatory incident edges)
+	 *
+	 * @param idx a vertex
+	 * @return The set of neighbors of 'idx' in LB
+	 */
+	public ISet getMandNeighOf(int idx) {
+		return getMandSuccOrNeighOf(idx);
+	}
+
+	/**
+	 * Get the set of neighbors of vertex 'idx' in the upper bound graph
+	 * (potential incident edges)
+	 *
+	 * @param idx a vertex
+	 * @return The set of neighbors of 'idx' in UB
+	 */
+	public ISet getPotNeighOf(int idx) {
+		return getPotSuccOrNeighOf(idx);
+	}
+
+	@Override
+	public boolean isDirected() {
+		return false;
+	}
+}

--- a/solver/src/main/java/org/chocosolver/solver/variables/impl/UndirectedGraphVarImpl.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/impl/UndirectedGraphVarImpl.java
@@ -42,18 +42,18 @@ public class UndirectedGraphVarImpl<E extends UndirectedGraph> extends AbstractG
 	//***********************************************************************************
 
 	@Override
-	public boolean removeArc(int x, int y, ICause cause) throws ContradictionException {
+	public boolean removeEdge(int x, int y, ICause cause) throws ContradictionException {
 		assert cause != null;
-		if (LB.edgeExists(x, y)) {
-			this.contradiction(cause, "remove mandatory arc");
+		if (LB.containsEdge(x, y)) {
+			this.contradiction(cause, "remove mandatory edge");
 			return false;
 		}
 		if (UB.removeEdge(x, y)) {
 			if (reactOnModification) {
-				delta.add(x, GraphDelta.AR_TAIL, cause);
-				delta.add(y, GraphDelta.AR_HEAD, cause);
+				delta.add(x, GraphDelta.EDGE_REMOVED_TAIL, cause);
+				delta.add(y, GraphDelta.EDGE_REMOVED_HEAD, cause);
 			}
-			GraphEventType e = GraphEventType.REMOVE_ARC;
+			GraphEventType e = GraphEventType.REMOVE_EDGE;
 			notifyPropagators(e, cause);
 			return true;
 		}
@@ -61,23 +61,23 @@ public class UndirectedGraphVarImpl<E extends UndirectedGraph> extends AbstractG
 	}
 
 	@Override
-	public boolean enforceArc(int x, int y, ICause cause) throws ContradictionException {
+	public boolean enforceEdge(int x, int y, ICause cause) throws ContradictionException {
 		assert cause != null;
 		enforceNode(x, cause);
 		enforceNode(y, cause);
-		if (UB.edgeExists(x, y)) {
+		if (UB.containsEdge(x, y)) {
 			if (LB.addEdge(x, y)) {
 				if (reactOnModification) {
-					delta.add(x, GraphDelta.AE_TAIL, cause);
-					delta.add(y, GraphDelta.AE_HEAD, cause);
+					delta.add(x, GraphDelta.EDGE_ENFORCED_TAIL, cause);
+					delta.add(y, GraphDelta.EDGE_ENFORCED_HEAD, cause);
 				}
-				GraphEventType e = GraphEventType.ADD_ARC;
+				GraphEventType e = GraphEventType.ADD_EDGE;
 				notifyPropagators(e, cause);
 				return true;
 			}
 			return false;
 		}
-		this.contradiction(cause, "enforce arc which is not in the domain");
+		this.contradiction(cause, "enforce edge which is not in the domain");
 		return false;
 	}
 }

--- a/solver/src/main/java/org/chocosolver/solver/variables/impl/scheduler/GraphEvtScheduler.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/impl/scheduler/GraphEvtScheduler.java
@@ -1,0 +1,45 @@
+/*
+ * This file is part of choco-solver, http://choco-solver.org/
+ *
+ * Copyright (c) 2021, IMT Atlantique. All rights reserved.
+ *
+ * Licensed under the BSD 4-clause license.
+ *
+ * See LICENSE file in the project root for full license information.
+ */
+package org.chocosolver.solver.variables.impl.scheduler;
+
+import org.chocosolver.solver.variables.events.GraphEventType;
+import org.chocosolver.util.iterators.EvtScheduler;
+
+public class GraphEvtScheduler implements EvtScheduler<GraphEventType> {
+
+	private boolean done = true;
+
+	@Override
+	public void init(int mask) {
+		done = false;
+	}
+
+	@Override
+	public int select(int mask) {
+		return 0;
+	}
+
+	@Override
+	public boolean hasNext() {
+		return !done;
+	}
+
+	@Override
+	public int next() {
+		if (done) return 1;
+		done = true;
+		return 0;
+	}
+
+	@Override
+	public void remove() {
+		throw new UnsupportedOperationException();
+	}
+}

--- a/solver/src/main/java/org/chocosolver/solver/variables/view/GraphNeighSetView.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/view/GraphNeighSetView.java
@@ -1,0 +1,108 @@
+/*
+ * This file is part of choco-solver, http://choco-solver.org/
+ *
+ * Copyright (c) 2021, IMT Atlantique. All rights reserved.
+ *
+ * Licensed under the BSD 4-clause license.
+ *
+ * See LICENSE file in the project root for full license information.
+ */
+package org.chocosolver.solver.variables.view;
+
+import org.chocosolver.solver.ICause;
+import org.chocosolver.solver.exception.ContradictionException;
+import org.chocosolver.solver.variables.UndirectedGraphVar;
+import org.chocosolver.solver.variables.delta.IGraphDeltaMonitor;
+import org.chocosolver.solver.variables.events.IEventType;
+import org.chocosolver.solver.variables.events.SetEventType;
+import org.chocosolver.util.objects.setDataStructures.ISet;
+import org.chocosolver.util.procedure.IntProcedure;
+import org.chocosolver.util.procedure.PairProcedure;
+
+import java.util.Arrays;
+
+/**
+ * A GraphSetView representing the set of neighbors of a node in an undirected graph variable.
+ * If the node is removed from the graph envelope, the set is empty.
+ * @author Dimitri Justeau-Allaire
+ * @since 03/03/2021
+ */
+public class GraphNeighSetView extends GraphSetView<UndirectedGraphVar> {
+
+    protected int node;
+    protected IGraphDeltaMonitor gdm;
+    protected PairProcedure arcRemoved;
+    protected PairProcedure arcEnforced;
+
+    /**
+     * Create a set view on the neighbors of an undirected graph variable node.
+     *
+     * @param name name of the variable
+     * @param graphVar observed graph variable
+     * @param node index of the observed node
+     */
+    protected GraphNeighSetView(String name, UndirectedGraphVar graphVar, int node) {
+        super(name, graphVar);
+        this.node = node;
+        this.gdm = graphVar.monitorDelta(this);
+        this.arcRemoved = (from, to) -> {
+            if (from == node || to == node) {
+                notifyPropagators(SetEventType.REMOVE_FROM_ENVELOPE, this);
+            }
+        };
+        this.arcEnforced = (from, to) -> {
+            if (from == node || to == node) {
+                notifyPropagators(SetEventType.ADD_TO_KER, this);
+            }
+        };
+    }
+
+    @Override
+    public ISet getLB() {
+        return graphVar.getMandNeighOf(node);
+    }
+
+    @Override
+    public ISet getUB() {
+        return graphVar.getPotNeighOf(node);
+    }
+
+    @Override
+    public boolean instantiateTo(int[] value, ICause cause) throws ContradictionException {
+        boolean changed = !isInstantiated();
+        for (int i : value) {
+            force(i, cause);
+        }
+        if (getLB().size() != value.length) {
+            contradiction(cause, this.getName() + " cannot be instantiated to " + Arrays.toString(value));
+        }
+        if (getUB().size() != value.length) {
+            for (int i : getUB()) {
+                if (!getLB().contains(i)) {
+                    remove(i, cause);
+                }
+            }
+        }
+        return changed;
+    }
+
+    @Override
+    public boolean isInstantiated() {
+        return getLB().size() == getUB().size();
+    }
+
+    @Override
+    protected boolean doRemoveSetElement(int element) throws ContradictionException {
+        return graphVar.removeArc(node, element, this);
+    }
+
+    @Override
+    protected boolean doForceSetElement(int element) throws ContradictionException {
+        return graphVar.enforceArc(node, element, this);
+    }
+
+    @Override
+    public void notify(IEventType event) throws ContradictionException {
+//        gdm.freez
+    }
+}

--- a/solver/src/main/java/org/chocosolver/solver/variables/view/GraphNeighSetView.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/view/GraphNeighSetView.java
@@ -59,12 +59,12 @@ public class GraphNeighSetView extends GraphSetView<UndirectedGraphVar> {
 
     @Override
     public ISet getLB() {
-        return graphVar.getMandNeighOf(node);
+        return graphVar.getMandatoryNeighborsOf(node);
     }
 
     @Override
     public ISet getUB() {
-        return graphVar.getPotNeighOf(node);
+        return graphVar.getPotentialNeighborsOf(node);
     }
 
     @Override
@@ -93,21 +93,21 @@ public class GraphNeighSetView extends GraphSetView<UndirectedGraphVar> {
 
     @Override
     protected boolean doRemoveSetElement(int element) throws ContradictionException {
-        return graphVar.removeArc(node, element, this);
+        return graphVar.removeEdge(node, element, this);
     }
 
     @Override
     protected boolean doForceSetElement(int element) throws ContradictionException {
-        return graphVar.enforceArc(node, element, this);
+        return graphVar.enforceEdge(node, element, this);
     }
 
     @Override
     public void notify(IEventType event) throws ContradictionException {
-        if (event == GraphEventType.REMOVE_ARC) {
-            gdm.forEachArc(arcRemoved, GraphEventType.REMOVE_ARC);
+        if (event == GraphEventType.REMOVE_EDGE) {
+            gdm.forEachEdge(arcRemoved, GraphEventType.REMOVE_EDGE);
         }
-        if (event == GraphEventType.ADD_ARC) {
-            gdm.forEachArc(arcEnforced, GraphEventType.ADD_ARC);
+        if (event == GraphEventType.ADD_EDGE) {
+            gdm.forEachEdge(arcEnforced, GraphEventType.ADD_EDGE);
         }
     }
 }

--- a/solver/src/main/java/org/chocosolver/solver/variables/view/GraphNeighSetView.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/view/GraphNeighSetView.java
@@ -13,10 +13,10 @@ import org.chocosolver.solver.ICause;
 import org.chocosolver.solver.exception.ContradictionException;
 import org.chocosolver.solver.variables.UndirectedGraphVar;
 import org.chocosolver.solver.variables.delta.IGraphDeltaMonitor;
+import org.chocosolver.solver.variables.events.GraphEventType;
 import org.chocosolver.solver.variables.events.IEventType;
 import org.chocosolver.solver.variables.events.SetEventType;
 import org.chocosolver.util.objects.setDataStructures.ISet;
-import org.chocosolver.util.procedure.IntProcedure;
 import org.chocosolver.util.procedure.PairProcedure;
 
 import java.util.Arrays;
@@ -103,6 +103,11 @@ public class GraphNeighSetView extends GraphSetView<UndirectedGraphVar> {
 
     @Override
     public void notify(IEventType event) throws ContradictionException {
-//        gdm.freez
+        if (event == GraphEventType.REMOVE_ARC) {
+            gdm.forEachArc(arcRemoved, GraphEventType.REMOVE_ARC);
+        }
+        if (event == GraphEventType.ADD_ARC) {
+            gdm.forEachArc(arcEnforced, GraphEventType.ADD_ARC);
+        }
     }
 }

--- a/solver/src/main/java/org/chocosolver/solver/variables/view/GraphNodeSetView.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/view/GraphNodeSetView.java
@@ -1,0 +1,92 @@
+/*
+ * This file is part of choco-solver, http://choco-solver.org/
+ *
+ * Copyright (c) 2021, IMT Atlantique. All rights reserved.
+ *
+ * Licensed under the BSD 4-clause license.
+ *
+ * See LICENSE file in the project root for full license information.
+ */
+package org.chocosolver.solver.variables.view;
+
+import org.chocosolver.solver.ICause;
+import org.chocosolver.solver.exception.ContradictionException;
+import org.chocosolver.solver.variables.GraphVar;
+import org.chocosolver.solver.variables.events.GraphEventType;
+import org.chocosolver.solver.variables.events.IEventType;
+import org.chocosolver.solver.variables.events.SetEventType;
+import org.chocosolver.util.objects.setDataStructures.ISet;
+
+import java.util.Arrays;
+
+/**
+ * A GraphSetView representing the set of nodes of an observed graph variable.
+ * @author Dimitri Justeau-Allaire
+ * @since 02/03/2021
+ */
+public class GraphNodeSetView extends GraphSetView<GraphVar> {
+
+    /**
+     * Create a set view on the set of nodes of a graph variable.
+     *
+     * @param name     name of the variable
+     * @param graphVar observed graph variable
+     */
+    protected GraphNodeSetView(String name, GraphVar graphVar) {
+        super(name, graphVar);
+    }
+
+    @Override
+    public ISet getLB() {
+        return graphVar.getMandatoryNodes();
+    }
+
+    @Override
+    public ISet getUB() {
+        return graphVar.getPotentialNodes();
+    }
+
+    @Override
+    public boolean instantiateTo(int[] value, ICause cause) throws ContradictionException {
+        boolean changed = !isInstantiated();
+        for (int i : value) {
+            force(i, cause);
+        }
+        if (getLB().size() != value.length) {
+            contradiction(cause, this.getName() + " cannot be instantiated to " + Arrays.toString(value));
+        }
+        if (getUB().size() != value.length) {
+            for (int i : getUB()) {
+                if (!getLB().contains(i)) {
+                    remove(i, cause);
+                }
+            }
+        }
+        return changed;
+    }
+
+    @Override
+    protected boolean doRemoveSetElement(int element) throws ContradictionException {
+        return graphVar.removeNode(element, this);
+    }
+
+    @Override
+    protected boolean doForceSetElement(int element) throws ContradictionException {
+        return graphVar.enforceNode(element, this);
+    }
+
+    @Override
+    public void notify(IEventType event) throws ContradictionException {
+        if (event == GraphEventType.REMOVE_NODE) {
+            notifyPropagators(SetEventType.REMOVE_FROM_ENVELOPE, this);
+        }
+        if (event == GraphEventType.ADD_NODE) {
+            notifyPropagators(SetEventType.ADD_TO_KER, this);
+        }
+    }
+
+    @Override
+    public boolean isInstantiated() {
+        return getLB().size() == getUB().size();
+    }
+}

--- a/solver/src/main/java/org/chocosolver/solver/variables/view/GraphNodeSetView.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/view/GraphNodeSetView.java
@@ -27,13 +27,20 @@ import java.util.Arrays;
 public class GraphNodeSetView extends GraphSetView<GraphVar> {
 
     /**
-     * Create a set view on the set of nodes of a graph variable.
-     *
+     * Create a set view over the set of nodes of a graph variable.
      * @param name name of the variable
      * @param graphVar observed graph variable
      */
-    protected GraphNodeSetView(String name, GraphVar graphVar) {
+    public GraphNodeSetView(String name, GraphVar graphVar) {
         super(name, graphVar);
+    }
+
+    /**
+     * Creates a set view over the set of nodes of a graph variable.
+     * @param graphVar observed graph variable
+     */
+    public GraphNodeSetView(GraphVar graphVar) {
+        this("NODES(" + graphVar.getName() + ")", graphVar);
     }
 
     @Override

--- a/solver/src/main/java/org/chocosolver/solver/variables/view/GraphNodeSetView.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/view/GraphNodeSetView.java
@@ -29,7 +29,7 @@ public class GraphNodeSetView extends GraphSetView<GraphVar> {
     /**
      * Create a set view on the set of nodes of a graph variable.
      *
-     * @param name     name of the variable
+     * @param name name of the variable
      * @param graphVar observed graph variable
      */
     protected GraphNodeSetView(String name, GraphVar graphVar) {

--- a/solver/src/main/java/org/chocosolver/solver/variables/view/GraphPredecessorsSetView.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/view/GraphPredecessorsSetView.java
@@ -22,13 +22,13 @@ import org.chocosolver.util.procedure.PairProcedure;
 import java.util.Arrays;
 
 /**
- * A GraphSetView representing the set of successors of a node in a graph variable.
- * Note that if the graph variable is undirected, the set of successors is the set of neighbors.
+ * A GraphSetView representing the set of predecessors of a node in a graph variable.
+ * Note that if the graph variable is undirected, the set of predecessors is the set of neighbors.
  * If the node is removed from the graph envelope, the set is empty.
  * @author Dimitri Justeau-Allaire
  * @since 03/03/2021
  */
-public class GraphSuccessorsSetView extends GraphSetView<GraphVar> {
+public class GraphPredecessorsSetView extends GraphSetView<GraphVar> {
 
     protected int node;
     protected IGraphDeltaMonitor gdm;
@@ -36,12 +36,12 @@ public class GraphSuccessorsSetView extends GraphSetView<GraphVar> {
     protected PairProcedure arcEnforced;
 
     /**
-     * Create a set view over the successors of a graph variable node.
+     * Create a set view over the predecessors of a graph variable node.
      * @param name name of the variable
      * @param graphVar observed graph variable
      * @param node index of the observed node
      */
-    public GraphSuccessorsSetView(String name, GraphVar graphVar, int node) {
+    public GraphPredecessorsSetView(String name, GraphVar graphVar, int node) {
         super(name, graphVar);
         this.node = node;
         this.gdm = graphVar.monitorDelta(this);
@@ -58,22 +58,22 @@ public class GraphSuccessorsSetView extends GraphSetView<GraphVar> {
     }
 
     /**
-     * Create a set view over the successors of a graph variable node.
+     * Create a set view over the predecessors of a graph variable node.
      * @param graphVar observed graph variable
      * @param node index of the observed node
      */
-    public GraphSuccessorsSetView(GraphVar graphVar, int node) {
-        this("SUCCESSORS_OF(" + graphVar.getName() + ", " + node + ")", graphVar, node);
+    public GraphPredecessorsSetView(GraphVar graphVar, int node) {
+        this("PREDECESSORS_OF(" + graphVar.getName() + ", " + node + ")", graphVar, node);
     }
 
     @Override
     public ISet getLB() {
-        return graphVar.getMandatorySuccessorsOf(node);
+        return graphVar.getMandatoryPredecessorsOf(node);
     }
 
     @Override
     public ISet getUB() {
-        return graphVar.getPotentialSuccessorsOf(node);
+        return graphVar.getPotentialPredecessorOf(node);
     }
 
     @Override
@@ -102,12 +102,12 @@ public class GraphSuccessorsSetView extends GraphSetView<GraphVar> {
 
     @Override
     protected boolean doRemoveSetElement(int element) throws ContradictionException {
-        return graphVar.removeEdge(node, element, this);
+        return graphVar.removeEdge(element, node, this);
     }
 
     @Override
     protected boolean doForceSetElement(int element) throws ContradictionException {
-        return graphVar.enforceEdge(node, element, this);
+        return graphVar.enforceEdge(element, node, this);
     }
 
     @Override

--- a/solver/src/main/java/org/chocosolver/solver/variables/view/GraphSetView.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/view/GraphSetView.java
@@ -48,6 +48,7 @@ public abstract class GraphSetView<E extends GraphVar> extends AbstractVariable 
     protected GraphSetView(String name, E graphVar) {
         super(name, graphVar.getModel());
         this.graphVar = graphVar;
+        this.graphVar.subscribeView(this);
     }
 
     /**
@@ -144,7 +145,7 @@ public abstract class GraphSetView<E extends GraphVar> extends AbstractVariable 
     @Override
     public IntVar getCard() {
         if(!hasCard()){
-            int ubc =  getLB().size();
+            int ubc =  getUB().size();
             int lbc = getLB().size();
             if(ubc==lbc) cardinality = model.intVar(ubc);
             else{

--- a/solver/src/main/java/org/chocosolver/solver/variables/view/GraphSetView.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/view/GraphSetView.java
@@ -1,0 +1,111 @@
+/*
+ * This file is part of choco-solver, http://choco-solver.org/
+ *
+ * Copyright (c) 2021, IMT Atlantique. All rights reserved.
+ *
+ * Licensed under the BSD 4-clause license.
+ *
+ * See LICENSE file in the project root for full license information.
+ */
+package org.chocosolver.solver.variables.view;
+
+import org.chocosolver.solver.ICause;
+import org.chocosolver.solver.Model;
+import org.chocosolver.solver.exception.ContradictionException;
+import org.chocosolver.solver.learn.ExplanationForSignedClause;
+import org.chocosolver.solver.variables.GraphVar;
+import org.chocosolver.solver.variables.SetVar;
+import org.chocosolver.solver.variables.Variable;
+import org.chocosolver.solver.variables.delta.SetDelta;
+import org.chocosolver.solver.variables.events.IEventType;
+import org.chocosolver.solver.variables.events.IntEventType;
+import org.chocosolver.solver.variables.impl.AbstractVariable;
+import org.chocosolver.solver.variables.impl.scheduler.SetEvtScheduler;
+import org.chocosolver.util.iterators.EvtScheduler;
+
+/**
+ * An abstract class for set views over graph variables.
+ * @author Dimitri Justeau-Allaire
+ * @since 01/03/2021
+ */
+public abstract class GraphSetView<E extends GraphVar> extends AbstractVariable implements IView, SetVar {
+
+    protected E graphVar;
+    protected SetDelta delta;
+    protected boolean reactOnModification;
+
+    /**
+     * Create the shared data of any type of variable.
+     *
+     * @param name  name of the variable
+     * @param model model which declares this variable
+     */
+    protected GraphSetView(String name, Model model) {
+        super(name, model);
+    }
+
+    /**
+     * Action to execute on graph var when this view requires to remove an element from its upper bound
+     * @param element element to remove from the set view
+     * @return true if the observed graph variable has been modified
+     * @throws ContradictionException
+     */
+    protected abstract boolean doRemoveSetElement(int element) throws ContradictionException;
+
+    /**
+     * Action to execute on graph var when this view requires to force an element to its lower bound
+     * @param element element to force to the set view
+     * @return true if the observed graph variable has been modified
+     * @throws ContradictionException
+     */
+    protected abstract boolean doForceSetElement(int element) throws ContradictionException;
+
+    @Override
+    public boolean force(int element, ICause cause) throws ContradictionException {
+        return false;
+    }
+
+    @Override
+    public boolean remove(int element, ICause cause) throws ContradictionException {
+        return false;
+    }
+
+    @Override
+    public void createDelta() {
+        if (!reactOnModification) {
+            reactOnModification = true;
+            delta = new SetDelta(model.getEnvironment());
+        }
+    }
+
+    @Override
+    public int getTypeAndKind() {
+        return Variable.VIEW | Variable.SET;
+    }
+
+    @Override
+    protected EvtScheduler createScheduler() {
+        return new SetEvtScheduler();
+    }
+
+
+    @Override
+    public E getVariable() {
+        return graphVar;
+    }
+
+    @Override
+    public void justifyEvent(IntEventType mask, int one, int two, int three) {
+        throw new UnsupportedOperationException("GraphSetView does not support explanation.");
+    }
+
+    @Override
+    public void explain(int p, ExplanationForSignedClause clause) {
+        throw new UnsupportedOperationException("GraphSetView does not support explanation.");
+    }
+
+    @Override
+    public void notify(IEventType event) throws ContradictionException {
+
+    }
+}

--- a/solver/src/main/java/org/chocosolver/solver/variables/view/GraphSuccessorsSetView.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/view/GraphSuccessorsSetView.java
@@ -11,7 +11,7 @@ package org.chocosolver.solver.variables.view;
 
 import org.chocosolver.solver.ICause;
 import org.chocosolver.solver.exception.ContradictionException;
-import org.chocosolver.solver.variables.UndirectedGraphVar;
+import org.chocosolver.solver.variables.GraphVar;
 import org.chocosolver.solver.variables.delta.IGraphDeltaMonitor;
 import org.chocosolver.solver.variables.events.GraphEventType;
 import org.chocosolver.solver.variables.events.IEventType;
@@ -22,12 +22,13 @@ import org.chocosolver.util.procedure.PairProcedure;
 import java.util.Arrays;
 
 /**
- * A GraphSetView representing the set of neighbors of a node in an undirected graph variable.
+ * A GraphSetView representing the set of successors of a node in a graph variable.
+ * Note that if the graph variable is undirected, the set of successors is the set of neighbors.
  * If the node is removed from the graph envelope, the set is empty.
  * @author Dimitri Justeau-Allaire
  * @since 03/03/2021
  */
-public class GraphNeighSetView extends GraphSetView<UndirectedGraphVar> {
+public class GraphSuccessorsSetView extends GraphSetView<GraphVar> {
 
     protected int node;
     protected IGraphDeltaMonitor gdm;
@@ -41,7 +42,7 @@ public class GraphNeighSetView extends GraphSetView<UndirectedGraphVar> {
      * @param graphVar observed graph variable
      * @param node index of the observed node
      */
-    protected GraphNeighSetView(String name, UndirectedGraphVar graphVar, int node) {
+    protected GraphSuccessorsSetView(String name, GraphVar graphVar, int node) {
         super(name, graphVar);
         this.node = node;
         this.gdm = graphVar.monitorDelta(this);
@@ -59,12 +60,12 @@ public class GraphNeighSetView extends GraphSetView<UndirectedGraphVar> {
 
     @Override
     public ISet getLB() {
-        return graphVar.getMandatoryNeighborsOf(node);
+        return graphVar.getMandatorySuccessorsOf(node);
     }
 
     @Override
     public ISet getUB() {
-        return graphVar.getPotentialNeighborsOf(node);
+        return graphVar.getPotentialSuccessorsOf(node);
     }
 
     @Override

--- a/solver/src/main/java/org/chocosolver/solver/variables/view/IView.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/view/IView.java
@@ -51,4 +51,9 @@ public interface IView extends ICause, Variable {
      * @throws ContradictionException if a failure occurs
      */
     void notify(IEventType event) throws ContradictionException;
+
+    @Override
+    default boolean isInstantiated() {
+        return getVariable().isInstantiated();
+    }
 }

--- a/solver/src/main/java/org/chocosolver/solver/variables/view/IView.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/view/IView.java
@@ -52,8 +52,4 @@ public interface IView extends ICause, Variable {
      */
     void notify(IEventType event) throws ContradictionException;
 
-    @Override
-    default boolean isInstantiated() {
-        return getVariable().isInstantiated();
-    }
 }

--- a/solver/src/main/java/org/chocosolver/solver/variables/view/IView.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/view/IView.java
@@ -23,6 +23,10 @@ import org.chocosolver.solver.variables.events.IntEventType;
  * This is intend to replace very specific propagator such as equality.
  * <br/>
  *
+ * This is an implementation of domain views, as described in:
+ * Van Hentenryck P., Michel L. (2014) Domain Views for Constraint Programming
+ * https://link.springer.com/chapter/10.1007/978-3-319-10428-7_51
+ *
  * @author Charles Prud'homme
  * @since 26/08/11
  */

--- a/solver/src/main/java/org/chocosolver/solver/variables/view/IView.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/view/IView.java
@@ -11,14 +11,9 @@ package org.chocosolver.solver.variables.view;
 
 import org.chocosolver.solver.ICause;
 import org.chocosolver.solver.exception.ContradictionException;
-import org.chocosolver.solver.learn.ExplanationForSignedClause;
-import org.chocosolver.solver.variables.IntVar;
 import org.chocosolver.solver.variables.Variable;
 import org.chocosolver.solver.variables.events.IEventType;
 import org.chocosolver.solver.variables.events.IntEventType;
-import org.chocosolver.util.objects.setDataStructures.iterable.IntIterableRangeSet;
-
-import static org.chocosolver.util.objects.setDataStructures.iterable.IntIterableSetUtils.unionOf;
 
 /**
  * An interface to define views.
@@ -38,7 +33,7 @@ public interface IView extends ICause, Variable {
      *
      * @return variable observed
      */
-    IntVar getVariable();
+    Variable getVariable();
 
     /**
      * This methods is related to explanations, it binds an event occurring on the observed
@@ -56,14 +51,4 @@ public interface IView extends ICause, Variable {
      * @throws ContradictionException if a failure occurs
      */
     void notify(IEventType event) throws ContradictionException;
-
-    default void explain(int p, ExplanationForSignedClause explanation) {
-        IntVar pivot = explanation.readVar(p);
-        IntVar other = (this == pivot ? getVariable() : (IntVar)this);
-        IntIterableRangeSet dom = explanation.complement(other);
-        other.unionLit(dom, explanation);
-        dom = explanation.complement(pivot);
-        unionOf(dom, explanation.readDom(p));
-        pivot.intersectLit(dom, explanation);
-    }
 }

--- a/solver/src/main/java/org/chocosolver/solver/variables/view/IntBoolView.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/view/IntBoolView.java
@@ -15,9 +15,10 @@ import org.chocosolver.solver.exception.ContradictionException;
 import org.chocosolver.solver.variables.BoolVar;
 import org.chocosolver.solver.variables.IntVar;
 import org.chocosolver.solver.variables.Variable;
+import org.chocosolver.solver.variables.delta.NoDelta;
+import org.chocosolver.solver.variables.delta.IDelta;
 import org.chocosolver.solver.variables.delta.IEnumDelta;
 import org.chocosolver.solver.variables.delta.IIntDeltaMonitor;
-import org.chocosolver.solver.variables.delta.NoDelta;
 import org.chocosolver.solver.variables.delta.OneValueDelta;
 import org.chocosolver.solver.variables.delta.monitor.OneValueDeltaMonitor;
 import org.chocosolver.solver.variables.events.IEventType;
@@ -234,6 +235,11 @@ public abstract class IntBoolView extends IntView<IntVar> implements BoolVar{
             delta = new OneValueDelta(model.getEnvironment());
             reactOnRemoval = true;
         }
+    }
+
+    @Override
+    public IDelta getDelta() {
+        return delta;
     }
 
     @SuppressWarnings("unchecked")

--- a/solver/src/main/java/org/chocosolver/solver/variables/view/IntView.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/view/IntView.java
@@ -12,6 +12,7 @@ package org.chocosolver.solver.variables.view;
 
 import org.chocosolver.solver.ICause;
 import org.chocosolver.solver.exception.ContradictionException;
+import org.chocosolver.solver.learn.ExplanationForSignedClause;
 import org.chocosolver.solver.variables.IntVar;
 import org.chocosolver.solver.variables.Variable;
 import org.chocosolver.solver.variables.delta.IDelta;
@@ -27,6 +28,8 @@ import org.chocosolver.util.objects.setDataStructures.iterable.IntIterableSet;
 
 import java.util.Iterator;
 import java.util.function.Consumer;
+
+import static org.chocosolver.util.objects.setDataStructures.iterable.IntIterableSetUtils.unionOf;
 
 /**
  * "A view implements the same operations as a variable. A view stores a reference to a variable.
@@ -464,5 +467,16 @@ public abstract class IntView<I extends IntVar> extends AbstractVariable impleme
             throw new NullPointerException("getLit() called on null, a call to createLit(Implications) is required");
         }
         return this.literal;
+    }
+
+    @Override
+    public void explain(int p, ExplanationForSignedClause explanation) {
+        IntVar pivot = explanation.readVar(p);
+        IntVar other = (this == pivot ? getVariable() : this);
+        IntIterableRangeSet dom = explanation.complement(other);
+        other.unionLit(dom, explanation);
+        dom = explanation.complement(pivot);
+        unionOf(dom, explanation.readDom(p));
+        pivot.intersectLit(dom, explanation);
     }
 }

--- a/solver/src/main/java/org/chocosolver/solver/variables/view/IntView.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/view/IntView.java
@@ -385,11 +385,6 @@ public abstract class IntView<I extends IntVar> extends AbstractVariable impleme
         return var.hasEnumeratedDomain();
     }
 
-    @Override
-    public boolean isInstantiated() {
-        return var.isInstantiated();
-    }
-
 	@Override
     public IDelta getDelta() {
         return var.getDelta();
@@ -401,18 +396,8 @@ public abstract class IntView<I extends IntVar> extends AbstractVariable impleme
     }
 
     @Override
-    public int compareTo(Variable o) {
-        return this.getId() - o.getId();
-    }
-
-    @Override
     public void notify(IEventType event) throws ContradictionException {
         super.notifyPropagators(transformEvent(event), this);
-    }
-
-    @Override
-    public IEventType transformEvent(IEventType evt){
-        return evt;
     }
 
     @Override

--- a/solver/src/main/java/org/chocosolver/solver/variables/view/IntView.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/view/IntView.java
@@ -385,6 +385,11 @@ public abstract class IntView<I extends IntVar> extends AbstractVariable impleme
         return var.hasEnumeratedDomain();
     }
 
+    @Override
+    public boolean isInstantiated() {
+        return getVariable().isInstantiated();
+    }
+
 	@Override
     public IDelta getDelta() {
         return var.getDelta();

--- a/solver/src/main/java/org/chocosolver/util/graphOperations/connectivity/StrongConnectivityFinder.java
+++ b/solver/src/main/java/org/chocosolver/util/graphOperations/connectivity/StrongConnectivityFinder.java
@@ -99,7 +99,7 @@ public class StrongConnectivityFinder  {
 	private void findSingletons(BitSet restriction) {
 		ISet nodes = graph.getNodes();
 		for (int i = restriction.nextSetBit(0); i >= 0; i = restriction.nextSetBit(i + 1)) {
-			if (nodes.contains(i) && graph.getPredOf(i).size() * graph.getSuccOf(i).size() == 0) {
+			if (nodes.contains(i) && graph.getPredecessorsOf(i).size() * graph.getSuccessorsOf(i).size() == 0) {
 				nodeSCC[i] = nbSCC;
 				sccFirstNode[nbSCC++] = i;
 				restriction.clear(i);
@@ -125,7 +125,7 @@ public class StrongConnectivityFinder  {
 		stack[stackIdx++] = i;
 		inStack.set(i);
 		p[k] = k;
-		iterator[k] = graph.getSuccOf(start).iterator();
+		iterator[k] = graph.getSuccessorsOf(start).iterator();
 		int j;
 		// algo
 		while (true) {
@@ -138,7 +138,7 @@ public class StrongConnectivityFinder  {
 						dfsNumOfNode[j] = k;
 						p[k] = i;
 						i = k;
-						iterator[i] = graph.getSuccOf(j).iterator();
+						iterator[i] = graph.getSuccessorsOf(j).iterator();
 						stack[stackIdx++] = i;
 						inStack.set(i);
 						inf[i] = i;

--- a/solver/src/main/java/org/chocosolver/util/graphOperations/dominance/AbstractLengauerTarjanDominatorsFinder.java
+++ b/solver/src/main/java/org/chocosolver/util/graphOperations/dominance/AbstractLengauerTarjanDominatorsFinder.java
@@ -104,14 +104,14 @@ public abstract class AbstractLengauerTarjanDominatorsFinder {
 
 	protected void initParams(boolean inverseGraph) {
 		for (int i = 0; i < n; i++) {
-			T.getSuccOf(i).clear();
-			T.getPredOf(i).clear();
+			T.getSuccessorsOf(i).clear();
+			T.getPredecessorsOf(i).clear();
 			if (inverseGraph) {
-				succs[i] = g.getPredOf(i);
-				preds[i] = g.getSuccOf(i);
+				succs[i] = g.getPredecessorsOf(i);
+				preds[i] = g.getSuccessorsOf(i);
 			} else {
-				succs[i] = g.getSuccOf(i);
-				preds[i] = g.getPredOf(i);
+				succs[i] = g.getSuccessorsOf(i);
+				preds[i] = g.getPredecessorsOf(i);
 			}
 			semi[i] = -1;
 			ancestor[i] = -1;
@@ -191,7 +191,7 @@ public abstract class AbstractLengauerTarjanDominatorsFinder {
 			if (dom[w] != vertex[semi[w]]) {
 				dom[w] = dom[dom[w]];
 			}
-			T.addArc(dom[w], w);
+			T.addEdge(dom[w], w);
 		}
 		dom[root] = root;
 	}
@@ -256,7 +256,7 @@ public abstract class AbstractLengauerTarjanDominatorsFinder {
 		// semi     = out = closing time = postorder
 		for (int i = 0; i < n; i++) {
 			parent[i] = -1;
-			succs[i] = T.getSuccOf(i);
+			succs[i] = T.getSuccessorsOf(i);
 			iterator[i] = succs[i].iterator();
 		}
 		//PREPROCESSING

--- a/solver/src/main/java/org/chocosolver/util/objects/graphs/DirectedGraph.java
+++ b/solver/src/main/java/org/chocosolver/util/objects/graphs/DirectedGraph.java
@@ -16,7 +16,7 @@ import org.chocosolver.util.objects.setDataStructures.SetFactory;
 import org.chocosolver.util.objects.setDataStructures.SetType;
 
 /**
- * Directed graph implementation : arcs are indexed per endpoints
+ * Directed graph implementation : directed edges are indexed per endpoints
  * @author Jean-Guillaume Fages, Xavier Lorca
  */
 public class DirectedGraph implements IGraph {
@@ -30,7 +30,7 @@ public class DirectedGraph implements IGraph {
     private ISet nodes;
     private int n;
     private SetType nodeSetType;
-    private SetType arcSetType;
+    private SetType edgeSetType;
 
     //***********************************************************************************
     // CONSTRUCTORS
@@ -43,19 +43,19 @@ public class DirectedGraph implements IGraph {
      *
      * @param n        maximum number of nodes
      * @param nodeSetType     data structure to use for representing node
-     * @param arcSetType     data structure to use for representing node successors and predecessors
+     * @param edgeSetType     data structure to use for representing node successors and predecessors
      * @param allNodes true iff all nodes must always remain present in the graph.
 	 *                 i.e. The node set is fixed to [0,n-1] and will never change
      */
-    public DirectedGraph(int n, SetType nodeSetType, SetType arcSetType, boolean allNodes) {
+    public DirectedGraph(int n, SetType nodeSetType, SetType edgeSetType, boolean allNodes) {
         this.nodeSetType = nodeSetType;
-        this.arcSetType = arcSetType;
+        this.edgeSetType = edgeSetType;
         this.n = n;
         predecessors = new ISet[n];
         successors = new ISet[n];
         for (int i = 0; i < n; i++) {
-            predecessors[i] = SetFactory.makeSet(arcSetType, 0);
-            successors[i] = SetFactory.makeSet(arcSetType, 0);
+            predecessors[i] = SetFactory.makeSet(edgeSetType, 0);
+            successors[i] = SetFactory.makeSet(edgeSetType, 0);
         }
         if (allNodes) {
             this.nodes = SetFactory.makeConstantSet(0,n-1);
@@ -72,12 +72,12 @@ public class DirectedGraph implements IGraph {
      * Nodes are stored as BITSET
      *
      * @param n        maximum number of nodes
-     * @param arcSetType     data structure to use for representing node successors and predecessors
+     * @param edgeSetType     data structure to use for representing node successors and predecessors
      * @param allNodes true iff all nodes must always remain present in the graph.
      *                 i.e. The node set is fixed to [0,n-1] and will never change
      */
-    public DirectedGraph(int n, SetType arcSetType, boolean allNodes) {
-        this(n, SetType.BITSET, arcSetType, allNodes);
+    public DirectedGraph(int n, SetType edgeSetType, boolean allNodes) {
+        this(n, SetType.BITSET, edgeSetType, allNodes);
     }
 
 
@@ -89,18 +89,18 @@ public class DirectedGraph implements IGraph {
      * @param model   model providing the backtracking environment
      * @param n        maximum number of nodes
      * @param nodeSetType     data structure to use for representing nodes
-     * @param arcSetType     data structure to use for representing node successors and predecessors
+     * @param edgeSetType     data structure to use for representing node successors and predecessors
      * @param allNodes true iff all nodes must always remain present in the graph
      */
-    public DirectedGraph(Model model, int n, SetType nodeSetType, SetType arcSetType, boolean allNodes) {
+    public DirectedGraph(Model model, int n, SetType nodeSetType, SetType edgeSetType, boolean allNodes) {
         this.n = n;
         this.nodeSetType = nodeSetType;
-        this.arcSetType = arcSetType;
+        this.edgeSetType = edgeSetType;
         predecessors = new ISet[n];
         successors = new ISet[n];
         for (int i = 0; i < n; i++) {
-            predecessors[i] = SetFactory.makeStoredSet(arcSetType, 0, model);
-            successors[i] = SetFactory.makeStoredSet(arcSetType, 0, model);
+            predecessors[i] = SetFactory.makeStoredSet(edgeSetType, 0, model);
+            successors[i] = SetFactory.makeStoredSet(edgeSetType, 0, model);
         }
         if (allNodes) {
             this.nodes = SetFactory.makeConstantSet(0,n-1);
@@ -118,11 +118,11 @@ public class DirectedGraph implements IGraph {
      *
      * @param model   model providing the backtracking environment
      * @param n        maximum number of nodes
-     * @param arcSetType     data structure to use for representing node successors and predecessors
+     * @param edgeSetType     data structure to use for representing node successors and predecessors
      * @param allNodes true iff all nodes must always remain present in the graph
      */
-    public DirectedGraph(Model model, int n, SetType arcSetType, boolean allNodes) {
-        this(model, n, SetType.BITSET, arcSetType, allNodes);
+    public DirectedGraph(Model model, int n, SetType edgeSetType, boolean allNodes) {
+        this(model, n, SetType.BITSET, edgeSetType, allNodes);
     }
 
     //***********************************************************************************
@@ -154,8 +154,8 @@ public class DirectedGraph implements IGraph {
     }
 
     @Override
-    public SetType getArcSetType() {
-        return arcSetType;
+    public SetType getEdgeSetType() {
+        return edgeSetType;
     }
 
     @Override
@@ -189,13 +189,13 @@ public class DirectedGraph implements IGraph {
     }
 
     /**
-     * remove arc (from,to) from the graph
+     * remove directed edge (from,to) from the graph
      *
      * @param from a node index
      * @param to   a node index
-     * @return true iff arc (from,to) was in the graph
+     * @return true iff directed edge (from,to) was in the graph
      */
-    public boolean removeArc(int from, int to) {
+    public boolean removeEdge(int from, int to) {
         if (successors[from].contains(to)) {
             assert (predecessors[to].contains(from)) : "incoherent directed graph";
             return successors[from].remove(to) | predecessors[to].remove(from);
@@ -204,13 +204,13 @@ public class DirectedGraph implements IGraph {
     }
 
     /**
-     * Test whether arc (from,to) exists or not in the graph
+     * Test whether directed edge (from,to) exists or not in the graph
      *
      * @param from a node index
      * @param to   a node index
-     * @return true iff arc (from,to) exists in the graph
+     * @return true iff directed edge (from,to) exists in the graph
      */
-    public boolean arcExists(int from, int to) {
+    public boolean containsEdge(int from, int to) {
         if (successors[from].contains(to)) {
             assert (predecessors[to].contains(from)) : "incoherent directed graph";
             return true;
@@ -219,23 +219,18 @@ public class DirectedGraph implements IGraph {
     }
 
     @Override
-    public boolean isArcOrEdge(int from, int to) {
-        return arcExists(from, to);
-    }
-
-    @Override
     public boolean isDirected() {
         return true;
     }
 
     /**
-     * add arc (from,to) to the graph
+     * add directed edge (from,to) to the graph
      *
      * @param from a node index
      * @param to   a node index
-     * @return true iff arc (from,to) was not already in the graph
+     * @return true iff directed edge (from,to) was not already in the graph
      */
-    public boolean addArc(int from, int to) {
+    public boolean addEdge(int from, int to) {
         addNode(from);
         addNode(to);
         if (!successors[from].contains(to)) {
@@ -251,12 +246,7 @@ public class DirectedGraph implements IGraph {
      * @param x node index
      * @return successors of x
      */
-    public ISet getSuccOf(int x) {
-        return successors[x];
-    }
-
-    @Override
-    public ISet getSuccOrNeighOf(int x) {
+    public ISet getSuccessorsOf(int x) {
         return successors[x];
     }
 
@@ -266,12 +256,8 @@ public class DirectedGraph implements IGraph {
      * @param x node index
      * @return predecessors of x
      */
-    public ISet getPredOf(int x) {
+    public ISet getPredecessorsOf(int x) {
         return predecessors[x];
     }
 
-    @Override
-    public ISet getPredOrNeighOf(int x) {
-        return predecessors[x];
-    }
 }

--- a/solver/src/main/java/org/chocosolver/util/objects/graphs/DirectedGraph.java
+++ b/solver/src/main/java/org/chocosolver/util/objects/graphs/DirectedGraph.java
@@ -29,7 +29,8 @@ public class DirectedGraph implements IGraph {
     private ISet[] predecessors;
     private ISet nodes;
     private int n;
-    private SetType type;
+    private SetType nodeSetType;
+    private SetType arcSetType;
 
     //***********************************************************************************
     // CONSTRUCTORS
@@ -41,25 +42,44 @@ public class DirectedGraph implements IGraph {
      * unless allNodes is true).
      *
      * @param n        maximum number of nodes
-     * @param type     data structure to use for representing node successors and predecessors
+     * @param nodeSetType     data structure to use for representing node
+     * @param arcSetType     data structure to use for representing node successors and predecessors
      * @param allNodes true iff all nodes must always remain present in the graph.
 	 *                 i.e. The node set is fixed to [0,n-1] and will never change
      */
-    public DirectedGraph(int n, SetType type, boolean allNodes) {
-        this.type = type;
+    public DirectedGraph(int n, SetType nodeSetType, SetType arcSetType, boolean allNodes) {
+        this.nodeSetType = nodeSetType;
+        this.arcSetType = arcSetType;
         this.n = n;
         predecessors = new ISet[n];
         successors = new ISet[n];
         for (int i = 0; i < n; i++) {
-            predecessors[i] = SetFactory.makeSet(type, 0);
-            successors[i] = SetFactory.makeSet(type, 0);
+            predecessors[i] = SetFactory.makeSet(arcSetType, 0);
+            successors[i] = SetFactory.makeSet(arcSetType, 0);
         }
         if (allNodes) {
             this.nodes = SetFactory.makeConstantSet(0,n-1);
         } else {
-            this.nodes = SetFactory.makeBitSet(0);
+            this.nodes = SetFactory.makeSet(nodeSetType, 0);
         }
     }
+
+    /**
+     * Creates an empty graph.
+     * Allocates memory for n nodes (but they should then be added explicitly,
+     * unless allNodes is true).
+     *
+     * Nodes are stored as BITSET
+     *
+     * @param n        maximum number of nodes
+     * @param arcSetType     data structure to use for representing node successors and predecessors
+     * @param allNodes true iff all nodes must always remain present in the graph.
+     *                 i.e. The node set is fixed to [0,n-1] and will never change
+     */
+    public DirectedGraph(int n, SetType arcSetType, boolean allNodes) {
+        this(n, SetType.BITSET, arcSetType, allNodes);
+    }
+
 
     /**
      * Creates an empty backtrable graph of n nodes
@@ -68,23 +88,41 @@ public class DirectedGraph implements IGraph {
      *
      * @param model   model providing the backtracking environment
      * @param n        maximum number of nodes
-     * @param type     data structure to use for representing node successors and predecessors
+     * @param nodeSetType     data structure to use for representing nodes
+     * @param arcSetType     data structure to use for representing node successors and predecessors
      * @param allNodes true iff all nodes must always remain present in the graph
      */
-    public DirectedGraph(Model model, int n, SetType type, boolean allNodes) {
+    public DirectedGraph(Model model, int n, SetType nodeSetType, SetType arcSetType, boolean allNodes) {
         this.n = n;
-        this.type = type;
+        this.nodeSetType = nodeSetType;
+        this.arcSetType = arcSetType;
         predecessors = new ISet[n];
         successors = new ISet[n];
         for (int i = 0; i < n; i++) {
-            predecessors[i] = SetFactory.makeStoredSet(type, 0, model);
-            successors[i] = SetFactory.makeStoredSet(type, 0, model);
+            predecessors[i] = SetFactory.makeStoredSet(arcSetType, 0, model);
+            successors[i] = SetFactory.makeStoredSet(arcSetType, 0, model);
         }
         if (allNodes) {
             this.nodes = SetFactory.makeConstantSet(0,n-1);
         } else {
-            this.nodes = SetFactory.makeStoredSet(SetType.BITSET, 0, model);
+            this.nodes = SetFactory.makeStoredSet(nodeSetType, 0, model);
         }
+    }
+
+    /**
+     * Creates an empty backtrable graph of n nodes
+     * Allocates memory for n nodes (but they should then be added explicitly,
+     * unless allNodes is true).
+     *
+     * Nodes are stored as BITSET
+     *
+     * @param model   model providing the backtracking environment
+     * @param n        maximum number of nodes
+     * @param arcSetType     data structure to use for representing node successors and predecessors
+     * @param allNodes true iff all nodes must always remain present in the graph
+     */
+    public DirectedGraph(Model model, int n, SetType arcSetType, boolean allNodes) {
+        this(model, n, SetType.BITSET, arcSetType, allNodes);
     }
 
     //***********************************************************************************
@@ -116,8 +154,13 @@ public class DirectedGraph implements IGraph {
     }
 
     @Override
-    public SetType getType() {
-        return type;
+    public SetType getArcSetType() {
+        return arcSetType;
+    }
+
+    @Override
+    public SetType getNodeSetType() {
+        return nodeSetType;
     }
 
     @Override

--- a/solver/src/main/java/org/chocosolver/util/objects/graphs/GraphFactory.java
+++ b/solver/src/main/java/org/chocosolver/util/objects/graphs/GraphFactory.java
@@ -1,0 +1,57 @@
+/*
+ * This file is part of choco-solver, http://choco-solver.org/
+ *
+ * Copyright (c) 2021, IMT Atlantique. All rights reserved.
+ *
+ * Licensed under the BSD 4-clause license.
+ *
+ * See LICENSE file in the project root for full license information.
+ */
+package org.chocosolver.util.objects.graphs;
+
+import org.chocosolver.solver.Model;
+import org.chocosolver.util.objects.setDataStructures.SetType;
+
+/**
+ * Factory for creating graph data structures.
+ * @author Dimitri Justeau-Allaire
+ * @since 02/03/2021
+ */
+public class GraphFactory {
+
+    /**
+     * Return an empty stored undirected graph.
+     * @param model The choco model
+     * @param n the maximum number of nodes
+     * @param nodeSetType set type for storing nodes
+     * @param arcSetType set type for storing arcs
+     * @return an empty stored undirected graph.
+     */
+    public static UndirectedGraph makeEmptyStoredGraph(Model model, int n, SetType nodeSetType, SetType arcSetType) {
+        return new UndirectedGraph(model, n, nodeSetType, arcSetType, false);
+    }
+
+    /**
+     * Return a complete (all nodes and all arcs, no loops) stored undirected graph.
+     * @param model The choco model
+     * @param n the maximum number of nodes
+     * @param nodeSetType set type for storing nodes
+     * @param arcSetType set type for storing arcs
+     * @param allNodesFixed if true all nodes are fixed to the graph (cannod be removed)
+     * @return an complete (all nodes, all arcs, no loops) stored undirected graph.
+     */
+    public static UndirectedGraph makeCompleteStoredGraph(Model model, int n, SetType nodeSetType, SetType arcSetType, boolean allNodesFixed) {
+        UndirectedGraph g = new UndirectedGraph(model, n, nodeSetType, arcSetType, allNodesFixed);
+        if (!allNodesFixed) {
+            for (int i = 0; i < n; i++) {
+                g.addNode(i);
+            }
+        }
+        for (int i = 0; i < n; i++) {
+            for (int j = i + 1; j < n; j++) {
+                g.addEdge(i, j);
+            }
+        }
+        return g;
+    }
+}

--- a/solver/src/main/java/org/chocosolver/util/objects/graphs/GraphFactory.java
+++ b/solver/src/main/java/org/chocosolver/util/objects/graphs/GraphFactory.java
@@ -20,15 +20,65 @@ import org.chocosolver.util.objects.setDataStructures.SetType;
 public class GraphFactory {
 
     /**
-     * Return an empty stored undirected graph.
+     * Return an EMPTY stored undirected graph.
      * @param model The choco model
      * @param n the maximum number of nodes
      * @param nodeSetType set type for storing nodes
      * @param arcSetType set type for storing arcs
      * @return an empty stored undirected graph.
      */
-    public static UndirectedGraph makeEmptyStoredGraph(Model model, int n, SetType nodeSetType, SetType arcSetType) {
+    public static UndirectedGraph makeStoredUndirectedGraph(Model model, int n, SetType nodeSetType, SetType arcSetType) {
         return new UndirectedGraph(model, n, nodeSetType, arcSetType, false);
+    }
+
+    /**
+     * Return an EMPTY stored directed graph.
+     * @param model The choco model
+     * @param n the maximum number of nodes
+     * @param nodeSetType set type for storing nodes
+     * @param arcSetType set type for storing arcs
+     * @return an empty stored directed graph.
+     */
+    public static DirectedGraph makeStoredDirectedGraph(Model model, int n, SetType nodeSetType, SetType arcSetType) {
+        return new DirectedGraph(model, n, nodeSetType, arcSetType, false);
+    }
+
+    /**
+     * Return a stored undirected graph with all nodes (no arcs) from 0 to n-1.
+     * @param model The choco model
+     * @param n the maximum number of nodes
+     * @param nodeSetType set type for storing nodes
+     * @param arcSetType set type for storing arcs
+     * @param allNodesFixed if true all nodes are fixed to the graph (cannod be removed)
+     * @return a stored undirected graph with all nodes (no arcs) from 0 to n-1.
+     */
+    public static UndirectedGraph makeStoredAllNodesUndirectedGraph(Model model, int n, SetType nodeSetType, SetType arcSetType, boolean allNodesFixed) {
+        UndirectedGraph g = new UndirectedGraph(model, n, nodeSetType, arcSetType, allNodesFixed);
+        if (!allNodesFixed) {
+            for (int i = 0; i < n; i++) {
+                g.addNode(i);
+            }
+        }
+        return g;
+    }
+
+    /**
+     * Return a stored directed graph with all nodes (no arcs) from 0 to n-1.
+     * @param model The choco model
+     * @param n the maximum number of nodes
+     * @param nodeSetType set type for storing nodes
+     * @param arcSetType set type for storing arcs
+     * @param allNodesFixed if true all nodes are fixed to the graph (cannod be removed)
+     * @return a stored directed graph with all nodes (no arcs) from 0 to n-1.
+     */
+    public static DirectedGraph makeStoredAllNodesDirectedGraph(Model model, int n, SetType nodeSetType, SetType arcSetType, boolean allNodesFixed) {
+        DirectedGraph g = new DirectedGraph(model, n, nodeSetType, arcSetType, allNodesFixed);
+        if (!allNodesFixed) {
+            for (int i = 0; i < n; i++) {
+                g.addNode(i);
+            }
+        }
+        return g;
     }
 
     /**
@@ -38,10 +88,29 @@ public class GraphFactory {
      * @param nodeSetType set type for storing nodes
      * @param arcSetType set type for storing arcs
      * @param allNodesFixed if true all nodes are fixed to the graph (cannod be removed)
-     * @return an complete (all nodes, all arcs, no loops) stored undirected graph.
+     * @return a complete (all nodes, all arcs, no loops) stored undirected graph.
      */
-    public static UndirectedGraph makeCompleteStoredGraph(Model model, int n, SetType nodeSetType, SetType arcSetType, boolean allNodesFixed) {
-        UndirectedGraph g = new UndirectedGraph(model, n, nodeSetType, arcSetType, allNodesFixed);
+    public static UndirectedGraph makeCompleteStoredUndirectedGraph(Model model, int n, SetType nodeSetType, SetType arcSetType, boolean allNodesFixed) {
+        UndirectedGraph g = makeStoredAllNodesUndirectedGraph(model, n, nodeSetType, arcSetType, allNodesFixed);
+        for (int i = 0; i < n; i++) {
+            for (int j = i + 1; j < n; j++) {
+                g.addEdge(i, j);
+            }
+        }
+        return g;
+    }
+
+    /**
+     * Return a complete (all nodes and all arcs, no loops) stored directed graph.
+     * @param model The choco model
+     * @param n the maximum number of nodes
+     * @param nodeSetType set type for storing nodes
+     * @param arcSetType set type for storing arcs
+     * @param allNodesFixed if true all nodes are fixed to the graph (cannod be removed)
+     * @return a complete (all nodes, all arcs, no loops) stored directed graph.
+     */
+    public static DirectedGraph makeCompleteStoredDirectedGraph(Model model, int n, SetType nodeSetType, SetType arcSetType, boolean allNodesFixed) {
+        DirectedGraph g = makeStoredAllNodesDirectedGraph(model, n, nodeSetType, arcSetType, allNodesFixed);
         if (!allNodesFixed) {
             for (int i = 0; i < n; i++) {
                 g.addNode(i);
@@ -49,7 +118,8 @@ public class GraphFactory {
         }
         for (int i = 0; i < n; i++) {
             for (int j = i + 1; j < n; j++) {
-                g.addEdge(i, j);
+                g.addArc(i, j);
+                g.addArc(j, i);
             }
         }
         return g;

--- a/solver/src/main/java/org/chocosolver/util/objects/graphs/GraphFactory.java
+++ b/solver/src/main/java/org/chocosolver/util/objects/graphs/GraphFactory.java
@@ -118,8 +118,8 @@ public class GraphFactory {
         }
         for (int i = 0; i < n; i++) {
             for (int j = i + 1; j < n; j++) {
-                g.addArc(i, j);
-                g.addArc(j, i);
+                g.addEdge(i, j);
+                g.addEdge(j, i);
             }
         }
         return g;

--- a/solver/src/main/java/org/chocosolver/util/objects/graphs/IGraph.java
+++ b/solver/src/main/java/org/chocosolver/util/objects/graphs/IGraph.java
@@ -51,12 +51,18 @@ public interface IGraph  {
     int getNbMaxNodes();
 
     /**
-     * Get the type of data structures used in the graph
-	 *
-     * @return the type of data structures used in the graph
+     * Get the type of data structures used in the graph to represent nodes
+     *
+     * @return the type of data structures used in the graph to represent nodes
      */
-    SetType getType();
+    SetType getNodeSetType();
 
+    /**
+     * Get the type of data structures used in the graph to represent arcs
+	 *
+     * @return the type of data structures used in the graph to represent arcs
+     */
+    SetType getArcSetType();
 
     /**
      * Get either x's successors or neighbors.

--- a/solver/src/main/java/org/chocosolver/util/objects/graphs/IGraph.java
+++ b/solver/src/main/java/org/chocosolver/util/objects/graphs/IGraph.java
@@ -16,6 +16,25 @@ import org.chocosolver.util.objects.setDataStructures.SetType;
  * @author Jean-Guillaume Fages, Xavier Lorca
  *         <p/>
  *         Provide an interface for the graph manipulation
+ *
+ * --- GRAPH API REFACTORING 04/03/2021 ---
+ *
+ * - The semantic distinction between arcs and edges has been removed for more clarity. If the graph is undirected,
+ *      edges are undirected, if the graph is directed, the graph is directed. Methods related to edges are
+ *      `addEdge`, `removeEdge`, and `containsEdge`.
+ *
+ * - The object model is such that the more abstract interface specifies directed graph accessors on edges,
+ *      `getSuccessorsOf` and `getPredecessorsOf`. When the graph is undirected, the method `getNeighborsOf` is
+ *      available. Note that an undirected graph is equivalent to a directed graph with couples of opposite
+ *      directed edges. Thus, the neighbors of a node in an undirected graph are both successors and predecessors,
+ *      and this is why these methods are equivalent to getNeighbors in the case of an undirected graph. To encourage
+ *      unambiguous use and facilitate code reading, the successors and predecessors related method have been defined
+ *      as deprecated in explicit uses of UndirectedGraphs.
+ *
+ *  - The possibility to chose (in constructors) and get the set data structure for nodes has also been added,
+ *      as it was only implemented for neighbors: `getNodeSetType` and `getEdgeSetType`. The previous default behaviour
+ *      has been conserved with default constructors.
+ *
  */
 public interface IGraph  {
 

--- a/solver/src/main/java/org/chocosolver/util/objects/graphs/IGraph.java
+++ b/solver/src/main/java/org/chocosolver/util/objects/graphs/IGraph.java
@@ -42,6 +42,24 @@ public interface IGraph  {
     boolean removeNode(int x);
 
     /**
+     * Add edge (x,y) to the graph
+     *
+     * @param x a node index
+     * @param y a node index
+     * @return true iff (x,y) was not already in the graph
+     */
+    boolean addEdge(int x, int y);
+
+    /**
+     * Remove edge (x,y) from the graph
+     *
+     * @param x a node index
+     * @param y a node index
+     * @return true iff (x,y) was in the graph
+     */
+    boolean removeEdge(int x, int y);
+
+    /**
      * The maximum number of nodes in the graph
 	 * Vertices of the graph belong to [0,getNbMaxNodes()-1]
 	 * This quantity is fixed at the creation of the graph
@@ -58,11 +76,11 @@ public interface IGraph  {
     SetType getNodeSetType();
 
     /**
-     * Get the type of data structures used in the graph to represent arcs
+     * Get the type of data structures used in the graph to represent edges
 	 *
-     * @return the type of data structures used in the graph to represent arcs
+     * @return the type of data structures used in the graph to represent edges
      */
-    SetType getArcSetType();
+    SetType getEdgeSetType();
 
     /**
      * Get either x's successors or neighbors.
@@ -73,7 +91,7 @@ public interface IGraph  {
      * @return x's successors if <code>this</code> is directed
      *         x's neighbors otherwise
      */
-    ISet getSuccOrNeighOf(int x);
+    ISet getSuccessorsOf(int x);
 
     /**
      * Get either x's predecessors or neighbors.
@@ -84,11 +102,11 @@ public interface IGraph  {
      * @return x's predecessors if <code>this</code> is directed
      *         x's neighbors otherwise
      */
-    ISet getPredOrNeighOf(int x);
+    ISet getPredecessorsOf(int x);
 
     /**
      * If <code>this </code> is directed
-     * returns true if and only if arc (x,y) exists
+     * returns true if and only if directed edge (x,y) exists
      * Else, if <code>this</code> is undirected
      * returns true if and only if edge (x,y) exists
      * <p/>
@@ -97,7 +115,17 @@ public interface IGraph  {
      * @param x a node index
      * @param y a node index
      */
-    boolean isArcOrEdge(int x, int y);
+    default boolean containsEdge(int x, int y) {
+        return getSuccessorsOf(x).contains(y);
+    }
+
+    /**
+     * @param x a node index
+     * @return True iff the graph contains the node x
+     */
+    default boolean containsNode(int x) {
+        return getNodes().contains(x);
+    }
 
     /**
      * @return true if and only if <code>this</code> is a directed graph
@@ -121,7 +149,7 @@ public interface IGraph  {
         for (int i : getNodes()) sb.append(i + " ");
         sb.append(";\n");
         for (int i : getNodes()) {
-            for (int j : getSuccOrNeighOf(i)) {
+            for (int j : getSuccessorsOf(i)) {
                 if (directed || i < j) sb.append(i + arc + j + " ;\n");
             }
         }

--- a/solver/src/main/java/org/chocosolver/util/objects/graphs/UndirectedGraph.java
+++ b/solver/src/main/java/org/chocosolver/util/objects/graphs/UndirectedGraph.java
@@ -29,7 +29,7 @@ public class UndirectedGraph implements IGraph {
     private ISet[] neighbors;
     private ISet nodes;
     private int n;
-    private SetType arcSetType;
+    private SetType edgeSetType;
     private SetType nodeSetType;
 
     //***********************************************************************************
@@ -44,16 +44,16 @@ public class UndirectedGraph implements IGraph {
      * @param model   model providing the backtracking environment
      * @param n        max number of nodes
      * @param nodeSetType     data structure storing for nodes
-     * @param arcSetType     data structure storing for node neighbors
+     * @param edgeSetType     data structure storing for node neighbors
      * @param allNodes true iff all nodes will always remain in the graph
      */
-    public UndirectedGraph(Model model, int n, SetType nodeSetType, SetType arcSetType, boolean allNodes) {
-        this.arcSetType = arcSetType;
+    public UndirectedGraph(Model model, int n, SetType nodeSetType, SetType edgeSetType, boolean allNodes) {
+        this.edgeSetType = edgeSetType;
         this.nodeSetType = nodeSetType;
         this.n = n;
         neighbors = new ISet[n];
         for (int i = 0; i < n; i++) {
-            neighbors[i] = SetFactory.makeStoredSet(this.arcSetType, 0, model);
+            neighbors[i] = SetFactory.makeStoredSet(this.edgeSetType, 0, model);
         }
         if (allNodes) {
             this.nodes = SetFactory.makeConstantSet(0,n-1);
@@ -71,11 +71,11 @@ public class UndirectedGraph implements IGraph {
      *
      * @param model   model providing the backtracking environment
      * @param n        max number of nodes
-     * @param arcSetType     data structure storing for node neighbors
+     * @param edgeSetType     data structure storing for node neighbors
      * @param allNodes true iff all nodes will always remain in the graph
      */
-    public UndirectedGraph(Model model, int n, SetType arcSetType, boolean allNodes) {
-        this(model, n, SetType.BITSET, arcSetType, allNodes);
+    public UndirectedGraph(Model model, int n, SetType edgeSetType, boolean allNodes) {
+        this(model, n, SetType.BITSET, edgeSetType, allNodes);
     }
 
     /**
@@ -85,16 +85,16 @@ public class UndirectedGraph implements IGraph {
      *
      * @param n        max number of nodes
      * @param nodeSetType     data structure storing for nodes
-     * @param arcSetType     data structure used for storing node neighbors
+     * @param edgeSetType     data structure used for storing node neighbors
      * @param allNodes true iff all nodes will always remain in the graph
      */
-    public UndirectedGraph(int n, SetType nodeSetType, SetType arcSetType, boolean allNodes) {
-        this.arcSetType = arcSetType;
+    public UndirectedGraph(int n, SetType nodeSetType, SetType edgeSetType, boolean allNodes) {
+        this.edgeSetType = edgeSetType;
         this.nodeSetType = nodeSetType;
         this.n = n;
         neighbors = new ISet[n];
         for (int i = 0; i < n; i++) {
-            neighbors[i] = SetFactory.makeSet(arcSetType, 0);
+            neighbors[i] = SetFactory.makeSet(edgeSetType, 0);
         }
         if (allNodes) {
             this.nodes = SetFactory.makeConstantSet(0,n-1);
@@ -111,11 +111,11 @@ public class UndirectedGraph implements IGraph {
      * Nodes are stored as BITSET
      *
      * @param n        max number of nodes
-     * @param arcSetType     data structure used for storing node neighbors
+     * @param edgeSetType     data structure used for storing node neighbors
      * @param allNodes true iff all nodes will always remain in the graph
      */
-    public UndirectedGraph(int n, SetType arcSetType, boolean allNodes) {
-        this(n, SetType.BITSET, arcSetType, allNodes);
+    public UndirectedGraph(int n, SetType edgeSetType, boolean allNodes) {
+        this(n, SetType.BITSET, edgeSetType, allNodes);
     }
 
     //***********************************************************************************
@@ -156,8 +156,8 @@ public class UndirectedGraph implements IGraph {
     /**
      * @inheritedDoc
      */
-    public SetType getArcSetType() {
-        return arcSetType;
+    public SetType getEdgeSetType() {
+        return edgeSetType;
     }
 
     @Override
@@ -176,7 +176,7 @@ public class UndirectedGraph implements IGraph {
     @Override
     public boolean removeNode(int x) {
         if (nodes.remove(x)) {
-            ISetIterator nei = getNeighOf(x).iterator();
+            ISetIterator nei = getNeighborsOf(x).iterator();
             while (nei.hasNext()) {
                 neighbors[nei.nextInt()].remove(x);
             }
@@ -214,17 +214,12 @@ public class UndirectedGraph implements IGraph {
      * @param y a node index
      * @return true iff edge (x,y) is in the graph
      */
-    public boolean edgeExists(int x, int y) {
+    public boolean containsEdge(int x, int y) {
         if (neighbors[x].contains(y)) {
             assert (neighbors[y].contains(x)) : "asymmetric adjacency matrix in an undirected graph";
             return true;
         }
         return false;
-    }
-
-    @Override
-    public boolean isArcOrEdge(int x, int y) {
-        return edgeExists(x, y);
     }
 
     /**
@@ -254,17 +249,25 @@ public class UndirectedGraph implements IGraph {
      * @param x node index
      * @return neighbors of x (predecessors and/or successors)
      */
-    public ISet getNeighOf(int x) {
+    public ISet getNeighborsOf(int x) {
         return neighbors[x];
     }
 
+    /**
+     * @deprecated For an undirected graph, this method is equivalent to getNeighborsOf.
+     */
+    @Deprecated
     @Override
-    public ISet getPredOrNeighOf(int x) {
+    public ISet getPredecessorsOf(int x) {
         return neighbors[x];
     }
 
+    /**
+     * @deprecated For an undirected graph, this method is equivalent to getNeighborsOf.
+     */
+    @Deprecated
     @Override
-    public ISet getSuccOrNeighOf(int x) {
+    public ISet getSuccessorsOf(int x) {
         return neighbors[x];
     }
 

--- a/solver/src/main/java/org/chocosolver/util/objects/graphs/UndirectedGraph.java
+++ b/solver/src/main/java/org/chocosolver/util/objects/graphs/UndirectedGraph.java
@@ -29,7 +29,8 @@ public class UndirectedGraph implements IGraph {
     private ISet[] neighbors;
     private ISet nodes;
     private int n;
-    private SetType type;
+    private SetType arcSetType;
+    private SetType nodeSetType;
 
     //***********************************************************************************
     // CONSTRUCTORS
@@ -42,21 +43,39 @@ public class UndirectedGraph implements IGraph {
      *
      * @param model   model providing the backtracking environment
      * @param n        max number of nodes
-     * @param type     data structure storing for node neighbors
+     * @param nodeSetType     data structure storing for nodes
+     * @param arcSetType     data structure storing for node neighbors
      * @param allNodes true iff all nodes will always remain in the graph
      */
-    public UndirectedGraph(Model model, int n, SetType type, boolean allNodes) {
-        this.type = type;
+    public UndirectedGraph(Model model, int n, SetType nodeSetType, SetType arcSetType, boolean allNodes) {
+        this.arcSetType = arcSetType;
+        this.nodeSetType = nodeSetType;
         this.n = n;
         neighbors = new ISet[n];
         for (int i = 0; i < n; i++) {
-            neighbors[i] = SetFactory.makeStoredSet(type, 0, model);
+            neighbors[i] = SetFactory.makeStoredSet(this.arcSetType, 0, model);
         }
         if (allNodes) {
             this.nodes = SetFactory.makeConstantSet(0,n-1);
         } else {
-            this.nodes = SetFactory.makeStoredSet(SetType.BITSET, 0, model);
+            this.nodes = SetFactory.makeStoredSet(this.nodeSetType, 0, model);
         }
+    }
+
+    /**
+     * Creates an empty backtrable undirected graph.
+     * Allocates memory for n nodes (but they should then be added explicitly,
+     * unless allNodes is true).
+     *
+     * Nodes are stored as BITSET
+     *
+     * @param model   model providing the backtracking environment
+     * @param n        max number of nodes
+     * @param arcSetType     data structure storing for node neighbors
+     * @param allNodes true iff all nodes will always remain in the graph
+     */
+    public UndirectedGraph(Model model, int n, SetType arcSetType, boolean allNodes) {
+        this(model, n, SetType.BITSET, arcSetType, allNodes);
     }
 
     /**
@@ -65,21 +84,38 @@ public class UndirectedGraph implements IGraph {
      * unless allNodes is true).
      *
      * @param n        max number of nodes
-     * @param type     data structure used for storing node neighbors
+     * @param nodeSetType     data structure storing for nodes
+     * @param arcSetType     data structure used for storing node neighbors
      * @param allNodes true iff all nodes will always remain in the graph
      */
-    public UndirectedGraph(int n, SetType type, boolean allNodes) {
-        this.type = type;
+    public UndirectedGraph(int n, SetType nodeSetType, SetType arcSetType, boolean allNodes) {
+        this.arcSetType = arcSetType;
+        this.nodeSetType = nodeSetType;
         this.n = n;
         neighbors = new ISet[n];
         for (int i = 0; i < n; i++) {
-            neighbors[i] = SetFactory.makeSet(type, 0);
+            neighbors[i] = SetFactory.makeSet(arcSetType, 0);
         }
         if (allNodes) {
             this.nodes = SetFactory.makeConstantSet(0,n-1);
         } else {
-            this.nodes = SetFactory.makeBitSet(0);
+            this.nodes = SetFactory.makeSet(nodeSetType, 0);
         }
+    }
+
+    /**
+     * Creates an empty (non-backtrackable) undirected graph.
+     * Allocates memory for n nodes (but they should then be added explicitly,
+     * unless allNodes is true).
+     *
+     * Nodes are stored as BITSET
+     *
+     * @param n        max number of nodes
+     * @param arcSetType     data structure used for storing node neighbors
+     * @param allNodes true iff all nodes will always remain in the graph
+     */
+    public UndirectedGraph(int n, SetType arcSetType, boolean allNodes) {
+        this(n, SetType.BITSET, arcSetType, allNodes);
     }
 
     //***********************************************************************************
@@ -120,8 +156,16 @@ public class UndirectedGraph implements IGraph {
     /**
      * @inheritedDoc
      */
-    public SetType getType() {
-        return type;
+    public SetType getArcSetType() {
+        return arcSetType;
+    }
+
+    @Override
+    /**
+     * @inheritedDoc
+     */
+    public SetType getNodeSetType() {
+        return nodeSetType;
     }
 
     @Override

--- a/solver/src/main/java/org/chocosolver/util/objects/setDataStructures/ISet.java
+++ b/solver/src/main/java/org/chocosolver/util/objects/setDataStructures/ISet.java
@@ -119,17 +119,4 @@ public interface ISet extends Iterable<Integer>{
 		}
 		return a;
 	}
-
-	/**
-	 * Compare the values of two ISets.
-	 * @param other another ISets
-	 * @return true iff the sets contain exactly the same values
-	 */
-	default boolean equals(ISet other) {
-		int[] thisArray = this.toArray();
-		int[] otherArray = other.toArray();
-		Arrays.sort(thisArray);
-		Arrays.sort(otherArray);
-		return Arrays.equals(thisArray, otherArray);
-	}
 }

--- a/solver/src/main/java/org/chocosolver/util/objects/setDataStructures/ISet.java
+++ b/solver/src/main/java/org/chocosolver/util/objects/setDataStructures/ISet.java
@@ -9,8 +9,6 @@
  */
 package org.chocosolver.util.objects.setDataStructures;
 
-import java.util.Arrays;
-
 /**
  * Class representing a set of integers
  * Created by IntelliJ IDEA.

--- a/solver/src/main/java/org/chocosolver/util/objects/setDataStructures/ISet.java
+++ b/solver/src/main/java/org/chocosolver/util/objects/setDataStructures/ISet.java
@@ -9,6 +9,8 @@
  */
 package org.chocosolver.util.objects.setDataStructures;
 
+import java.util.Arrays;
+
 /**
  * Class representing a set of integers
  * Created by IntelliJ IDEA.
@@ -116,5 +118,18 @@ public interface ISet extends Iterable<Integer>{
 			a[idx++] = iter.nextInt();
 		}
 		return a;
+	}
+
+	/**
+	 * Compare the values of two ISets.
+	 * @param other another ISets
+	 * @return true iff the sets contain exactly the same values
+	 */
+	default boolean equals(ISet other) {
+		int[] thisArray = this.toArray();
+		int[] otherArray = other.toArray();
+		Arrays.sort(thisArray);
+		Arrays.sort(otherArray);
+		return Arrays.equals(thisArray, otherArray);
 	}
 }

--- a/solver/src/main/java/org/chocosolver/util/tools/PreProcessing.java
+++ b/solver/src/main/java/org/chocosolver/util/tools/PreProcessing.java
@@ -127,7 +127,7 @@ public class PreProcessing {
                             IntVar[] ivars) {
         component.add(ivars[v]);
         visited.set(v);
-        for (int x : g.getNeighOf(v)) {
+        for (int x : g.getNeighborsOf(v)) {
             if (!visited.get(x)) {
                 scc(x, visited, g, component, ivars);
             }

--- a/solver/src/test/java/org/chocosolver/solver/variables/impl/AbstractGraphVarTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/variables/impl/AbstractGraphVarTest.java
@@ -1,0 +1,84 @@
+/*
+ * This file is part of choco-solver, http://choco-solver.org/
+ *
+ * Copyright (c) 2021, IMT Atlantique. All rights reserved.
+ *
+ * Licensed under the BSD 4-clause license.
+ *
+ * See LICENSE file in the project root for full license information.
+ */
+package org.chocosolver.solver.variables.impl;
+
+import org.chocosolver.solver.ICause;
+import org.chocosolver.solver.Model;
+import org.chocosolver.solver.exception.ContradictionException;
+import org.chocosolver.util.objects.graphs.GraphFactory;
+import org.chocosolver.util.objects.graphs.UndirectedGraph;
+import org.chocosolver.util.objects.setDataStructures.SetType;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.util.Arrays;
+
+/**
+ * Test call for AbstractGraphVar
+ */
+public class AbstractGraphVarTest {
+
+    /**
+     * Instantiate an AbstractGraphVar and test the basic methods.
+     */
+    @Test(groups="1s", timeOut=60000)
+    public void basicTest() {
+        Model m = new Model();
+        int n = 3;
+        UndirectedGraph LB = GraphFactory.makeStoredUndirectedGraph(m, n, SetType.BITSET, SetType.BITSET);
+        UndirectedGraph UB = GraphFactory.makeCompleteStoredUndirectedGraph(m, n, SetType.BITSET, SetType.BITSET, false);
+        UB.removeNode(2);
+        AbstractGraphVar g = new UndirectedGraphVarImpl("g", m, LB, UB);
+        ICause fakeCause = new ICause() {};
+        try {
+            g.instantiateTo(UB, fakeCause);
+        } catch (ContradictionException e) {
+            Assert.fail();
+        }
+        Assert.assertTrue(g.isInstantiated());
+        g.toString();
+        // Attempt to remove kernel node
+        try {
+            g.removeNode(0, fakeCause);
+            Assert.fail();
+        } catch (ContradictionException e) {
+            // SUCCESS
+        }
+        // Remove node that does not belong to UB
+        try {
+            Assert.assertFalse(g.removeNode(2, fakeCause));
+        } catch (ContradictionException e) {
+            e.printStackTrace();
+        }
+        // Enforce node not in the domain
+        try {
+            g.enforceNode(2, fakeCause);
+            Assert.fail();
+        } catch (ContradictionException e) {
+            // SUCCESS
+        }
+        // Test getValueAsBoolMatrix
+        boolean[][] expected = new boolean[][] {
+                {false, true, false},
+                {true, false, false},
+                {false, false, false},
+                {true, true, false}
+        };
+        Assert.assertTrue(Arrays.deepEquals(expected, g.getValueAsBoolMatrix()));
+        // Test instantiateTo from bool matrix
+        try {
+            g.instantiateTo(expected, fakeCause);
+        } catch (ContradictionException e) {
+            Assert.fail();
+        }
+        // Test graphviz export (just in case of bug, the output is not tested here)
+        g.getValue().graphVizExport();
+    }
+}

--- a/solver/src/test/java/org/chocosolver/solver/variables/impl/DirectedGraphVarImplTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/variables/impl/DirectedGraphVarImplTest.java
@@ -1,0 +1,101 @@
+/*
+ * This file is part of choco-solver, http://choco-solver.org/
+ *
+ * Copyright (c) 2021, IMT Atlantique. All rights reserved.
+ *
+ * Licensed under the BSD 4-clause license.
+ *
+ * See LICENSE file in the project root for full license information.
+ */
+package org.chocosolver.solver.variables.impl;
+
+import org.chocosolver.solver.Model;
+import org.chocosolver.solver.variables.DirectedGraphVar;
+import org.chocosolver.util.objects.graphs.DirectedGraph;
+import org.chocosolver.util.objects.graphs.GraphFactory;
+import org.chocosolver.util.objects.setDataStructures.SetType;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+/**
+ * Test suite for DirectedGraphVarImpl class
+ * @author Dimitri Justeau-Allaire
+ * @since 02/03/2021
+ */
+public class DirectedGraphVarImplTest {
+
+    /**
+     * Test the instantiation of a single directed graph variable with all combinations of node and arc sets types.
+     * Enumerate of possible graph instantiations with the default strategy and assert that no value has been missed.
+     */
+    @Test(groups="1s", timeOut=60000)
+    public void testInstantiateAndGenerate() {
+        Model m = new Model();
+        int n = 3;
+        for (SetType nodeSetType : SetType.values()) {
+            if(!nodeSetType.name().contains("FIXED")) {
+                for (SetType arcSetType : SetType.values()) {
+                    if (!arcSetType.name().contains("FIXED")) {
+                        DirectedGraph LB = GraphFactory.makeStoredDirectedGraph(m, n, nodeSetType, arcSetType);
+                        DirectedGraph UB = GraphFactory.makeStoredAllNodesDirectedGraph(m, n, nodeSetType, arcSetType, false);
+                        UB.addArc(0, 1);
+                        UB.addArc(1, 2);
+                        UB.addArc(2, 0);
+                        DirectedGraphVar g = new DirectedGraphVarImpl("g", m, LB, UB);
+                        Assert.assertTrue(g.isDirected());
+                        while (m.getSolver().solve()) ;
+                        Assert.assertEquals(18, m.getSolver().getSolutionCount());
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Same as previous but with two directed graph variables
+     * (needed because current implementation of default search uses one GraphStrategy for one graph variable)
+     */
+    @Test(groups="1s", timeOut=60000)
+    public void testInstantiateAndGenerateTwo() {
+        Model m = new Model();
+        int n = 3;
+        for (SetType nodeSetType : SetType.values()) {
+            if(!nodeSetType.name().contains("FIXED")) {
+                for (SetType arcSetType : SetType.values()) {
+                    if (!arcSetType.name().contains("FIXED")) {
+                        DirectedGraph LB1 = GraphFactory.makeStoredDirectedGraph(m, n, nodeSetType, arcSetType);
+                        DirectedGraph LB2 = GraphFactory.makeStoredDirectedGraph(m, n, nodeSetType, arcSetType);
+                        DirectedGraph UB1 = GraphFactory.makeStoredAllNodesDirectedGraph(m, n, nodeSetType, arcSetType, false);
+                        DirectedGraph UB2 = GraphFactory.makeStoredAllNodesDirectedGraph(m, n, nodeSetType, arcSetType, false);
+                        UB1.addArc(0, 1);
+                        UB1.addArc(1, 2);
+                        UB1.addArc(2, 0);
+                        UB2.addArc(0, 1);
+                        UB2.addArc(1, 2);
+                        UB2.addArc(2, 0);
+                        DirectedGraphVar g1 = new DirectedGraphVarImpl("g1", m, LB1, UB1);
+                        DirectedGraphVar g2 = new DirectedGraphVarImpl("g2", m, LB2, UB2);
+                        while (m.getSolver().solve()) ;
+                        Assert.assertEquals(18 * 18, m.getSolver().getSolutionCount());
+                    }
+                }
+            }
+        }
+    }
+
+    @Test(groups="1s", timeOut=60000)
+    public void testDirectedGraphVarInstantiated() {
+        Model m = new Model();
+        int n = 3;
+        DirectedGraph LB = GraphFactory.makeCompleteStoredDirectedGraph(m, n, SetType.BITSET, SetType.BITSET, true);
+        DirectedGraph UB = GraphFactory.makeCompleteStoredDirectedGraph(m, n, SetType.BITSET, SetType.BITSET, true);
+        DirectedGraphVar g = new DirectedGraphVarImpl("g", m, LB, UB);
+        Assert.assertTrue(g.isInstantiated());
+        DirectedGraph gval = (DirectedGraph) g.getValue();
+        Assert.assertEquals(gval.getNodes().size(), 3);
+        DirectedGraph LB2 = GraphFactory.makeStoredDirectedGraph(m, n, SetType.BITSET, SetType.BITSET);
+        DirectedGraph UB2 = GraphFactory.makeCompleteStoredDirectedGraph(m, n, SetType.BITSET, SetType.BITSET, true);
+        DirectedGraphVar g2 = new DirectedGraphVarImpl("g2", m, LB2, UB2);
+        Assert.assertFalse(g2.isInstantiated());
+    }
+}

--- a/solver/src/test/java/org/chocosolver/solver/variables/impl/DirectedGraphVarImplTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/variables/impl/DirectedGraphVarImplTest.java
@@ -9,7 +9,9 @@
  */
 package org.chocosolver.solver.variables.impl;
 
+import org.chocosolver.solver.ICause;
 import org.chocosolver.solver.Model;
+import org.chocosolver.solver.exception.ContradictionException;
 import org.chocosolver.solver.variables.DirectedGraphVar;
 import org.chocosolver.util.objects.graphs.DirectedGraph;
 import org.chocosolver.util.objects.graphs.GraphFactory;
@@ -25,6 +27,58 @@ import org.testng.annotations.Test;
 public class DirectedGraphVarImplTest {
 
     /**
+     * Instantiate a DirectedGraphVar and test the basic methods.
+     */
+    @Test(groups="1s", timeOut=60000)
+    public void basicTest() {
+        Model m = new Model();
+        int n = 3;
+        DirectedGraph LB = GraphFactory.makeStoredDirectedGraph(m, n, SetType.BITSET, SetType.BITSET);
+        DirectedGraph UB = GraphFactory.makeStoredAllNodesDirectedGraph(m, n, SetType.BITSET, SetType.BITSET, false);
+        UB.addEdge(0, 1);
+        UB.addEdge(1, 2);
+        UB.addEdge(2, 0);
+        DirectedGraphVar g = new DirectedGraphVarImpl("g", m, LB, UB);
+        Assert.assertEquals(g.getMandatoryPredecessorsOf(0).size(), 0);
+        Assert.assertEquals(g.getMandatoryPredecessorsOf(1).size(), 0);
+        Assert.assertEquals(g.getMandatoryPredecessorsOf(2).size(), 0);
+        Assert.assertEquals(g.getMandatorySuccessorsOf(0).size(), 0);
+        Assert.assertEquals(g.getMandatorySuccessorsOf(1).size(), 0);
+        Assert.assertEquals(g.getMandatorySuccessorsOf(2).size(), 0);
+        Assert.assertEquals(g.getPotentialPredecessorOf(0).size(), 1);
+        Assert.assertEquals(g.getPotentialPredecessorOf(1).size(), 1);
+        Assert.assertEquals(g.getPotentialPredecessorOf(2).size(), 1);
+        Assert.assertEquals(g.getPotentialSuccessorsOf(0).size(), 1);
+        Assert.assertEquals(g.getPotentialSuccessorsOf(1).size(), 1);
+        Assert.assertEquals(g.getPotentialSuccessorsOf(2).size(), 1);
+        // Try to remove a mandatory edge
+        ICause fakeCause = new ICause() {};
+        LB.addNode(0);
+        LB.addNode(1);
+        LB.addEdge(0, 1);
+        try {
+            g.removeEdge(0, 1, fakeCause);
+            Assert.fail();
+        } catch (ContradictionException e) {
+            // SUCCESS
+        }
+        // Try to remove and edge not in the domain
+        UB.removeNode(2);
+        try {
+            Assert.assertFalse(g.removeEdge(0, 2, fakeCause));
+        } catch (ContradictionException e) {
+            Assert.fail();
+        }
+        // Try to enforce an edge not in UB
+        try {
+            g.enforceEdge(0, 0, fakeCause);
+            Assert.fail();
+        } catch (ContradictionException e) {
+            // SUCCESS
+        }
+    }
+
+    /**
      * Test the instantiation of a single directed graph variable with all combinations of node and arc sets types.
      * Enumerate of possible graph instantiations with the default strategy and assert that no value has been missed.
      */
@@ -38,9 +92,9 @@ public class DirectedGraphVarImplTest {
                     if (!arcSetType.name().contains("FIXED")) {
                         DirectedGraph LB = GraphFactory.makeStoredDirectedGraph(m, n, nodeSetType, arcSetType);
                         DirectedGraph UB = GraphFactory.makeStoredAllNodesDirectedGraph(m, n, nodeSetType, arcSetType, false);
-                        UB.addArc(0, 1);
-                        UB.addArc(1, 2);
-                        UB.addArc(2, 0);
+                        UB.addEdge(0, 1);
+                        UB.addEdge(1, 2);
+                        UB.addEdge(2, 0);
                         DirectedGraphVar g = new DirectedGraphVarImpl("g", m, LB, UB);
                         Assert.assertTrue(g.isDirected());
                         while (m.getSolver().solve()) ;
@@ -67,12 +121,12 @@ public class DirectedGraphVarImplTest {
                         DirectedGraph LB2 = GraphFactory.makeStoredDirectedGraph(m, n, nodeSetType, arcSetType);
                         DirectedGraph UB1 = GraphFactory.makeStoredAllNodesDirectedGraph(m, n, nodeSetType, arcSetType, false);
                         DirectedGraph UB2 = GraphFactory.makeStoredAllNodesDirectedGraph(m, n, nodeSetType, arcSetType, false);
-                        UB1.addArc(0, 1);
-                        UB1.addArc(1, 2);
-                        UB1.addArc(2, 0);
-                        UB2.addArc(0, 1);
-                        UB2.addArc(1, 2);
-                        UB2.addArc(2, 0);
+                        UB1.addEdge(0, 1);
+                        UB1.addEdge(1, 2);
+                        UB1.addEdge(2, 0);
+                        UB2.addEdge(0, 1);
+                        UB2.addEdge(1, 2);
+                        UB2.addEdge(2, 0);
                         DirectedGraphVar g1 = new DirectedGraphVarImpl("g1", m, LB1, UB1);
                         DirectedGraphVar g2 = new DirectedGraphVarImpl("g2", m, LB2, UB2);
                         while (m.getSolver().solve()) ;

--- a/solver/src/test/java/org/chocosolver/solver/variables/impl/UndirectedGraphVarImplTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/variables/impl/UndirectedGraphVarImplTest.java
@@ -9,13 +9,19 @@
  */
 package org.chocosolver.solver.variables.impl;
 
+import org.chocosolver.solver.ICause;
 import org.chocosolver.solver.Model;
+import org.chocosolver.solver.exception.ContradictionException;
+import org.chocosolver.solver.variables.DirectedGraphVar;
 import org.chocosolver.solver.variables.UndirectedGraphVar;
+import org.chocosolver.util.objects.graphs.DirectedGraph;
 import org.chocosolver.util.objects.graphs.GraphFactory;
 import org.chocosolver.util.objects.graphs.UndirectedGraph;
 import org.chocosolver.util.objects.setDataStructures.SetType;
 import org.testng.Assert;
 import org.testng.annotations.Test;
+
+import java.util.Arrays;
 
 /**
  * Test suite for UndirectedGraphVarImpl class
@@ -23,6 +29,41 @@ import org.testng.annotations.Test;
  * @since 02/03/2021
  */
 public class UndirectedGraphVarImplTest {
+
+    /**
+     * Instantiate an UndirectedGraphVar and test the basic methods.
+     */
+    @Test(groups="1s", timeOut=60000)
+    public void basicTest() {
+        Model m = new Model();
+        int n = 3;
+        UndirectedGraph LB = GraphFactory.makeStoredUndirectedGraph(m, n, SetType.BITSET, SetType.BITSET);
+        UndirectedGraph UB = GraphFactory.makeCompleteStoredUndirectedGraph(m, n, SetType.BITSET, SetType.BITSET, true);
+        UndirectedGraphVar g = new UndirectedGraphVarImpl("g", m, LB, UB);
+        int[] mandNeigZero = g.getMandatoryNeighborsOf(0).toArray();
+        int[] potNeigZero = g.getPotentialNeighborsOf(0).toArray();
+        int[] mandPredZero = g.getMandatoryPredecessorsOf(0).toArray();
+        int[] potPredZero = g.getPotentialPredecessorOf(0).toArray();
+        int[] mandSuccZero = g.getMandatorySuccessorsOf(0).toArray();
+        int[] potSuccZero = g.getPotentialSuccessorsOf(0).toArray();
+        Arrays.sort(mandNeigZero);
+        Arrays.sort(potNeigZero);
+        Arrays.sort(mandPredZero);
+        Arrays.sort(potPredZero);
+        Arrays.sort(mandSuccZero);
+        Arrays.sort(potSuccZero);
+        Assert.assertTrue(Arrays.equals(g.getMandatoryPredecessorsOf(0).toArray(), mandNeigZero));
+        Assert.assertTrue(Arrays.equals(g.getMandatorySuccessorsOf(0).toArray(), mandNeigZero));
+        Assert.assertTrue(Arrays.equals(g.getPotentialPredecessorOf(0).toArray(), potNeigZero));
+        Assert.assertTrue(Arrays.equals(g.getPotentialSuccessorsOf(0).toArray(), potNeigZero));
+        ICause fakeCause = new ICause() {};
+        try {
+            g.instantiateTo(UB, fakeCause);
+        } catch (ContradictionException e) {
+            Assert.fail();
+        }
+        Assert.assertTrue(g.isInstantiated());
+    }
 
     /**
      * Test the instantiation of a single undirected graph variable with all combinations of node and arc sets types.

--- a/solver/src/test/java/org/chocosolver/solver/variables/impl/UndirectedGraphVarImplTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/variables/impl/UndirectedGraphVarImplTest.java
@@ -18,7 +18,7 @@ import org.testng.Assert;
 import org.testng.annotations.Test;
 
 /**
- * Test suite for UndirectedGraphVarImpl classe
+ * Test suite for UndirectedGraphVarImpl class
  * @author Dimitri Justeau-Allaire
  * @since 02/03/2021
  */

--- a/solver/src/test/java/org/chocosolver/solver/variables/impl/UndirectedGraphVarImplTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/variables/impl/UndirectedGraphVarImplTest.java
@@ -10,7 +10,7 @@
 package org.chocosolver.solver.variables.impl;
 
 import org.chocosolver.solver.Model;
-import org.chocosolver.solver.variables.GraphVar;
+import org.chocosolver.solver.variables.UndirectedGraphVar;
 import org.chocosolver.util.objects.graphs.GraphFactory;
 import org.chocosolver.util.objects.graphs.UndirectedGraph;
 import org.chocosolver.util.objects.setDataStructures.SetType;
@@ -36,9 +36,10 @@ public class UndirectedGraphVarImplTest {
             if(!nodeSetType.name().contains("FIXED")) {
                 for (SetType arcSetType : SetType.values()) {
                     if (!arcSetType.name().contains("FIXED")) {
-                        UndirectedGraph LB = GraphFactory.makeEmptyStoredGraph(m, n, nodeSetType, arcSetType);
-                        UndirectedGraph UB = GraphFactory.makeCompleteStoredGraph(m, n, nodeSetType, arcSetType, false);
-                        GraphVar g = new UndirectedGraphVarImpl("g", m, LB, UB);
+                        UndirectedGraph LB = GraphFactory.makeStoredUndirectedGraph(m, n, nodeSetType, arcSetType);
+                        UndirectedGraph UB = GraphFactory.makeCompleteStoredUndirectedGraph(m, n, nodeSetType, arcSetType, false);
+                        UndirectedGraphVar g = new UndirectedGraphVarImpl("g", m, LB, UB);
+                        Assert.assertFalse(g.isDirected());
                         while (m.getSolver().solve()) ;
                         Assert.assertEquals(18, m.getSolver().getSolutionCount());
                     }
@@ -59,12 +60,12 @@ public class UndirectedGraphVarImplTest {
             if(!nodeSetType.name().contains("FIXED")) {
                 for (SetType arcSetType : SetType.values()) {
                     if (!arcSetType.name().contains("FIXED")) {
-                        UndirectedGraph LB1 = GraphFactory.makeEmptyStoredGraph(m, n, nodeSetType, arcSetType);
-                        UndirectedGraph LB2 = GraphFactory.makeEmptyStoredGraph(m, n, nodeSetType, arcSetType);
-                        UndirectedGraph UB1 = GraphFactory.makeCompleteStoredGraph(m, n, nodeSetType, arcSetType, false);
-                        UndirectedGraph UB2 = GraphFactory.makeCompleteStoredGraph(m, n, nodeSetType, arcSetType, false);
-                        GraphVar g1 = new UndirectedGraphVarImpl("g1", m, LB1, UB1);
-                        GraphVar g2 = new UndirectedGraphVarImpl("g2", m, LB2, UB2);
+                        UndirectedGraph LB1 = GraphFactory.makeStoredUndirectedGraph(m, n, nodeSetType, arcSetType);
+                        UndirectedGraph LB2 = GraphFactory.makeStoredUndirectedGraph(m, n, nodeSetType, arcSetType);
+                        UndirectedGraph UB1 = GraphFactory.makeCompleteStoredUndirectedGraph(m, n, nodeSetType, arcSetType, false);
+                        UndirectedGraph UB2 = GraphFactory.makeCompleteStoredUndirectedGraph(m, n, nodeSetType, arcSetType, false);
+                        UndirectedGraphVar g1 = new UndirectedGraphVarImpl("g1", m, LB1, UB1);
+                        UndirectedGraphVar g2 = new UndirectedGraphVarImpl("g2", m, LB2, UB2);
                         while (m.getSolver().solve()) ;
                         Assert.assertEquals(18 * 18, m.getSolver().getSolutionCount());
                     }
@@ -77,15 +78,15 @@ public class UndirectedGraphVarImplTest {
     public void testGraphVarInstantiated() {
         Model m = new Model();
         int n = 3;
-        UndirectedGraph LB = GraphFactory.makeCompleteStoredGraph(m, n, SetType.BITSET, SetType.BITSET, true);
-        UndirectedGraph UB = GraphFactory.makeCompleteStoredGraph(m, n, SetType.BITSET, SetType.BITSET, true);
-        GraphVar g = new UndirectedGraphVarImpl("g", m, LB, UB);
+        UndirectedGraph LB = GraphFactory.makeCompleteStoredUndirectedGraph(m, n, SetType.BITSET, SetType.BITSET, true);
+        UndirectedGraph UB = GraphFactory.makeCompleteStoredUndirectedGraph(m, n, SetType.BITSET, SetType.BITSET, true);
+        UndirectedGraphVar g = new UndirectedGraphVarImpl("g", m, LB, UB);
         Assert.assertTrue(g.isInstantiated());
         UndirectedGraph gval = (UndirectedGraph) g.getValue();
         Assert.assertEquals(gval.getNodes().size(), 3);
-        UndirectedGraph LB2 = GraphFactory.makeEmptyStoredGraph(m, n, SetType.BITSET, SetType.BITSET);
-        UndirectedGraph UB2 = GraphFactory.makeCompleteStoredGraph(m, n, SetType.BITSET, SetType.BITSET, true);
-        GraphVar g2 = new UndirectedGraphVarImpl("g2", m, LB2, UB2);
+        UndirectedGraph LB2 = GraphFactory.makeStoredUndirectedGraph(m, n, SetType.BITSET, SetType.BITSET);
+        UndirectedGraph UB2 = GraphFactory.makeCompleteStoredUndirectedGraph(m, n, SetType.BITSET, SetType.BITSET, true);
+        UndirectedGraphVar g2 = new UndirectedGraphVarImpl("g2", m, LB2, UB2);
         Assert.assertFalse(g2.isInstantiated());
     }
 }

--- a/solver/src/test/java/org/chocosolver/solver/variables/impl/UndirectedGraphVarImplTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/variables/impl/UndirectedGraphVarImplTest.java
@@ -72,4 +72,20 @@ public class UndirectedGraphVarImplTest {
             }
         }
     }
+
+    @Test(groups="1s", timeOut=60000)
+    public void testGraphVarInstantiated() {
+        Model m = new Model();
+        int n = 3;
+        UndirectedGraph LB = GraphFactory.makeCompleteStoredGraph(m, n, SetType.BITSET, SetType.BITSET, true);
+        UndirectedGraph UB = GraphFactory.makeCompleteStoredGraph(m, n, SetType.BITSET, SetType.BITSET, true);
+        GraphVar g = new UndirectedGraphVarImpl("g", m, LB, UB);
+        Assert.assertTrue(g.isInstantiated());
+        UndirectedGraph gval = (UndirectedGraph) g.getValue();
+        Assert.assertEquals(gval.getNodes().size(), 3);
+        UndirectedGraph LB2 = GraphFactory.makeEmptyStoredGraph(m, n, SetType.BITSET, SetType.BITSET);
+        UndirectedGraph UB2 = GraphFactory.makeCompleteStoredGraph(m, n, SetType.BITSET, SetType.BITSET, true);
+        GraphVar g2 = new UndirectedGraphVarImpl("g2", m, LB2, UB2);
+        Assert.assertFalse(g2.isInstantiated());
+    }
 }

--- a/solver/src/test/java/org/chocosolver/solver/variables/impl/UndirectedGraphVarImplTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/variables/impl/UndirectedGraphVarImplTest.java
@@ -1,0 +1,75 @@
+/*
+ * This file is part of choco-solver, http://choco-solver.org/
+ *
+ * Copyright (c) 2021, IMT Atlantique. All rights reserved.
+ *
+ * Licensed under the BSD 4-clause license.
+ *
+ * See LICENSE file in the project root for full license information.
+ */
+package org.chocosolver.solver.variables.impl;
+
+import org.chocosolver.solver.Model;
+import org.chocosolver.solver.variables.GraphVar;
+import org.chocosolver.util.objects.graphs.GraphFactory;
+import org.chocosolver.util.objects.graphs.UndirectedGraph;
+import org.chocosolver.util.objects.setDataStructures.SetType;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+/**
+ * Test suite for UndirectedGraphVarImpl classe
+ * @author Dimitri Justeau-Allaire
+ * @since 02/03/2021
+ */
+public class UndirectedGraphVarImplTest {
+
+    /**
+     * Test the instantiation of a single undirected graph variable with all combinations of node and arc sets types.
+     * Enumerate of possible graph instantiations with the default strategy and assert that no value has been missed.
+     */
+    @Test(groups="1s", timeOut=60000)
+    public void testInstantiateAndGenerate() {
+        Model m = new Model();
+        int n = 3;
+        for (SetType nodeSetType : SetType.values()) {
+            if(!nodeSetType.name().contains("FIXED")) {
+                for (SetType arcSetType : SetType.values()) {
+                    if (!arcSetType.name().contains("FIXED")) {
+                        UndirectedGraph LB = GraphFactory.makeEmptyStoredGraph(m, n, nodeSetType, arcSetType);
+                        UndirectedGraph UB = GraphFactory.makeCompleteStoredGraph(m, n, nodeSetType, arcSetType, false);
+                        GraphVar g = new UndirectedGraphVarImpl("g", m, LB, UB);
+                        while (m.getSolver().solve()) ;
+                        Assert.assertEquals(18, m.getSolver().getSolutionCount());
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Same as previous but with two undirected graph variables
+     * (needed because current implementation of default search uses one GraphStrategy for one graph variable)
+     */
+    @Test(groups="1s", timeOut=60000)
+    public void testInstantiateAndGenerateTwo() {
+        Model m = new Model();
+        int n = 3;
+        for (SetType nodeSetType : SetType.values()) {
+            if(!nodeSetType.name().contains("FIXED")) {
+                for (SetType arcSetType : SetType.values()) {
+                    if (!arcSetType.name().contains("FIXED")) {
+                        UndirectedGraph LB1 = GraphFactory.makeEmptyStoredGraph(m, n, nodeSetType, arcSetType);
+                        UndirectedGraph LB2 = GraphFactory.makeEmptyStoredGraph(m, n, nodeSetType, arcSetType);
+                        UndirectedGraph UB1 = GraphFactory.makeCompleteStoredGraph(m, n, nodeSetType, arcSetType, false);
+                        UndirectedGraph UB2 = GraphFactory.makeCompleteStoredGraph(m, n, nodeSetType, arcSetType, false);
+                        GraphVar g1 = new UndirectedGraphVarImpl("g1", m, LB1, UB1);
+                        GraphVar g2 = new UndirectedGraphVarImpl("g2", m, LB2, UB2);
+                        while (m.getSolver().solve()) ;
+                        Assert.assertEquals(18 * 18, m.getSolver().getSolutionCount());
+                    }
+                }
+            }
+        }
+    }
+}

--- a/solver/src/test/java/org/chocosolver/solver/variables/view/GraphNeighSetViewTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/variables/view/GraphNeighSetViewTest.java
@@ -1,0 +1,116 @@
+/*
+ * This file is part of choco-solver, http://choco-solver.org/
+ *
+ * Copyright (c) 2021, IMT Atlantique. All rights reserved.
+ *
+ * Licensed under the BSD 4-clause license.
+ *
+ * See LICENSE file in the project root for full license information.
+ */
+package org.chocosolver.solver.variables.view;
+
+import org.chocosolver.solver.Model;
+import org.chocosolver.solver.exception.ContradictionException;
+import org.chocosolver.solver.variables.UndirectedGraphVar;
+import org.chocosolver.solver.variables.impl.UndirectedGraphVarImpl;
+import org.chocosolver.util.objects.graphs.GraphFactory;
+import org.chocosolver.util.objects.graphs.UndirectedGraph;
+import org.chocosolver.util.objects.setDataStructures.SetType;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.util.Arrays;
+
+/**
+ * Test suite for GraphNeighSetView class
+ * @author Dimitri Justeau-Allaire
+ * @since 02/03/2021
+ */
+public class GraphNeighSetViewTest {
+
+    /**
+     * Test the instantiation of a graph neigh set view over an undirected graph variable
+     * Generate all possible solutions and ensure that the view is properly updated.
+     */
+    @Test(groups="1s", timeOut=60000)
+    public void testInstantiateAndGenerateUndirectedGraph() {
+        Model m = new Model();
+        int n = 5;
+        UndirectedGraph LB = GraphFactory.makeStoredUndirectedGraph(m, n, SetType.BITSET, SetType.BITSET);
+        UndirectedGraph UB = GraphFactory.makeCompleteStoredUndirectedGraph(m, n, SetType.BITSET, SetType.BITSET, false);
+        UndirectedGraphVar g = new UndirectedGraphVarImpl("g", m, LB, UB);
+        GraphNeighSetView s = new GraphNeighSetView("s", g, 0);
+        Assert.assertEquals(s.getLB().size(), 0);
+        Assert.assertEquals(s.getUB().size(), 4);
+        while (m.getSolver().solve()) {
+            int[] neighsInGraph = g.getValue().getNeighOf(0).toArray();
+            int[] neighSet = s.getValue().toArray();
+            Arrays.sort(neighsInGraph);
+            Arrays.sort(neighSet);
+            Assert.assertEquals(neighsInGraph, neighSet);
+        }
+    }
+
+    /**
+     * Post a constraint on the view to force it to a particular value and ensure that the observed
+     * graph is properly affected.
+     */
+    @Test(groups="1s", timeOut=60000)
+    public void testFixedViewUndirectedGraph() {
+        Model m = new Model();
+        int n = 5;
+        UndirectedGraph LB = GraphFactory.makeStoredUndirectedGraph(m, n, SetType.BITSET, SetType.BITSET);
+        UndirectedGraph UB = GraphFactory.makeCompleteStoredUndirectedGraph(m, n, SetType.BITSET, SetType.BITSET, false);
+        UndirectedGraphVar g = new UndirectedGraphVarImpl("g", m, LB, UB);
+        GraphNeighSetView s = new GraphNeighSetView("s", g, 0);
+        m.allEqual(s, m.setVar(new int[] {1, 2, 4})).post();
+        while (m.getSolver().solve()) {
+            int[] neighsInGraph = g.getValue().getNeighOf(0).toArray();
+            int[] neighSet = s.getValue().toArray();
+            Arrays.sort(neighsInGraph);
+            Arrays.sort(neighSet);
+            Assert.assertEquals(neighsInGraph, neighSet);
+            Assert.assertEquals(neighsInGraph, new int[] {1, 2, 4});
+        }
+    }
+
+    /**
+     * Post a constraint on the view to force it to a particular value and ensure that the observed
+     * graph is properly affected.
+     */
+    @Test(groups="1s", timeOut=60000)
+    public void testInstantiateTo() throws ContradictionException {
+        Model m = new Model();
+        int n = 5;
+        UndirectedGraph LB = GraphFactory.makeStoredUndirectedGraph(m, n, SetType.BITSET, SetType.BITSET);
+        UndirectedGraph UB = GraphFactory.makeCompleteStoredUndirectedGraph(m, n, SetType.BITSET, SetType.BITSET, false);
+        UndirectedGraphVar g = new UndirectedGraphVarImpl("g", m, LB, UB);
+        GraphNeighSetView s = new GraphNeighSetView("s", g, 0);
+        s.instantiateTo(new int[] {2, 3}, s);
+        while (m.getSolver().solve()) {
+            int[] neighsInGraph = g.getValue().getNeighOf(0).toArray();
+            int[] neighSet = s.getValue().toArray();
+            Arrays.sort(neighsInGraph);
+            Arrays.sort(neighSet);
+            Assert.assertEquals(neighsInGraph, neighSet);
+            Assert.assertEquals(neighsInGraph, new int[] {2, 3});
+        }
+    }
+
+    /**
+     * Post contradictory constraints on the view and on the variable and ensure failure.
+     */
+    @Test(groups="1s", timeOut=60000)
+    public void testFail() throws ContradictionException {
+        Model m = new Model();
+        int n = 5;
+        UndirectedGraph LB = GraphFactory.makeStoredUndirectedGraph(m, n, SetType.BITSET, SetType.BITSET);
+        UndirectedGraph UB = GraphFactory.makeStoredAllNodesUndirectedGraph(m, n, SetType.BITSET, SetType.BITSET, false);
+        UB.addEdge(0, 1);
+        UB.addEdge(0, 2);
+        UndirectedGraphVar g = new UndirectedGraphVarImpl("g", m, LB, UB);
+        GraphNeighSetView s = new GraphNeighSetView("s", g, 0);
+        m.allEqual(s, m.setVar(new int[] {1, 2, 3})).post();
+        Assert.assertFalse(m.getSolver().solve());
+    }
+}

--- a/solver/src/test/java/org/chocosolver/solver/variables/view/GraphNeighSetViewTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/variables/view/GraphNeighSetViewTest.java
@@ -43,7 +43,7 @@ public class GraphNeighSetViewTest {
         Assert.assertEquals(s.getLB().size(), 0);
         Assert.assertEquals(s.getUB().size(), 4);
         while (m.getSolver().solve()) {
-            int[] neighsInGraph = g.getValue().getNeighOf(0).toArray();
+            int[] neighsInGraph = g.getValue().getNeighborsOf(0).toArray();
             int[] neighSet = s.getValue().toArray();
             Arrays.sort(neighsInGraph);
             Arrays.sort(neighSet);
@@ -65,7 +65,7 @@ public class GraphNeighSetViewTest {
         GraphNeighSetView s = new GraphNeighSetView("s", g, 0);
         m.allEqual(s, m.setVar(new int[] {1, 2, 4})).post();
         while (m.getSolver().solve()) {
-            int[] neighsInGraph = g.getValue().getNeighOf(0).toArray();
+            int[] neighsInGraph = g.getValue().getNeighborsOf(0).toArray();
             int[] neighSet = s.getValue().toArray();
             Arrays.sort(neighsInGraph);
             Arrays.sort(neighSet);
@@ -88,7 +88,7 @@ public class GraphNeighSetViewTest {
         GraphNeighSetView s = new GraphNeighSetView("s", g, 0);
         s.instantiateTo(new int[] {2, 3}, s);
         while (m.getSolver().solve()) {
-            int[] neighsInGraph = g.getValue().getNeighOf(0).toArray();
+            int[] neighsInGraph = g.getValue().getNeighborsOf(0).toArray();
             int[] neighSet = s.getValue().toArray();
             Arrays.sort(neighsInGraph);
             Arrays.sort(neighSet);

--- a/solver/src/test/java/org/chocosolver/solver/variables/view/GraphNodeSetViewTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/variables/view/GraphNodeSetViewTest.java
@@ -1,0 +1,67 @@
+/*
+ * This file is part of choco-solver, http://choco-solver.org/
+ *
+ * Copyright (c) 2021, IMT Atlantique. All rights reserved.
+ *
+ * Licensed under the BSD 4-clause license.
+ *
+ * See LICENSE file in the project root for full license information.
+ */
+package org.chocosolver.solver.variables.view;
+
+import org.chocosolver.solver.Model;
+import org.chocosolver.solver.variables.GraphVar;
+import org.chocosolver.solver.variables.impl.UndirectedGraphVarImpl;
+import org.chocosolver.util.objects.graphs.GraphFactory;
+import org.chocosolver.util.objects.graphs.UndirectedGraph;
+import org.chocosolver.util.objects.setDataStructures.ISet;
+import org.chocosolver.util.objects.setDataStructures.SetType;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+/**
+ * Test suite for GraphNodeSetView class
+ * @author Dimitri Justeau-Allaire
+ * @since 02/03/2021
+ */
+public class GraphNodeSetViewTest {
+
+    /**
+     * Test the instantiation of a graph node set view over an undirected graph variable
+     * Generate all possible solutions and ensure that the view is properly updated.
+     */
+    @Test(groups="1s", timeOut=60000)
+    public void testInstantiateAndGenerateUndirectedGraph() {
+        Model m = new Model();
+        int n = 5;
+        UndirectedGraph LB = GraphFactory.makeEmptyStoredGraph(m, n, SetType.BITSET, SetType.BITSET);
+        UndirectedGraph UB = GraphFactory.makeCompleteStoredGraph(m, n, SetType.BITSET, SetType.BITSET, false);
+        GraphVar g = new UndirectedGraphVarImpl("g", m, LB, UB);
+        GraphNodeSetView s = new GraphNodeSetView("s", g);
+        while (m.getSolver().solve()) {
+            ISet nodes = g.getValue().getNodes();
+            ISet nodeSet = s.getValue();
+            Assert.assertEquals(nodes, nodeSet);
+        }
+    }
+
+    /**
+     * Post a constraint on the view to force it to a particular value and ensure that the observed
+     * graph is properly affected.
+     */
+    @Test(groups="1s", timeOut=60000)
+    public void testFixedViewUndirectedGraph() {
+        Model m = new Model();
+        int n = 5;
+        UndirectedGraph LB = GraphFactory.makeEmptyStoredGraph(m, n, SetType.BITSET, SetType.BITSET);
+        UndirectedGraph UB = GraphFactory.makeCompleteStoredGraph(m, n, SetType.BITSET, SetType.BITSET, false);
+        GraphVar g = new UndirectedGraphVarImpl("g", m, LB, UB);
+        GraphNodeSetView s = new GraphNodeSetView("s", g);
+        m.allEqual(s, m.setVar(new int[] {0, 2, 4})).post();
+        while (m.getSolver().solve()) {
+            ISet nodes = g.getValue().getNodes();
+            ISet nodeSet = s.getValue();
+            Assert.assertEquals(nodes, nodeSet);
+        }
+    }
+}

--- a/solver/src/test/java/org/chocosolver/solver/variables/view/GraphNodeSetViewTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/variables/view/GraphNodeSetViewTest.java
@@ -15,8 +15,7 @@ import org.chocosolver.solver.constraints.graph.PropNbNodes;
 import org.chocosolver.solver.exception.ContradictionException;
 import org.chocosolver.solver.variables.GraphVar;
 import org.chocosolver.solver.variables.IntVar;
-import org.chocosolver.solver.variables.impl.DirectedGraphVarImpl;
-import org.chocosolver.solver.variables.impl.UndirectedGraphVarImpl;
+import org.chocosolver.solver.variables.SetVar;
 import org.chocosolver.util.objects.graphs.DirectedGraph;
 import org.chocosolver.util.objects.graphs.GraphFactory;
 import org.chocosolver.util.objects.graphs.UndirectedGraph;
@@ -43,7 +42,7 @@ public class GraphNodeSetViewTest {
         int n = 5;
         UndirectedGraph LB = GraphFactory.makeStoredUndirectedGraph(m, n, SetType.BITSET, SetType.BITSET);
         UndirectedGraph UB = GraphFactory.makeCompleteStoredUndirectedGraph(m, n, SetType.BITSET, SetType.BITSET, false);
-        GraphVar g = new UndirectedGraphVarImpl("g", m, LB, UB);
+        GraphVar g = m.undirectedGraphVar("g", LB, UB);
         GraphNodeSetView s = new GraphNodeSetView("s", g);
         while (m.getSolver().solve()) {
             int[] nodes = g.getValue().getNodes().toArray();
@@ -64,7 +63,7 @@ public class GraphNodeSetViewTest {
         int n = 4;
         DirectedGraph LB = GraphFactory.makeStoredDirectedGraph(m, n, SetType.BITSET, SetType.BITSET);
         DirectedGraph UB = GraphFactory.makeCompleteStoredDirectedGraph(m, n, SetType.BITSET, SetType.BITSET, false);
-        GraphVar g = new DirectedGraphVarImpl("g", m, LB, UB);
+        GraphVar g = m.directedGraphVar("g", LB, UB);
         GraphNodeSetView s = new GraphNodeSetView("s", g);
         while (m.getSolver().solve()) {
             int[] nodes = g.getValue().getNodes().toArray();
@@ -84,7 +83,7 @@ public class GraphNodeSetViewTest {
         int n = 5;
         UndirectedGraph LB = GraphFactory.makeStoredUndirectedGraph(m, n, SetType.BITSET, SetType.BITSET);
         UndirectedGraph UB = GraphFactory.makeCompleteStoredUndirectedGraph(m, n, SetType.BITSET, SetType.BITSET, false);
-        GraphVar g = new UndirectedGraphVarImpl("g", m, LB, UB);
+        GraphVar g = m.undirectedGraphVar("g", LB, UB);
         GraphNodeSetView s = new GraphNodeSetView("s", g);
         m.allEqual(s, m.setVar(new int[] {0, 2, 4})).post();
         while (m.getSolver().solve()) {
@@ -107,7 +106,7 @@ public class GraphNodeSetViewTest {
         int n = 5;
         UndirectedGraph LB = GraphFactory.makeStoredUndirectedGraph(m, n, SetType.BITSET, SetType.BITSET);
         UndirectedGraph UB = GraphFactory.makeCompleteStoredUndirectedGraph(m, n, SetType.BITSET, SetType.BITSET, false);
-        GraphVar g = new UndirectedGraphVarImpl("g", m, LB, UB);
+        GraphVar g = m.undirectedGraphVar("g", LB, UB);
         GraphNodeSetView s = new GraphNodeSetView("s", g);
         s.instantiateTo(new int[] {0, 2, 4}, s);
         while (m.getSolver().solve()) {
@@ -129,7 +128,7 @@ public class GraphNodeSetViewTest {
         int n = 5;
         DirectedGraph LB = GraphFactory.makeStoredDirectedGraph(m, n, SetType.BITSET, SetType.BITSET);
         DirectedGraph UB = GraphFactory.makeCompleteStoredDirectedGraph(m, n, SetType.BITSET, SetType.BITSET, false);
-        GraphVar g = new DirectedGraphVarImpl("g", m, LB, UB);
+        GraphVar g = m.directedGraphVar("g", LB, UB);
         GraphNodeSetView s = new GraphNodeSetView("s", g);
         m.allEqual(s, m.setVar(new int[] {0, 2, 4})).post();
         while (m.getSolver().solve()) {
@@ -151,8 +150,8 @@ public class GraphNodeSetViewTest {
         int n = 10;
         UndirectedGraph LB = GraphFactory.makeStoredUndirectedGraph(m, n, SetType.BITSET, SetType.BITSET);
         UndirectedGraph UB = GraphFactory.makeCompleteStoredUndirectedGraph(m, n, SetType.BITSET, SetType.BITSET, false);
-        GraphVar g = new UndirectedGraphVarImpl("g", m, LB, UB);
-        GraphNodeSetView s = new GraphNodeSetView("s", g);
+        GraphVar g = m.undirectedGraphVar("g", LB, UB);
+        SetVar s = m.graphNodeSetView(g);
         Constraint nbNodes = new Constraint("NbNodes", new PropNbNodes(g, m.intVar(3, 7)));
         m.post(nbNodes);
         m.member(0, s).post();

--- a/solver/src/test/java/org/chocosolver/solver/variables/view/GraphNodeSetViewTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/variables/view/GraphNodeSetViewTest.java
@@ -19,6 +19,8 @@ import org.chocosolver.util.objects.setDataStructures.SetType;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
+import java.util.Arrays;
+
 /**
  * Test suite for GraphNodeSetView class
  * @author Dimitri Justeau-Allaire
@@ -59,8 +61,10 @@ public class GraphNodeSetViewTest {
         GraphNodeSetView s = new GraphNodeSetView("s", g);
         m.allEqual(s, m.setVar(new int[] {0, 2, 4})).post();
         while (m.getSolver().solve()) {
-            ISet nodes = g.getValue().getNodes();
-            ISet nodeSet = s.getValue();
+            int[] nodes = g.getValue().getNodes().toArray();
+            int[] nodeSet = s.getValue().toArray();
+            Arrays.sort(nodes);
+            Arrays.sort(nodeSet);
             Assert.assertEquals(nodes, nodeSet);
         }
     }

--- a/solver/src/test/java/org/chocosolver/solver/variables/view/GraphPredecessorsSetViewTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/variables/view/GraphPredecessorsSetViewTest.java
@@ -14,7 +14,10 @@ import org.chocosolver.solver.constraints.Constraint;
 import org.chocosolver.solver.constraints.graph.PropNbEdges;
 import org.chocosolver.solver.constraints.graph.PropNbNodes;
 import org.chocosolver.solver.exception.ContradictionException;
-import org.chocosolver.solver.variables.*;
+import org.chocosolver.solver.variables.DirectedGraphVar;
+import org.chocosolver.solver.variables.IntVar;
+import org.chocosolver.solver.variables.SetVar;
+import org.chocosolver.solver.variables.UndirectedGraphVar;
 import org.chocosolver.util.objects.graphs.DirectedGraph;
 import org.chocosolver.util.objects.graphs.GraphFactory;
 import org.chocosolver.util.objects.graphs.UndirectedGraph;
@@ -29,7 +32,7 @@ import java.util.Arrays;
  * @author Dimitri Justeau-Allaire
  * @since 02/03/2021
  */
-public class GraphSuccessorsSetViewTest {
+public class GraphPredecessorsSetViewTest {
 
     /**
      * Test the instantiation of a graph neigh set view over an undirected graph variable
@@ -39,14 +42,14 @@ public class GraphSuccessorsSetViewTest {
     public void testInstantiateAndGenerateUndirectedGraph() {
         Model m = new Model();
         int n = 5;
-        UndirectedGraph LB = GraphFactory.makeStoredUndirectedGraph(m, n, SetType.BITSET, SetType.BITSET);
-        UndirectedGraph UB = GraphFactory.makeCompleteStoredUndirectedGraph(m, n, SetType.BITSET, SetType.BITSET, false);
-        UndirectedGraphVar g = m.undirectedGraphVar("g", LB, UB);
-        GraphSuccessorsSetView s = new GraphSuccessorsSetView("s", g, 0);
+        DirectedGraph LB = GraphFactory.makeStoredDirectedGraph(m, n, SetType.BITSET, SetType.BITSET);
+        DirectedGraph UB = GraphFactory.makeCompleteStoredDirectedGraph(m, n, SetType.BITSET, SetType.BITSET, false);
+        DirectedGraphVar g = m.directedGraphVar("g", LB, UB);
+        GraphPredecessorsSetView s = new GraphPredecessorsSetView("s", g, 0);
         Assert.assertEquals(s.getLB().size(), 0);
         Assert.assertEquals(s.getUB().size(), 4);
         while (m.getSolver().solve()) {
-            int[] neighsInGraph = g.getValue().getNeighborsOf(0).toArray();
+            int[] neighsInGraph = g.getValue().getPredecessorsOf(0).toArray();
             int[] neighSet = s.getValue().toArray();
             Arrays.sort(neighsInGraph);
             Arrays.sort(neighSet);
@@ -59,16 +62,16 @@ public class GraphSuccessorsSetViewTest {
      * graph is properly affected.
      */
     @Test(groups="1s", timeOut=60000)
-    public void testFixedViewUndirectedGraph() {
+    public void testFixedViewDirectedGraph() {
         Model m = new Model();
         int n = 5;
-        UndirectedGraph LB = GraphFactory.makeStoredUndirectedGraph(m, n, SetType.BITSET, SetType.BITSET);
-        UndirectedGraph UB = GraphFactory.makeCompleteStoredUndirectedGraph(m, n, SetType.BITSET, SetType.BITSET, false);
-        UndirectedGraphVar g = m.undirectedGraphVar("g", LB, UB);
-        GraphSuccessorsSetView s = new GraphSuccessorsSetView("s", g, 0);
+        DirectedGraph LB = GraphFactory.makeStoredDirectedGraph(m, n, SetType.BITSET, SetType.BITSET);
+        DirectedGraph UB = GraphFactory.makeCompleteStoredDirectedGraph(m, n, SetType.BITSET, SetType.BITSET, false);
+        DirectedGraphVar g = m.directedGraphVar("g", LB, UB);
+        GraphPredecessorsSetView s = new GraphPredecessorsSetView("s", g, 0);
         m.allEqual(s, m.setVar(new int[] {1, 2, 4})).post();
         while (m.getSolver().solve()) {
-            int[] neighsInGraph = g.getValue().getNeighborsOf(0).toArray();
+            int[] neighsInGraph = g.getValue().getPredecessorsOf(0).toArray();
             int[] neighSet = s.getValue().toArray();
             Arrays.sort(neighsInGraph);
             Arrays.sort(neighSet);
@@ -85,13 +88,13 @@ public class GraphSuccessorsSetViewTest {
     public void testInstantiateTo() throws ContradictionException {
         Model m = new Model();
         int n = 5;
-        UndirectedGraph LB = GraphFactory.makeStoredUndirectedGraph(m, n, SetType.BITSET, SetType.BITSET);
-        UndirectedGraph UB = GraphFactory.makeCompleteStoredUndirectedGraph(m, n, SetType.BITSET, SetType.BITSET, false);
-        UndirectedGraphVar g = m.undirectedGraphVar("g", LB, UB);
-        GraphSuccessorsSetView s = new GraphSuccessorsSetView("s", g, 0);
+        DirectedGraph LB = GraphFactory.makeStoredDirectedGraph(m, n, SetType.BITSET, SetType.BITSET);
+        DirectedGraph UB = GraphFactory.makeCompleteStoredDirectedGraph(m, n, SetType.BITSET, SetType.BITSET, false);
+        DirectedGraphVar g = m.directedGraphVar("g", LB, UB);
+        GraphPredecessorsSetView s = new GraphPredecessorsSetView("s", g, 0);
         s.instantiateTo(new int[] {2, 3}, s);
         while (m.getSolver().solve()) {
-            int[] neighsInGraph = g.getValue().getNeighborsOf(0).toArray();
+            int[] neighsInGraph = g.getValue().getPredecessorsOf(0).toArray();
             int[] neighSet = s.getValue().toArray();
             Arrays.sort(neighsInGraph);
             Arrays.sort(neighSet);
@@ -127,10 +130,10 @@ public class GraphSuccessorsSetViewTest {
         DirectedGraph LB = GraphFactory.makeStoredDirectedGraph(m, n, SetType.BITSET, SetType.BITSET);
         DirectedGraph UB = GraphFactory.makeStoredAllNodesDirectedGraph(m, n, SetType.BITSET, SetType.BITSET, false);
         for (int i = 1; i < n; i ++) {
-            UB.addEdge(0, i);
+            UB.addEdge(i, 0);
         }
         DirectedGraphVar g = m.directedGraphVar("g", LB, UB);
-        SetVar s = m.graphSuccessorsSetView(g, 0);
+        SetVar s = m.graphPredecessorsSetView(g, 0);
         Constraint nbEdges = new Constraint("NbEdges", new PropNbEdges(g, m.intVar(3, 7)));
         m.post(nbEdges);
         m.member(2, s).post();
@@ -141,7 +144,7 @@ public class GraphSuccessorsSetViewTest {
         while (m.getSolver().solve()) {
             Assert.assertTrue(g.getValue().getNodes().contains(0));
             Assert.assertTrue(g.getValue().getNodes().contains(2));
-            Assert.assertTrue(g.getValue().getSuccessorsOf(0).contains(2));
+            Assert.assertTrue(g.getValue().getPredecessorsOf(0).contains(2));
             Assert.assertTrue(card.getValue() >= 3 && card.getValue() <= 4);
             Assert.assertTrue(s.getValue().size() >= 3 && s.getValue().size() <= 4);
         }


### PR DESCRIPTION
Fixes # .

Changes proposed in this PR:
- Graph variables were migrated from choco-graph to choco, with some graph API refactoring. This refactoring does not change the behaviour of graph data structures nor graph variable, but attempt to provide a cleaning and unambiguous API for using graph data structures and variable. The changes are the following:

    - The semantic distinction between arcs and edges has been removed for more clarity (arc is mainly used in French, but in     English it is much more common to talk about (directed or not) edges. If the graph is undirected, edges are undirected, if the graph is directed, the graph is directed.
        - In graph data structures (`IGraph`), methods related to edges are `addEdge`, `removeEdge`, and `containsEdge`.
        - In graph variables (`GraphVar`), methods related to edges are `enforceEdge` and `removeEdge`.
 
    - The object model is such that the more abstract interface specifies directed graph accessors on edges (in `IGraph`: `getSuccessorsOf` and `getPredecessorsOf`; in GraphVar: `getMandatorySuccessorsOf`, `getPotentialSuccessorsOf`, `getMandatoryPredecessorsOf`, and `getPotentialPredecessorsOf`. When the graph is undirected, the methods `getNeighbors` in `UndirectedGraph`, and `getMandatoryNeighborsOf` and `getPotentialNeighborsOf` in `UndirectedGraphVar` are available. Note that an undirected graph is equivalent to a directed graph with couples of opposite directed edges. Thus, the neighbors of a node in an undirected graph are both successors and predecessors, and this is why these methods are equivalent to neighbors related methods in the case of an undirected graph. To encourage unambiguous use and facilitate code reading, the successors and predecessors related method have been defined as deprecated in explicit uses of UndirectedGraphs.
 
   - The possibility to chose (in graph data structure constructors) and get the set data structure for nodes has also been added, as it was only implemented for neighbors: `getNodeSetType` and `getEdgeSetType`. The previous default behaviour has been conserved with default constructors. 
- Set views over graph variables were implemented and tested. It is planned to add more of these views as they provide straightforward and expressive modelling possibilities. For now, the abstract class `GraphSetView` and the views `GraphNodeSetView` (set view over the nodes of a graph var), `GraphSuccessorsSetView` (set view over successors of a node of a graph, or simply neighbors for undirected graph vars), and `GraphPredecessorsSetView` (same as previous with predecessors) were implemented.
- `GraphDeltaMonitor` has been modified in accordance with commit 84a3fc304ceca684cebe776543a3bb4e5b6d76ad.
- All new functionalities over graph variables and graph views were integrated in corresponding factoring following the coding style of Choco.
- A `GraphFactory` was implemented, similarly to the `SetFactory`, to provide useful functions for instantiating graph data structures.
 
@chocoteam/core-developer 
