### PR TITLE
Patch `compareTo` in Propagator.java for correct scala support.

### DIFF
--- a/solver/src/main/java/org/chocosolver/solver/constraints/Propagator.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/Propagator.java
@@ -628,7 +628,7 @@ public abstract class Propagator<V extends Variable> implements ICause, Identity
     }
 
     @Override
-    public int compareTo(Propagator o) {
+    public int compareTo(Propagator<V> o) {
         return this.ID - o.ID;
     }
 


### PR DESCRIPTION
on Scala 3, the compiler seems to have some deep trouble with the fact that  the `compareTo` argument has no type arguments. Even though this is fine for Java and its type-erasure knowledge, Scala totally breaks. I propose the simple addition of the `V` type parameter just to make sure this does not happen. It should not occur any hurdle anywhere else in the code, I believe.

I've just cloned and tested my scala codebase with the simple change, and it has worked! So there's nos loss. I could not complete the real number tests of the choco test suite due to lack of time and experience with IBEX, but the other discrete tests all passed. 

I am sorry if the main branch was no the one to be patched. It is such an easy patch that I think it will be easy to propagate to the correct branches.