### PR TITLE
Dead code removal in IIntConstraintFactory#nvalue().

### DIFF
--- a/solver/src/main/java/org/chocosolver/solver/constraints/IIntConstraintFactory.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/IIntConstraintFactory.java
@@ -1833,7 +1833,6 @@ public interface IIntConstraintFactory extends ISelf<Model> {
      * @return the conjunction of atleast_nvalue and atmost_nvalue
      */
     default Constraint nValues(IntVar[] vars, IntVar nValues) {
-        int[] vals = getDomainUnion(vars);
         Gci gci = new Gci(vars);
         R[] rules = new R[]{new R1(), new R3(vars.length, nValues.getModel())};
         return new Constraint(


### PR DESCRIPTION
The call to getDomainUnion() is useless given
that PropAtLeastNValues and PropAtMostNValues
propagators are commented.

Possibly, this call was escaped by the compiler but
this is a better way to be sure.