### PR TITLE
PARSER performance test : fix objective checking

### DIFF
--- a/parsers/src/test/java/org/chocosolver/flatzinc/PerformanceTest.java
+++ b/parsers/src/test/java/org/chocosolver/flatzinc/PerformanceTest.java
@@ -52,7 +52,7 @@ public class PerformanceTest {
                 parameters.add(new Object[]{
                         ROOT + columns[0] + File.separator + columns[1], // path
                         Integer.parseInt(columns[2]), // solutions
-                        Integer.getInteger(columns[3]), // best
+                        "_".equals(columns[3])?null:Integer.parseInt(columns[3]), // best
                         Integer.parseInt(columns[4]), // nodes
                         Integer.parseInt(columns[5]) // failures
                 });
@@ -83,12 +83,12 @@ public class PerformanceTest {
         //fzn.getModel().displayPropagatorOccurrences();
         fzn.solve();
         Assert.assertEquals(fzn.getModel().getSolver().getSearchState(), SearchState.TERMINATED, "Unexpected search state");
-        Assert.assertEquals(fzn.getModel().getSolver().getSolutionCount(), solutions, "Unexpected number of solutions");
-        Assert.assertEquals(fzn.getModel().getSolver().getNodeCount(), nodes, "Unexpected number of nodes");
-        Assert.assertEquals(fzn.getModel().getSolver().getFailCount(), failures, "Unexpected number of failures");
         if (bst != null) {
             Assert.assertEquals(fzn.getModel().getSolver().getObjectiveManager().getBestSolutionValue(), bst, "Unexpected best solution");
         }
+        Assert.assertEquals(fzn.getModel().getSolver().getSolutionCount(), solutions, "Unexpected number of solutions");
+        Assert.assertEquals(fzn.getModel().getSolver().getNodeCount(), nodes, "Unexpected number of nodes");
+        Assert.assertEquals(fzn.getModel().getSolver().getFailCount(), failures, "Unexpected number of failures");
     }
 
 
@@ -139,10 +139,10 @@ public class PerformanceTest {
         //fzn.getModel().displayPropagatorOccurrences();
         fzn.solve();
         Assert.assertEquals(fzn.getModel().getSolver().getSearchState(), SearchState.TERMINATED, "Unexpected search state");
-        Assert.assertEquals(fzn.getModel().getSolver().getSolutionCount(), 33, "Unexpected number of solutions");
+        Assert.assertEquals(fzn.getModel().getSolver().getObjectiveManager().getBestSolutionValue(), 103936, "Unexpected best solution");
         Assert.assertEquals(fzn.getModel().getSolver().getNodeCount(), 2_174_212, "Unexpected number of nodes");
         Assert.assertEquals(fzn.getModel().getSolver().getFailCount(), 2_174_147, "Unexpected number of failures");
-        Assert.assertEquals(fzn.getModel().getSolver().getObjectiveManager().getBestSolutionValue(), 103936, "Unexpected best solution");
+        Assert.assertEquals(fzn.getModel().getSolver().getSolutionCount(), 33, "Unexpected number of solutions");
     }
 
     @Test(groups = "mzn", timeOut = 120_000, priority = 2)
@@ -165,9 +165,9 @@ public class PerformanceTest {
         //fzn.getModel().displayPropagatorOccurrences();
         fzn.solve();
         Assert.assertEquals(fzn.getModel().getSolver().getSearchState(), SearchState.TERMINATED, "Unexpected search state");
+        Assert.assertEquals(fzn.getModel().getSolver().getObjectiveManager().getBestSolutionValue(), 1123, "Unexpected best solution");
         Assert.assertEquals(fzn.getModel().getSolver().getSolutionCount(), 35, "Unexpected number of solutions");
         Assert.assertEquals(fzn.getModel().getSolver().getNodeCount(), 841_296, "Unexpected number of nodes");
         Assert.assertEquals(fzn.getModel().getSolver().getFailCount(), 841_227, "Unexpected number of failures");
-        Assert.assertEquals(fzn.getModel().getSolver().getObjectiveManager().getBestSolutionValue(), 1123, "Unexpected best solution");
     }
 }

--- a/parsers/src/test/resources/flatzinc/instances.csv
+++ b/parsers/src/test/resources/flatzinc/instances.csv
@@ -1,5 +1,5 @@
 #year,name,solutions,best,nodes,fails
-2021,feistel.fzn,1,17,174,160
+2021,feistel.fzn,1,_,174,160
 2020,bnn+inventory_4_8s.fzn,1,17,16,15
 #2020,bnn+cellda_y_10s.fzn,1,6,16582,16581
 2020,is+v1HjuSBQMb.fzn,18,454656,13938,13903


### PR DESCRIPTION
- best objective value was never read
- check objective before nb sols & nodes & fails in case we can find the same optimum faster