### PR TITLE
`IntVar` handles with `long` values...

### DIFF
--- a/solver/src/main/java/org/chocosolver/solver/constraints/nary/sum/PropScalarWithLong.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/nary/sum/PropScalarWithLong.java
@@ -1,0 +1,321 @@
+/*
+ * This file is part of choco-solver, http://choco-solver.org/
+ *
+ * Copyright (c) 2022, IMT Atlantique. All rights reserved.
+ *
+ * Licensed under the BSD 4-clause license.
+ *
+ * See LICENSE file in the project root for full license information.
+ */
+package org.chocosolver.solver.constraints.nary.sum;
+
+import org.chocosolver.solver.constraints.Operator;
+import org.chocosolver.solver.exception.ContradictionException;
+import org.chocosolver.solver.variables.IntVar;
+import org.chocosolver.util.ESat;
+
+/**
+ * A propagator for SUM(x_i*c_i) = b
+ * <br/>
+ * Based on "Bounds Consistency Techniques for Long Linear Constraint" </br>
+ * W. Harvey and J. Schimpf
+ * <p>
+ *
+ * @author Charles Prud'homme
+ * @since 18/03/11
+ */
+public class PropScalarWithLong extends PropSumWithLong {
+
+    /**
+     * The coefficients
+     */
+    private final long[] c;
+
+    /**
+     * Create a scalar product: SUM(x_i*c_i) o b
+     * Variables and coefficients are excepted to be ordered wrt to coefficients: first positive ones then negative ones.
+     * @param variables list of integer variables
+     * @param coeffs list of coefficients
+     * @param pos position of the last positive coefficient
+     * @param o operator
+     * @param b bound to respect.
+     */
+    public PropScalarWithLong(IntVar[] variables, long[] coeffs, int pos, Operator o, long b) {
+        super(variables, pos, o, b);
+        this.c = coeffs;
+    }
+
+
+    @Override
+    protected void prepare() {
+        sumLB = sumUB = 0;
+        int i = 0;
+        long lb, ub;
+        maxI = 0;
+        for (; i < pos; i++) { // first the positive coefficients
+            lb = vars[i].getLB() * c[i];
+            ub = vars[i].getUB() * c[i];
+            sumLB += lb;
+            sumUB += ub;
+            I[i] = (ub - lb);
+            if(maxI < I[i])maxI = I[i];
+        }
+        for (; i < l; i++) { // then the negative ones
+            lb = vars[i].getUB() * c[i];
+            ub = vars[i].getLB() * c[i];
+            sumLB += lb;
+            sumUB += ub;
+            I[i] = (ub - lb);
+            if(maxI < I[i])maxI = I[i];
+        }
+    }
+
+
+    @Override
+    protected void filterOnEq() throws ContradictionException {
+        boolean anychange;
+        long F = b - sumLB;
+        long E = sumUB - b;
+        do {
+            anychange = false;
+            // When explanations are on, no global failure allowed
+            if (model.getSolver().isLearnOff() && F < 0 || E < 0) {
+                fails();
+            }
+            if (maxI > F || maxI > E) {
+                maxI = 0;
+                long lb, ub;
+                int i = 0;
+                // positive coefficients first
+                while (i < pos) {
+                    if (I[i] - F > 0) {
+                        lb = vars[i].getLB() * c[i];
+                        ub = lb + I[i];
+                        if (vars[i].updateUpperBound(divFloor(F + lb, c[i]), this)) {
+                            long nub = vars[i].getUB() * c[i];
+                            E += nub - ub;
+                            I[i] = nub - lb;
+                            anychange = true;
+                        }
+                    }
+                    if (I[i] - E > 0) {
+                        ub = vars[i].getUB() * c[i];
+                        lb = ub - I[i];
+                        if (vars[i].updateLowerBound(divCeil(ub - E, c[i]), this)) {
+                            long nlb = vars[i].getLB() * c[i];
+                            F -= nlb - lb;
+                            I[i] = ub - nlb;
+                            anychange = true;
+                        }
+                    }
+                    if(maxI < I[i])maxI = I[i];
+                    i++;
+                }
+                // then negative ones
+                while (i < l) {
+                    if (I[i] - F > 0) {
+                        lb = vars[i].getUB() * c[i];
+                        ub = lb + I[i];
+                        if (vars[i].updateLowerBound(divCeil(-F - lb, -c[i]), this)) {
+                            long nub = vars[i].getLB() * c[i];
+                            E += nub - ub;
+                            I[i] = nub - lb;
+                            anychange = true;
+                        }
+                    }
+                    if (I[i] - E > 0) {
+                        ub = vars[i].getLB() * c[i];
+                        lb = ub - I[i];
+                        if (vars[i].updateUpperBound(divFloor(-ub + E, -c[i]), this)) {
+                            long nlb = vars[i].getUB() * c[i];
+                            F -= nlb - lb;
+                            I[i] = ub - nlb;
+                            anychange = true;
+                        }
+                    }
+                    if(maxI < I[i])maxI = I[i];
+                    i++;
+                }
+            }
+            if (F <= 0 && E <= 0) {
+                this.setPassive();
+                return;
+            }
+        } while (anychange);
+    }
+
+    @Override
+    protected void filterOnLeq() throws ContradictionException {
+        long F = b - sumLB;
+        long E = sumUB - b;
+        // When explanations are on, no global failure allowed
+        if (model.getSolver().isLearnOff() &&F < 0) {
+            fails();
+        }
+        if (maxI > F) {
+            long lb, ub;
+            int i = 0;
+            maxI = 0;
+            // positive coefficients first
+            while (i < pos) {
+                maxI = 0;
+                if (I[i] - F > 0) {
+                    lb = vars[i].getLB() * c[i];
+                    ub = lb + I[i];
+                    if (vars[i].updateUpperBound(divFloor(F + lb, c[i]), this)) {
+                        long nub = vars[i].getUB() * c[i];
+                        E += nub - ub;
+                        I[i] = nub - lb;
+                    }
+                }
+                if(maxI < I[i])maxI = I[i];
+                i++;
+            }
+            // then negative ones
+            while (i < l) {
+                if (I[i] - F > 0) {
+                    lb = vars[i].getUB() * c[i];
+                    ub = lb + I[i];
+                    if (vars[i].updateLowerBound(divCeil(-F - lb, -c[i]), this)) {
+                        long nub = vars[i].getLB() * c[i];
+                        E += nub - ub;
+                        I[i] = nub - lb;
+                    }
+                }
+                if(maxI < I[i])maxI = I[i];
+                i++;
+            }
+        }
+        if (E <= 0) {
+            this.setPassive();
+        }
+    }
+
+    @Override
+    protected void filterOnGeq() throws ContradictionException {
+        long F = b - sumLB;
+        long E = sumUB - b;
+        // When explanations are on, no global failure allowed
+        if (model.getSolver().isLearnOff() && E < 0) {
+            fails();
+        }
+        if (maxI > E) {
+            maxI = 0;
+            long lb, ub;
+            int i = 0;
+            // positive coefficients first
+            while (i < pos) {
+                if (I[i] - E > 0) {
+                    ub = vars[i].getUB() * c[i];
+                    lb = ub - I[i];
+                    if (vars[i].updateLowerBound(divCeil(ub - E, c[i]), this)) {
+                        long nlb = vars[i].getLB() * c[i];
+                        F -= nlb - lb;
+                        I[i] = ub - nlb;
+                    }
+                }
+                if(maxI < I[i])maxI = I[i];
+                i++;
+            }
+            // then negative ones
+            while (i < l) {
+                if (I[i] - E > 0) {
+                    ub = vars[i].getLB() * c[i];
+                    lb = ub - I[i];
+                    if (vars[i].updateUpperBound(divFloor(-ub + E, -c[i]), this)) {
+                        long nlb = vars[i].getUB() * c[i];
+                        F -= nlb - lb;
+                        I[i] = ub - nlb;
+                    }
+                }
+                if(maxI < I[i])maxI = I[i];
+                i++;
+            }
+        }
+        if (F <= 0) {
+            this.setPassive();
+        }
+    }
+
+    @Override
+    protected void filterOnNeq() throws ContradictionException {
+        long F = b - sumLB;
+        long E = sumUB - b;
+        if (F < 0 || E < 0) {
+            setPassive();
+            return;
+        }
+        int w = -1;
+        int sum = 0;
+        for (int i = 0; i < l; i++) {
+            if (vars[i].isInstantiated()) {
+                sum += vars[i].getValue() * c[i];
+            } else if (w == -1) {
+                w = i;
+            } else return;
+        }
+        if (w == -1) {
+            if (sum == b) {
+                this.fails();
+            }
+        } else if(c[w]!=0 && (b - sum)%c[w]==0){
+            vars[w].removeValue((b - sum)/c[w], this);
+        }
+    }
+
+    @Override
+    public ESat isEntailed() {
+        long sumUB = 0, sumLB = 0;
+        int i = 0;
+        for (; i < pos; i++) { // first the positive coefficients
+            sumLB += vars[i].getLB() * c[i];
+            sumUB += vars[i].getUB() * c[i];
+        }
+        for (; i < l; i++) { // then the negative ones
+            sumLB += vars[i].getUB() * c[i];
+            sumUB += vars[i].getLB() * c[i];
+        }
+        return check(sumLB, sumUB);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder linComb = new StringBuilder(20);
+        linComb.append(c[0]).append('.').append(vars[0].getName());
+        int i = 1;
+        for (; i < pos; i++) {
+            linComb.append(" + ").append(c[i]).append('.').append(vars[i].getName());
+        }
+        for (; i < l; i++) {
+            linComb.append(" - ").append(-c[i]).append('.').append(vars[i].getName());
+        }
+        linComb.append(" ").append(o).append(" ");
+        linComb.append(b);
+        return linComb.toString();
+    }
+
+
+    private long divFloor(long a, long b) {
+        // <!> we assume b > 0
+        if (a >= 0) {
+            return (a / b);
+        } else {
+            return (a - b + 1) / b;
+        }
+    }
+
+    private long divCeil(long a, long b) {
+        // <!> we assume b > 0
+        if (a >= 0) {
+            return ((a + b - 1) / b);
+        } else {
+            return a / b;
+        }
+    }
+
+    @Override
+    protected PropScalarWithLong opposite(){
+        return new PropScalarWithLong(vars, c, pos, nop(o), b + nb(o));
+    }
+
+}

--- a/solver/src/main/java/org/chocosolver/solver/constraints/nary/sum/PropSumWithLong.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/nary/sum/PropSumWithLong.java
@@ -1,0 +1,488 @@
+/*
+ * This file is part of choco-solver, http://choco-solver.org/
+ *
+ * Copyright (c) 2022, IMT Atlantique. All rights reserved.
+ *
+ * Licensed under the BSD 4-clause license.
+ *
+ * See LICENSE file in the project root for full license information.
+ */
+package org.chocosolver.solver.constraints.nary.sum;
+
+import org.chocosolver.solver.constraints.Operator;
+import org.chocosolver.solver.constraints.Propagator;
+import org.chocosolver.solver.constraints.PropagatorPriority;
+import org.chocosolver.solver.exception.ContradictionException;
+import org.chocosolver.solver.variables.IntVar;
+import org.chocosolver.solver.variables.events.IntEventType;
+import org.chocosolver.util.ESat;
+
+/**
+ * A propagator for SUM(x_i) o b
+ * <br/>
+ * Based on "Bounds Consistency Techniques for Long Linear Constraint" </br>
+ * W. Harvey and J. Schimpf
+ * <p>
+ *
+ * @author Charles Prud'homme
+ * @since 18/03/11
+ */
+public class PropSumWithLong extends Propagator<IntVar> {
+
+    /**
+     * The position of the last positive coefficient
+     */
+    protected final int pos;
+
+    /**
+     * Number of variables
+     */
+    protected final int l;
+
+    /**
+     * Bound to respect
+     */
+    protected final long b;
+
+    /**
+     * Variability of each variable (ie domain amplitude)
+     */
+    protected final long[] I;
+
+    /**
+     * Stores the maximal variability
+     */
+    protected long maxI;
+
+    /**
+     * SUm of lower bounds
+     */
+    protected long sumLB;
+
+    /**
+     * Sum of upper bounds
+     */
+    protected long sumUB;
+
+    /**
+     * The operator among EQ, LE, GE and NE
+     */
+    protected final Operator o;
+
+
+    /**
+     * Creates a sum propagator: SUM(x_i) o b
+     * Coefficients are induced by <code>pos</code>:
+     * those before <code>pos</code> (included) are equal to 1,
+     * the other ones are equal to -1.
+     *
+     * @param variables list of integer variables
+     * @param pos position of the last positive coefficient
+     * @param o operator amng EQ, LE, GE and NE
+     * @param b bound to respect
+     */
+    public PropSumWithLong(IntVar[] variables, int pos, Operator o, long b) {
+        this(variables, pos, o, b, computePriority(variables.length), false);
+    }
+
+
+    PropSumWithLong(IntVar[] variables, int pos, Operator o, long b, PropagatorPriority priority, boolean reactOnFineEvent){
+        super(variables, priority, reactOnFineEvent);
+        this.pos = pos;
+        this.o = o;
+        this.b = b;
+        l = variables.length;
+        I = new long[l];
+        maxI = 0;
+    }
+
+    /**
+     * Compute the priority of the propagator wrt the number of involved variables
+     * @param nbvars number of variables
+     * @return the priority
+     */
+    protected static PropagatorPriority computePriority(int nbvars) {
+        if (nbvars == 1) {
+            return PropagatorPriority.UNARY;
+        } else if (nbvars == 2) {
+            return PropagatorPriority.BINARY;
+        } else if (nbvars == 3) {
+            return PropagatorPriority.TERNARY;
+        } else {
+            return PropagatorPriority.LINEAR;
+        }
+    }
+
+    @Override
+    public int getPropagationConditions(int vIdx) {
+        switch (o) {
+            case NQ:
+                return IntEventType.instantiation();
+            case LE:
+                return IntEventType.combine(IntEventType.INSTANTIATE, vIdx < pos ? IntEventType.INCLOW : IntEventType.DECUPP);
+            case GE:
+                return IntEventType.combine(IntEventType.INSTANTIATE, vIdx < pos ? IntEventType.DECUPP : IntEventType.INCLOW);
+            default:
+                return IntEventType.boundAndInst();
+        }
+    }
+
+
+    /**
+     * Prepare the propagation: compute sumLB, sumUB and I
+     */
+    protected void prepare() {
+        sumLB = sumUB = 0;
+        int i = 0;
+        int lb, ub;
+        maxI = 0;
+        for (; i < pos; i++) { // first the positive coefficients
+            lb = vars[i].getLB();
+            ub = vars[i].getUB();
+            sumLB += lb;
+            sumUB += ub;
+            I[i] = (ub - lb);
+            if(maxI < I[i])maxI = I[i];
+        }
+        for (; i < l; i++) { // then the negative ones
+            lb = -vars[i].getUB();
+            ub = -vars[i].getLB();
+            sumLB += lb;
+            sumUB += ub;
+            I[i] = (ub - lb);
+            if(maxI < I[i])maxI = I[i];
+        }
+    }
+
+
+    @Override
+    public void propagate(int evtmask) throws ContradictionException {
+        filter();
+    }
+
+    /**
+     * Execute filtering wrt the operator
+     * @throws ContradictionException if contradiction is detected
+     */
+    protected void filter() throws ContradictionException {
+        prepare();
+        switch (o) {
+            case LE:
+                filterOnLeq();
+                break;
+            case GE:
+                filterOnGeq();
+                break;
+            case NQ:
+                filterOnNeq();
+                break;
+            default:
+                filterOnEq();
+                break;
+        }
+    }
+
+    /**
+     * Apply filtering when operator is EQ
+     * @throws ContradictionException if contradiction is detected
+     */
+    protected void filterOnEq() throws ContradictionException {
+        boolean anychange;
+        long F = b - sumLB;
+        long E = sumUB - b;
+        do {
+            anychange = false;
+            // When explanations are on, no global failure allowed
+            if (model.getSolver().isLearnOff() && (F < 0 || E < 0)) {
+                fails();
+            }
+            if (maxI > F || maxI > E) {
+                long lb, ub;
+                int i = 0;
+                maxI = 0;
+                // positive coefficients first
+                while (i < pos) {
+                    if (I[i] - F > 0) {
+                        lb = vars[i].getLB();
+                        ub = lb + I[i];
+                        if (vars[i].updateUpperBound(F + lb, this)) {
+                            int nub = vars[i].getUB();
+                            E += nub - ub;
+                            I[i] = nub - lb;
+                            anychange = true;
+                        }
+                    }
+                    if (I[i] - E > 0) {
+                        ub = vars[i].getUB();
+                        lb = ub - I[i];
+                        if (vars[i].updateLowerBound(ub - E, this)) {
+                            int nlb = vars[i].getLB();
+                            F -= nlb - lb;
+                            I[i] = ub - nlb;
+                            anychange = true;
+                        }
+                    }
+                    if(maxI < I[i])maxI = I[i];
+                    i++;
+                }
+                // then negative ones
+                while (i < l) {
+                    if (I[i] - F > 0) {
+                        lb = -vars[i].getUB();
+                        ub = lb + I[i];
+                        if (vars[i].updateLowerBound(-F - lb, this)) {
+                            int nub = -vars[i].getLB();
+                            E += nub - ub;
+                            I[i] = nub - lb;
+                            anychange = true;
+                        }
+                    }
+                    if (I[i] - E > 0) {
+                        ub = -vars[i].getLB();
+                        lb = ub - I[i];
+                        if (vars[i].updateUpperBound(-ub + E, this)) {
+                            int nlb = -vars[i].getUB();
+                            F -= nlb - lb;
+                            I[i] = ub - nlb;
+                            anychange = true;
+                        }
+                    }
+                    if(maxI < I[i])maxI = I[i];
+                    i++;
+                }
+            }
+            // useless since true when all variables are instantiated
+            if (F <= 0 && E <= 0) {
+                this.setPassive();
+                return;
+            }
+        }while (anychange) ;
+    }
+
+    /**
+     * Apply filtering when operator is LE
+     * @throws ContradictionException if contradiction is detected
+     */
+    protected void filterOnLeq() throws ContradictionException {
+        long F = b - sumLB;
+        long E = sumUB - b;
+        // When explanations are on, no global failure allowed
+        if (model.getSolver().isLearnOff() && F < 0) {
+            fails();
+        }
+        if (maxI > F) {
+            maxI = 0;
+            long lb, ub;
+            int i = 0;
+            // positive coefficients first
+            while (i < pos) {
+                if (I[i] - F > 0) {
+                    lb = vars[i].getLB();
+                    ub = lb + I[i];
+                    if (vars[i].updateUpperBound(F + lb, this)) {
+                        int nub = vars[i].getUB();
+                        E += nub - ub;
+                        I[i] = nub - lb;
+                    }
+                }
+                if(maxI < I[i])maxI = I[i];
+                i++;
+            }
+            // then negative ones
+            while (i < l) {
+                if (I[i] - F > 0) {
+                    lb = -vars[i].getUB();
+                    ub = lb + I[i];
+                    if (vars[i].updateLowerBound(-F - lb, this)) {
+                        int nub = -vars[i].getLB();
+                        E += nub - ub;
+                        I[i] = nub - lb;
+                    }
+                }
+                if(maxI < I[i])maxI = I[i];
+                i++;
+            }
+        }
+        if (E <= 0) {
+            this.setPassive();
+        }
+    }
+
+    /**
+     * Apply filtering when operator is GE
+     * @throws ContradictionException if contradiction is detected
+     */
+    protected void filterOnGeq() throws ContradictionException {
+        long F = b - sumLB;
+        long E = sumUB - b;
+        // When explanations are on, no global failure allowed
+        if (model.getSolver().isLearnOff() && E < 0) {
+            fails();
+        }
+        if(maxI > E) {
+            maxI = 0;
+            long lb, ub;
+            int i = 0;
+            // positive coefficients first
+            while (i < pos) {
+                if (I[i] - E > 0) {
+                    ub = vars[i].getUB();
+                    lb = ub - I[i];
+                    if (vars[i].updateLowerBound(ub - E, this)) {
+                        int nlb = vars[i].getLB();
+                        F -= nlb - lb;
+                        I[i] = ub - nlb;
+                    }
+                }
+                if(maxI < I[i])maxI = I[i];
+                i++;
+            }
+            // then negative ones
+            while (i < l) {
+                if (I[i] - E > 0) {
+                    ub = -vars[i].getLB();
+                    lb = ub - I[i];
+                    if (vars[i].updateUpperBound(-ub + E, this)) {
+                        int nlb = -vars[i].getUB();
+                        F -= nlb - lb;
+                        I[i] = ub - nlb;
+                    }
+                }
+                if(maxI < I[i])maxI = I[i];
+                i++;
+            }
+        }
+        if (F <= 0) {
+            this.setPassive();
+        }
+    }
+
+    /**
+     * Apply filtering when operator is NE
+     * @throws ContradictionException if contradiction is detected
+     */
+    protected void filterOnNeq() throws ContradictionException {
+        long F = b - sumLB;
+        long E = sumUB - b;
+        if (F < 0 || E < 0) {
+            setPassive();
+            return;
+        }
+        int w = -1;
+        int sum = 0;
+        for (int i = 0; i < l; i++) {
+            if (vars[i].isInstantiated()) {
+                sum += i < pos ? vars[i].getValue() : -vars[i].getValue();
+            } else if (w == -1) {
+                w = i;
+            } else return;
+        }
+        if (w == -1) {
+            if (sum == b) {
+                this.fails();
+            }
+        } else {
+            vars[w].removeValue(w < pos ? b - sum : sum - b, this);
+        }
+    }
+
+    @Override
+    public ESat isEntailed() {
+        long sumUB = 0, sumLB = 0;
+        int i = 0;
+        for (; i < pos; i++) { // first the positive coefficients
+            sumLB += vars[i].getLB();
+            sumUB += vars[i].getUB();
+        }
+        for (; i < l; i++) { // then the negative ones
+            sumLB -= vars[i].getUB();
+            sumUB -= vars[i].getLB();
+        }
+        return check(sumLB, sumUB);
+    }
+
+    /**
+     * Whether the current state of the scalar product is entailed
+     * @param sumLB sum of lower bounds
+     * @param sumUB sum of upper bounds
+     * @return the entailment check
+     */
+    public ESat check(long sumLB, long sumUB){
+        switch (o) {
+            case NQ:
+                if (sumUB < b || sumLB > b) {
+                    return ESat.TRUE;
+                }
+                if (sumUB == b && sumLB == b) {
+                    return ESat.FALSE;
+                }
+                return ESat.UNDEFINED;
+            case LE:
+                if (sumUB <= b) {
+                    return ESat.TRUE;
+                }
+                if (sumLB > b) {
+                    return ESat.FALSE;
+                }
+                return ESat.UNDEFINED;
+            case GE:
+                if (sumLB >= b) {
+                    return ESat.TRUE;
+                }
+                if (sumUB < b) {
+                    return ESat.FALSE;
+                }
+                return ESat.UNDEFINED;
+            default:
+                if (sumLB == b && sumUB == b) {
+                    return ESat.TRUE;
+                }
+                if (sumUB < b || sumLB > b) {
+                    return ESat.FALSE;
+                }
+                return ESat.UNDEFINED;
+        }
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder linComb = new StringBuilder(20);
+        linComb.append(pos == 0 ? "-" : "").append(vars[0].getName());
+        int i = 1;
+        for (; i < pos; i++) {
+            linComb.append(" + ").append(vars[i].getName());
+        }
+        for (; i < l; i++) {
+            linComb.append(" - ").append(vars[i].getName());
+        }
+        linComb.append(" ").append(o).append(" ");
+        linComb.append(b);
+        return linComb.toString();
+    }
+
+    public static long nb(Operator co){
+        switch (co){
+            case LE:
+                return 1;
+            case GE:
+                return -1;
+            default:
+                return 0;
+        }
+    }
+
+    public static Operator nop(Operator co){
+        switch (co){
+            case LE:
+                return Operator.GE;
+            case GE:
+                return Operator.LE;
+            default:
+                return Operator.getOpposite(co);
+        }
+    }
+
+    protected PropSumWithLong opposite(){
+        return new PropSumWithLong(vars, pos, nop(o), b + nb(o));
+    }
+}

--- a/solver/src/main/java/org/chocosolver/solver/constraints/nary/sum/SumWithLongConstraint.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/nary/sum/SumWithLongConstraint.java
@@ -1,0 +1,47 @@
+/*
+ * This file is part of choco-solver, http://choco-solver.org/
+ *
+ * Copyright (c) 2022, IMT Atlantique. All rights reserved.
+ *
+ * Licensed under the BSD 4-clause license.
+ *
+ * See LICENSE file in the project root for full license information.
+ */
+package org.chocosolver.solver.constraints.nary.sum;
+
+import org.chocosolver.solver.constraints.Constraint;
+import org.chocosolver.solver.constraints.ConstraintsName;
+import org.chocosolver.solver.constraints.Propagator;
+import org.chocosolver.solver.variables.IntVar;
+
+/**
+ * <p>
+ * Project: choco-solver.
+ *
+ * @author Charles Prud'homme
+ * @since 28/06/2016.
+ */
+public class SumWithLongConstraint extends Constraint {
+    /**
+     * Make a new constraint defined as a set of given propagators
+     *
+     * @param propagator propagator defining the constraint
+     */
+    public SumWithLongConstraint(Propagator<IntVar> propagator) {
+        super(ConstraintsName.SUM, propagator);
+    }
+
+    /**
+     * The only reason this class exists
+     *
+     * @return an accurate opposite constraint
+     */
+    @Override
+    protected Constraint makeOpposite() {
+        if (propagators[0] instanceof PropSum) {
+            PropSumWithLong me = (PropSumWithLong) propagators[0];
+            return new SumWithLongConstraint(me.opposite());
+        } else
+            return super.makeOpposite();
+    }
+}

--- a/solver/src/main/java/org/chocosolver/solver/constraints/ternary/PropTimesNaiveWithLong.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/ternary/PropTimesNaiveWithLong.java
@@ -1,0 +1,104 @@
+/*
+ * This file is part of choco-solver, http://choco-solver.org/
+ *
+ * Copyright (c) 2022, IMT Atlantique. All rights reserved.
+ *
+ * Licensed under the BSD 4-clause license.
+ *
+ * See LICENSE file in the project root for full license information.
+ */
+package org.chocosolver.solver.constraints.ternary;
+
+import org.chocosolver.solver.constraints.Propagator;
+import org.chocosolver.solver.constraints.PropagatorPriority;
+import org.chocosolver.solver.exception.ContradictionException;
+import org.chocosolver.solver.variables.IntVar;
+import org.chocosolver.solver.variables.events.IntEventType;
+import org.chocosolver.util.ESat;
+
+/**
+ * V0 * V1 = V2
+ * <br/>
+ *
+ * @author Charles Prud'homme
+ * @since 26/01/11
+ */
+public class PropTimesNaiveWithLong extends Propagator<IntVar> {
+
+    protected static final long MAX = Long.MAX_VALUE - 1, MIN = Long.MIN_VALUE + 1;
+
+    private final IntVar v0;
+    private final IntVar v1;
+    private final IntVar v2;
+
+    public PropTimesNaiveWithLong(IntVar v1, IntVar v2, IntVar result) {
+        super(new IntVar[]{v1, v2, result}, PropagatorPriority.TERNARY, false);
+        this.v0 = vars[0];
+        this.v1 = vars[1];
+        this.v2 = vars[2];
+    }
+
+    @Override
+    public final int getPropagationConditions(int vIdx) {
+        return IntEventType.boundAndInst();
+    }
+
+    @Override
+    public final void propagate(int evtmask) throws ContradictionException {
+        boolean hasChanged = true;
+        while (hasChanged) {
+            hasChanged = div(v0, v2.getLB(), v2.getUB(), v1.getLB(), v1.getUB());
+            hasChanged |= div(v1, v2.getLB(), v2.getUB(), v0.getLB(), v0.getUB());
+            hasChanged |= mul(v2, v0.getLB(), v0.getUB(), v1.getLB(), v1.getUB());
+        }
+        if (v2.isInstantiatedTo(0) && (v0.isInstantiatedTo(0) || v1.isInstantiatedTo(0))) {
+            setPassive();
+        }
+    }
+
+    @Override
+    public final ESat isEntailed() {
+        if (isCompletelyInstantiated()) {
+            return ESat.eval(v0.getValue() * v1.getValue() == v2.getValue());
+        }
+        return ESat.UNDEFINED;
+    }
+
+    private boolean div(IntVar var, int a, int b, int c, int d) throws ContradictionException {
+        long min, max;
+
+        if (a <= 0 && b >= 0 && c <= 0 && d >= 0) { // case 1
+            min = MIN;
+            max = MAX;
+            return var.updateLowerBound(min, this) | var.updateUpperBound(max, this);
+        } else if (c == 0 && d == 0 && (a > 0 || b < 0)) // case 2
+            fails(); // TODO: could be more precise, for explanation purpose
+        else if (c < 0 && d > 0 && (a > 0 || b < 0)) { // case 3
+            max = Math.max(Math.abs(a), Math.abs(b));
+            min = -max;
+            return var.updateLowerBound(min, this) | var.updateUpperBound(max, this);
+        } else if (c == 0 && d != 0 && (a > 0 || b < 0)) // case 4 a
+            return div(var, a, b, 1, d);
+        else if (c != 0 && d == 0 && (a > 0 || b < 0)) // case 4 b
+            return div(var, a, b, c, -1);
+        else { // if (c > 0 || d < 0) { // case 5
+            float ac = (float) a / c, ad = (float) a / d,
+                    bc = (float) b / c, bd = (float) b / d;
+            float low = Math.min(Math.min(ac, ad), Math.min(bc, bd));
+            float high = Math.max(Math.max(ac, ad), Math.max(bc, bd));
+            min = Math.round(Math.ceil(low));
+            max = Math.round(Math.floor(high));
+            if (min > max) this.fails(); // TODO: could be more precise, for explanation purpose
+            return var.updateLowerBound(min, this) | var.updateUpperBound(max, this);
+        }
+        return false;
+    }
+
+    private boolean mul(IntVar var, int a, int b, int c, int d) throws ContradictionException {
+        long min = Math.min(Math.min(a * c, a * d), Math.min(b * c, b * d));
+        long max = Math.max(Math.max(a * c, a * d), Math.max(b * c, b * d));
+        return var.updateLowerBound(min, this) | var.updateUpperBound(max, this);
+    }
+
+
+}

--- a/solver/src/main/java/org/chocosolver/solver/variables/IntVar.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/IntVar.java
@@ -73,6 +73,35 @@ public interface IntVar extends ICause, Variable, Iterable<Integer>, ArExpressio
     boolean removeValue(int value, ICause cause) throws ContradictionException;
 
     /**
+     * Removes <code>value</code>from the domain of <code>this</code>. The instruction comes from <code>propagator</code>.
+     * <p>
+     *     This method deals with <code>value</code> as <b>long</b>.
+     *     If such a long can be safely cast to an int, this falls back to regular case (int).
+     *     Otherwise, it can either trivially do nothing or fail.
+     * </p>
+     * <ul>
+     * <li>If <code>value</code> is out of the domain, nothing is done and the return value is <code>false</code>,</li>
+     * <li>if removing <code>value</code> leads to a dead-end (domain wipe-out),
+     * a <code>ContradictionException</code> is thrown,</li>
+     * <li>otherwise, if removing <code>value</code> from the domain can be done safely,
+     * the event type is created (the original event can be promoted) and observers are notified
+     * and the return value is <code>true</code></li>
+     * </ul>
+     *
+     * @param value value to remove from the domain (int)
+     * @param cause removal releaser
+     * @return true if the value has been removed, false otherwise
+     * @throws ContradictionException if the domain become empty due to this action
+     */
+    default boolean removeValue(long value, ICause cause) throws ContradictionException{
+        if ((int) value != value) { // cannot be cast to an int
+            return false;
+        } else {
+            return removeValue((int) value, cause);
+        }
+    }
+
+    /**
      * Removes the value in <code>values</code>from the domain of <code>this</code>. The instruction comes from <code>propagator</code>.
      * <ul>
      * <li>If all values are out of the domain, nothing is done and the return value is <code>false</code>,</li>
@@ -147,6 +176,35 @@ public interface IntVar extends ICause, Variable, Iterable<Integer>, ArExpressio
     boolean instantiateTo(int value, ICause cause) throws ContradictionException;
 
     /**
+     * Instantiates the domain of <code>this</code> to <code>value</code>. The instruction comes from <code>propagator</code>.
+     * <p>
+     *     This method deals with <code>value</code> as <b>long</b>.
+     *     If such a long can be safely cast to an int, this falls back to regular case (int).
+     *     Otherwise, it can either trivially do nothing or fail.
+     * </p>
+     * <ul>
+     * <li>If the domain of <code>this</code> is already instantiated to <code>value</code>,
+     * nothing is done and the return value is <code>false</code>,</li>
+     * <li>If the domain of <code>this</code> is already instantiated to another value,
+     * then a <code>ContradictionException</code> is thrown,</li>
+     * <li>Otherwise, the domain of <code>this</code> is restricted to <code>value</code> and the observers are notified
+     * and the return value is <code>true</code>.</li>
+     * </ul>
+     *
+     * @param value instantiation value (int)
+     * @param cause instantiation releaser
+     * @return true if the instantiation is done, false otherwise
+     * @throws ContradictionException if the domain become empty due to this action
+     */
+    default boolean instantiateTo(long value, ICause cause) throws ContradictionException{
+        if ((int) value != value) { // cannot be cast to an int
+            return instantiateTo(value < getLB() ? getLB() - 1 : getUB() + 1, cause);
+        } else {
+            return instantiateTo((int) value, cause);
+        }
+    }
+
+    /**
      * Updates the lower bound of the domain of <code>this</code> to <code>value</code>.
      * The instruction comes from <code>propagator</code>.
      * <ul>
@@ -164,6 +222,40 @@ public interface IntVar extends ICause, Variable, Iterable<Integer>, ArExpressio
      * @throws ContradictionException if the domain become empty due to this action
      */
     boolean updateLowerBound(int value, ICause cause) throws ContradictionException;
+
+    /**
+     * Updates the lower bound of the domain of <code>this</code> to <code>value</code>.
+     * The instruction comes from <code>propagator</code>.
+     * <p>
+     *     This method deals with <code>value</code> as <b>long</b>.
+     *     If such a long can be safely cast to an int, this falls back to regular case (int).
+     *     Otherwise, it can either trivially do nothing or fail.
+     * </p>
+     * <ul>
+     * <li>If <code>value</code> is smaller than the lower bound of the domain, nothing is done and the return value is <code>false</code>,</li>
+     * <li>if updating the lower bound to <code>value</code> leads to a dead-end (domain wipe-out),
+     * a <code>ContradictionException</code> is thrown,</li>
+     * <li>otherwise, if updating the lower bound to <code>value</code> can be done safely,
+     * the event type is created (the original event can be promoted) and observers are notified
+     * and the return value is <code>true</code></li>
+     * </ul>
+     *
+     * @param value new lower bound (included)
+     * @param cause updating releaser
+     * @return true if the lower bound has been updated, false otherwise
+     * @throws ContradictionException if the domain become empty due to this action
+     */
+    default boolean updateLowerBound(long value, ICause cause) throws ContradictionException {
+        if ((int) value != value) { // cannot be cast to an int
+            if (value < getLB()) {
+                return false;
+            } else { // then value >> getLB, this fails
+                return updateLowerBound(getUB() + 1, cause);
+            }
+        } else {
+            return updateLowerBound((int) value, cause);
+        }
+    }
 
     /**
      * Updates the upper bound of the domain of <code>this</code> to <code>value</code>.
@@ -184,6 +276,39 @@ public interface IntVar extends ICause, Variable, Iterable<Integer>, ArExpressio
      */
     boolean updateUpperBound(int value, ICause cause) throws ContradictionException;
 
+    /**
+     * Updates the upper bound of the domain of <code>this</code> to <code>value</code>.
+     * The instruction comes from <code>propagator</code>.
+     * <p>
+     *     This method deals with <code>value</code> as <b>long</b>.
+     *     If such a long can be safely cast to an int, this falls back to regular case (int).
+     *     Otherwise, it can either trivially do nothing or fail.
+     * </p>
+     * <ul>
+     * <li>If <code>value</code> is greater than the upper bound of the domain, nothing is done and the return value is <code>false</code>,</li>
+     * <li>if updating the upper bound to <code>value</code> leads to a dead-end (domain wipe-out),
+     * a <code>ContradictionException</code> is thrown,</li>
+     * <li>otherwise, if updating the upper bound to <code>value</code> can be done safely,
+     * the event type is created (the original event can be promoted) and observers are notified
+     * and the return value is <code>true</code></li>
+     * </ul>
+     *
+     * @param value new upper bound (included)
+     * @param cause update releaser
+     * @return true if the upper bound has been updated, false otherwise
+     * @throws ContradictionException if the domain become empty due to this action
+     */
+    default boolean updateUpperBound(long value, ICause cause) throws ContradictionException {
+        if ((int) value != value) { // cannot be cast to an int
+            if (value > getUB()) {
+                return false;
+            } else { // then value << getUB, this fails
+                return updateUpperBound(getLB() - 1, cause);
+            }
+        } else {
+            return updateUpperBound((int) value, cause);
+        }
+    }
 
     /**
      * Updates the lower bound and the upper bound of the domain of <code>this</code> to, resp. <code>lb</code> and <code>ub</code>.

--- a/solver/src/test/java/org/chocosolver/solver/constraints/nary/ScalarTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/nary/ScalarTest.java
@@ -10,10 +10,16 @@
 package org.chocosolver.solver.constraints.nary;
 
 import org.chocosolver.solver.Model;
+import org.chocosolver.solver.Settings;
+import org.chocosolver.solver.exception.ContradictionException;
+import org.chocosolver.solver.search.strategy.Search;
 import org.chocosolver.solver.variables.IntVar;
 import org.chocosolver.util.ESat;
+import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
+
+import java.util.Arrays;
 
 import static org.testng.Assert.*;
 
@@ -30,7 +36,7 @@ public class ScalarTest {
     }
 
 
-    @Test(groups = "1s", timeOut=60000)
+    @Test(groups = "1s", timeOut = 60000)
     public void testNominal() {
         int[] coeffs = new int[]{1, 5, 7, 8};
         IntVar[] vars = model.intVarArray(4, new int[]{1, 3, 5});
@@ -39,7 +45,7 @@ public class ScalarTest {
         checkSolutions(coeffs, vars, model.intVar(35));
     }
 
-    @Test(groups = "1s", timeOut=60000)
+    @Test(groups = "1s", timeOut = 60000)
     public void testNominalBounded() {
         int[] coeffs = new int[]{1, 5, 7, 8};
         IntVar[] vars = model.intVarArray(4, 1, 6, true);
@@ -48,7 +54,7 @@ public class ScalarTest {
         checkSolutions(coeffs, vars, model.intVar(35));
     }
 
-    @Test(groups = "1s", timeOut=60000)
+    @Test(groups = "1s", timeOut = 60000)
     public void testNominalBoundedWithNegatives() {
         int[] coeffs = new int[]{5, 6, 7, 9};
         IntVar[] vars = model.intVarArray(4, -5, 5, true);
@@ -57,7 +63,7 @@ public class ScalarTest {
         checkSolutions(coeffs, vars, model.intVar(0), "<=");
     }
 
-    @Test(groups = "1s", timeOut=60000)
+    @Test(groups = "1s", timeOut = 60000)
     public void testCoeffAtZeroSolutions() {
         int[] coeffs = new int[]{0, 4, 5};
         IntVar[] vars = model.intVarArray(3, 0, 1000);
@@ -70,7 +76,7 @@ public class ScalarTest {
         assertEquals(nbSol, 1001);
     }
 
-    @Test(groups = "1s", timeOut=60000)
+    @Test(groups = "1s", timeOut = 60000)
     public void testCoeffAtZeroNoSolutions() {
         int[] coeffs = new int[]{0};
         IntVar[] vars = new IntVar[]{
@@ -82,19 +88,19 @@ public class ScalarTest {
         assertFalse(model.getSolver().solve());
     }
 
-    @Test(groups = "1s", timeOut=60000)
+    @Test(groups = "1s", timeOut = 60000)
     public void testWithSumVariable() {
         int[] coeffs = new int[]{1};
         IntVar[] vars = new IntVar[]{
-            model.intVar(1, 100)
+                model.intVar(1, 100)
         };
         IntVar sum = model.intVar(1, 100);
         model.scalar(vars, coeffs, "=", sum).post();
 
-        assertEquals(checkSolutions(coeffs, vars, sum) , 100);
+        assertEquals(checkSolutions(coeffs, vars, sum), 100);
     }
 
-    @Test(groups = "1s", timeOut=60000)
+    @Test(groups = "1s", timeOut = 60000)
     public void testSameVariableNoSolution() {
         IntVar ref = model.intVar(new int[]{1, 5});
         IntVar[] vars = new IntVar[]{ref, ref};
@@ -104,7 +110,7 @@ public class ScalarTest {
         assertFalse(model.getSolver().solve());
     }
 
-    @Test(groups = "1s", timeOut=60000)
+    @Test(groups = "1s", timeOut = 60000)
     public void testSameVariableSolution() {
         IntVar ref = model.intVar(1, 5);
         IntVar[] vars = new IntVar[]{ref, ref};
@@ -137,6 +143,51 @@ public class ScalarTest {
 
     private int checkSolutions(int[] coeffs, IntVar[] vars, IntVar sum) {
         return checkSolutions(coeffs, vars, sum, "=");
+    }
+
+    @Test(groups = "10s")
+    public void testBigCoeffs1() throws ContradictionException {
+        for (int i = 0; i < 70; i++) {
+            int rhs = 0;
+            Model cp = new Model(Settings.init().setMinCardinalityForSumDecomposition(1001));
+            IntVar[] xs = cp.intVarArray(101, 0, 100);
+            int[] coeffs = new int[101];
+            Arrays.fill(coeffs,  IntVar.MAX_INT_BOUND);
+
+            cp.post(cp.scalar(xs, coeffs,">=", rhs));
+            cp.getSolver().setSearch(Search.randomSearch(xs, i));
+            Assert.assertNotNull(cp.getSolver().findSolution());
+        }
+    }
+
+    @Test(groups = "10s")
+    public void testBigCoeffs2() throws ContradictionException {
+        for (int i = 0; i < 70; i++) {
+            int rhs = 0;
+            Model cp = new Model(Settings.init().setMinCardinalityForSumDecomposition(1001));
+            IntVar[] xs = cp.intVarArray(1000, 0, 100);
+            int[] coeffs = new int[1000];
+            Arrays.fill(coeffs,  IntVar.MAX_INT_BOUND);
+
+            cp.post(cp.scalar(xs, coeffs,"=", rhs));
+            cp.getSolver().setSearch(Search.randomSearch(xs, i));
+            Assert.assertNotNull(cp.getSolver().findSolution());
+        }
+    }
+
+    @Test(groups = "10s")
+    public void testBigCoeffs3() throws ContradictionException {
+        for (int i = 0; i < 70; i++) {
+            int rhs = 0;
+            Model cp = new Model(Settings.init().setMinCardinalityForSumDecomposition(1001));
+            IntVar[] xs = cp.intVarArray(1000, 0, 100);
+            int[] coeffs = new int[1000];
+            Arrays.fill(coeffs,  IntVar.MAX_INT_BOUND);
+
+            cp.post(cp.scalar(xs, coeffs,"!=", rhs));
+            cp.getSolver().setSearch(Search.randomSearch(xs, i));
+            Assert.assertNotNull(cp.getSolver().findSolution());
+        }
     }
 
 }

--- a/solver/src/test/java/org/chocosolver/solver/constraints/nary/SumTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/nary/SumTest.java
@@ -10,8 +10,8 @@
 package org.chocosolver.solver.constraints.nary;
 
 import org.chocosolver.solver.Model;
+import org.chocosolver.solver.Settings;
 import org.chocosolver.solver.exception.ContradictionException;
-import org.chocosolver.solver.exception.SolverException;
 import org.chocosolver.solver.search.loop.monitors.IMonitorSolution;
 import org.chocosolver.solver.search.strategy.Search;
 import org.chocosolver.solver.variables.IntVar;
@@ -22,9 +22,7 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import static java.util.Arrays.stream;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.*;
 
 /**
  * @author Alexandre LEBRUN
@@ -38,8 +36,8 @@ public class SumTest {
         model = new Model();
     }
 
-    @Test(groups = "1s", timeOut=60000)
-    public void testNominal() throws ContradictionException{
+    @Test(groups = "1s", timeOut = 60000)
+    public void testNominal() throws ContradictionException {
         IntVar[] vars = model.intVarArray(5, 0, 5);
         IntVar sum = model.intVar(15, 20);
         model.sum(vars, "=", sum).post();
@@ -58,7 +56,7 @@ public class SumTest {
         assertEquals(nbSol, nbSol2);
     }
 
-    @Test(groups = "1s", timeOut=60000)
+    @Test(groups = "1s", timeOut = 60000)
     public void testNoSolution() {
         IntVar[] vars = model.intVarArray(5, 0, 5);
         IntVar sum = model.intVar(26, 30);
@@ -68,7 +66,7 @@ public class SumTest {
         assertFalse(model.getSolver().solve());
     }
 
-    @Test(groups = "1s", timeOut=60000)
+    @Test(groups = "1s", timeOut = 60000)
     public void testZero() {
         IntVar[] vars = new IntVar[]{
                 model.intVar(-5, -1),
@@ -83,7 +81,7 @@ public class SumTest {
     }
 
 
-    @Test(groups = "1s", timeOut=60000)
+    @Test(groups = "1s", timeOut = 60000)
     public void testSameVariableSolution() {
         IntVar ref = model.intVar(1, 5);
         IntVar[] vars = new IntVar[]{ref, ref};
@@ -92,7 +90,7 @@ public class SumTest {
         checkSolutions(vars, model.intVar(10));
     }
 
-    @Test(groups = "1s", timeOut=60000)
+    @Test(groups = "1s", timeOut = 60000)
     public void testSameVariableNoSolution() {
         IntVar ref = model.intVar(1, 5);
         IntVar[] vars = new IntVar[]{ref, ref};
@@ -102,7 +100,7 @@ public class SumTest {
     }
 
 
-    @Test(groups = "1s", timeOut=60000)
+    @Test(groups = "1s", timeOut = 60000)
     public void testZeroElements() {
         IntVar[] vars = new IntVar[0];
         IntVar sum = model.intVar(-100, 100);
@@ -111,7 +109,7 @@ public class SumTest {
         assertEquals(checkSolutions(vars, sum), 1);
     }
 
-    @Test(groups = "1s", timeOut=60000)
+    @Test(groups = "1s", timeOut = 60000)
     public void testNoExactSolution() {
         IntVar[] vars = model.intVarArray(5, new int[]{0, 2});
         IntVar sum = model.intVar(101);
@@ -120,7 +118,7 @@ public class SumTest {
         assertFalse(model.getSolver().solve());
     }
 
-    @Test(groups = "1s", timeOut=60000)
+    @Test(groups = "1s", timeOut = 60000)
     public void testSimpleSum() {
         IntVar[] vars = model.intVarArray(2, new int[]{2, 3});
         IntVar sum = model.intVar(5);
@@ -129,7 +127,7 @@ public class SumTest {
         assertEquals(checkSolutions(">=", vars, sum), 3);
     }
 
-    @Test(groups = "1s", timeOut=60000)
+    @Test(groups = "1s", timeOut = 60000)
     public void testJustAbove() {
         IntVar[] vars = model.intVarArray(6, 6, 10);
         IntVar sum = model.intVar(0, 36);
@@ -139,7 +137,7 @@ public class SumTest {
         assertFalse(model.getSolver().solve());
     }
 
-    @Test(groups = "1s", timeOut=60000)
+    @Test(groups = "1s", timeOut = 60000)
     public void justBelow() {
         IntVar[] vars = model.intVarArray(7, 0, 7);
         IntVar sum = model.intVar(49);
@@ -179,8 +177,8 @@ public class SumTest {
         return nbSol;
     }
 
-    @Test(groups="1s", timeOut=60000)
-    public void testJL01(){
+    @Test(groups = "1s", timeOut = 60000)
+    public void testJL01() {
         Model m = new Model();
         IntVar i = m.intVar("i", -1, 0);
         IntVar j = m.intVar("j", 0, 1);
@@ -191,8 +189,8 @@ public class SumTest {
         Assert.assertEquals(m.getSolver().getSolutionCount(), 3);
     }
 
-    @Test(groups="1s", timeOut=60000)
-    public void testFH01(){
+    @Test(groups = "1s", timeOut = 60000)
+    public void testFH01() {
         Model m = new Model();
         IntVar[] i = m.intVarArray("i", 3, 0, 2);
         IntVar o = m.intVar("o", 0, 6);
@@ -217,7 +215,7 @@ public class SumTest {
      *
      * @throws ContradictionException always. But it really should not.
      */
-    @Test(groups="1s", timeOut=60000)
+    @Test(groups = "1s", timeOut = 60000)
     public void sumGtIsSubjectToUnderflowWhenRhsIsConstant() throws ContradictionException {
         Model choco = new Model();
 
@@ -243,7 +241,7 @@ public class SumTest {
      *
      * @throws ContradictionException always. But it really should not.
      */
-    @Test(groups="1s", timeOut=60000)
+    @Test(groups = "1s", timeOut = 60000)
     public void sumGtIsSubjectToUnderflowWhenRhsIsVar() throws ContradictionException {
         Model choco = new Model();
 
@@ -274,7 +272,7 @@ public class SumTest {
      *
      * @throws ContradictionException always. But it really should not.
      */
-    @Test(groups="1s", timeOut=60000)
+    @Test(groups = "1s", timeOut = 60000)
     public void sumGeIsSubjectToUnderflowWhenRhsIsConstant() throws ContradictionException {
         Model choco = new Model();
 
@@ -300,7 +298,7 @@ public class SumTest {
      *
      * @throws ContradictionException always. But it really should not.
      */
-    @Test(groups="1s", timeOut=60000)
+    @Test(groups = "1s", timeOut = 60000)
     public void sumGeIsSubjectToUnderflowWhenRhsIsVar() throws ContradictionException {
         Model choco = new Model();
 
@@ -330,7 +328,7 @@ public class SumTest {
      *
      * @throws ContradictionException always. But it really should not.
      */
-    @Test(groups="1s", timeOut=60000,expectedExceptions = ContradictionException.class)
+    @Test(groups = "1s", timeOut = 60000, expectedExceptions = ContradictionException.class)
     public void sumLeIsSubjectToUnderflowWhenRhsIsConstant() throws ContradictionException {
         Model choco = new Model();
 
@@ -355,7 +353,7 @@ public class SumTest {
      *
      * @throws ContradictionException never. But it really should throw one.
      */
-    @Test(groups="1s", timeOut=60000,expectedExceptions = ContradictionException.class)
+    @Test(groups = "1s", timeOut = 60000, expectedExceptions = ContradictionException.class)
     public void sumLeIsSubjectToUnderflowWhenRhsIsVar() throws ContradictionException {
         Model choco = new Model();
 
@@ -384,7 +382,7 @@ public class SumTest {
      *
      * @throws ContradictionException always. But it really should not.
      */
-    @Test(groups="1s", timeOut=60000,expectedExceptions = ContradictionException.class)
+    @Test(groups = "1s", timeOut = 60000, expectedExceptions = ContradictionException.class)
     public void sumLtIsSubjectToUnderflowWhenRhsIsConstant() throws ContradictionException {
         Model choco = new Model();
 
@@ -409,7 +407,7 @@ public class SumTest {
      *
      * @throws ContradictionException never. But it really should throw one.
      */
-    @Test(groups="1s", timeOut=60000,expectedExceptions = ContradictionException.class)
+    @Test(groups = "1s", timeOut = 60000, expectedExceptions = ContradictionException.class)
     public void sumLtIsSubjectToUnderflowWhenRhsIsVar() throws ContradictionException {
         Model choco = new Model();
 
@@ -423,13 +421,14 @@ public class SumTest {
     }
 
     ///
+
     /**
      * This case illustrates that the same problem occurs even when there is
      * more than one single variable involved in the constraint.
      *
      * @throws ContradictionException always. But it really should not.
      */
-    @Test(groups="1s", timeOut=60000)
+    @Test(groups = "1s", timeOut = 60000)
     public void isAlsoHappensWhenThereIsMoreThanOneVariableInTheSum() throws ContradictionException {
         Model choco = new Model();
 
@@ -456,10 +455,10 @@ public class SumTest {
      * here it is not the case (even though all possible solutions are
      * feasible).
      */
-    @Test(groups="1s", timeOut=60000,expectedExceptions = SolverException.class)
+    @Test(groups = "1s", timeOut = 60000)
     public void firstSumGeShouldBeBoundZConsistent() throws ContradictionException {
-        int   rhs = -2147483647;
-        Model  cp = new Model();
+        int rhs = -2147483647;
+        Model cp = new Model();
         IntVar x0 = cp.intVar(new int[]{-5, 5});
         IntVar x1 = cp.intVar(new int[]{-5, 5});
         IntVar x2 = cp.intVar(new int[]{-5, 5});
@@ -469,13 +468,13 @@ public class SumTest {
         cp.getSolver().propagate(); // throws a spurious inconsistency
     }
 
-    @Test(groups="1s", timeOut=60000, expectedExceptions = SolverException.class)
+    @Test(groups = "1s", timeOut = 60000, expectedExceptions = ContradictionException.class)
     public void secndSumGeShouldBeBoundZConsistent() throws ContradictionException {
-        int   rhs = 0;
-        Model  cp = new Model();
+        int rhs = 0;
+        Model cp = new Model();
         IntVar x0 = cp.intVar(new int[]{-731435840});
-        IntVar x1 = cp.intVar(new int[]{-731435844,-731435843,-731435841,-731435837});
-        IntVar x2 = cp.intVar(new int[]{-731435847,-731435842,-731435840,-731435839,-731435837});
+        IntVar x1 = cp.intVar(new int[]{-731435844, -731435843, -731435841, -731435837});
+        IntVar x2 = cp.intVar(new int[]{-731435847, -731435842, -731435840, -731435839, -731435837});
 
         cp.post(cp.sum(new IntVar[]{x0, x1, x2}, ">=", rhs));
         cp.getSolver().propagate(); // throws a spurious inconsistency
@@ -484,10 +483,10 @@ public class SumTest {
     /**
      * Same remark as above, exept it is for the > operator rather than >=
      */
-    @Test(groups="1s", timeOut=60000, expectedExceptions = SolverException.class)
+    @Test(groups = "1s", timeOut = 60000)
     public void firstSumGtShouldBeBoundZConsistent() throws ContradictionException {
-        int   rhs = -2147483647;
-        Model  cp = new Model();
+        int rhs = -2147483647;
+        Model cp = new Model();
         IntVar x0 = cp.intVar(new int[]{-5, 5});
         IntVar x1 = cp.intVar(new int[]{-5, 5});
         IntVar x2 = cp.intVar(new int[]{-5, 5});
@@ -496,17 +495,18 @@ public class SumTest {
         cp.post(cp.sum(new IntVar[]{x0, x1, x2, x3}, ">", rhs));
         cp.getSolver().propagate(); // throws a spurious inconsistency
     }
+
     /**
      * Same remark as above, exept it is for the > operator rather than >=
      */
-    @Test(groups="1s", timeOut=60000, expectedExceptions = SolverException.class)
+    @Test(groups = "1s", timeOut = 60000, expectedExceptions = ContradictionException.class)
     public void secndSumGtShouldBeBoundZConsistent() throws ContradictionException {
-        int   rhs = 0;
-        Model  cp = new Model();
+        int rhs = 0;
+        Model cp = new Model();
         IntVar x0 = cp.intVar(new int[]{-777264600});
         IntVar x1 = cp.intVar(new int[]{-777264591});
-        IntVar x2 = cp.intVar(new int[]{-777264597,-777264591});
-        IntVar x3 = cp.intVar(new int[]{-777264597,-777264591});
+        IntVar x2 = cp.intVar(new int[]{-777264597, -777264591});
+        IntVar x3 = cp.intVar(new int[]{-777264597, -777264591});
 
         cp.post(cp.sum(new IntVar[]{x0, x1, x2, x3}, ">", rhs));
         cp.getSolver().propagate(); // does not detect inconsistency
@@ -515,14 +515,14 @@ public class SumTest {
     /**
      * Same remark as above, exept it is for the > operator rather than >=
      */
-    @Test(groups="1s", timeOut=60000, expectedExceptions = ContradictionException.class)
+    @Test(groups = "1s", timeOut = 60000, expectedExceptions = ContradictionException.class)
     public void secndSumGtShouldBeBoundZConsistent2() throws ContradictionException {
-        int   rhs = 0;
-        Model  cp = new Model();
+        int rhs = 0;
+        Model cp = new Model();
         IntVar x0 = cp.intVar(new int[]{-100});
         IntVar x1 = cp.intVar(new int[]{-91});
-        IntVar x2 = cp.intVar(new int[]{-97,-91});
-        IntVar x3 = cp.intVar(new int[]{-97,-91});
+        IntVar x2 = cp.intVar(new int[]{-97, -91});
+        IntVar x3 = cp.intVar(new int[]{-97, -91});
 
         cp.post(cp.sum(new IntVar[]{x0, x1, x2, x3}, ">", rhs));
         cp.getSolver().propagate(); // does not detect inconsistency
@@ -532,60 +532,63 @@ public class SumTest {
      * Here we consider the <= operator. Here, it is problematic as it fails to
      * detect an inconsistency (even one which is obvious to an human brain)
      */
-    @Test(groups="1s", timeOut=60000, expectedExceptions = SolverException.class)
+    @Test(groups = "1s", timeOut = 60000, expectedExceptions = ContradictionException.class)
     public void firstSumLeShouldBeBoundZConsistent() throws ContradictionException {
-        int   rhs = -2147483647;
-        Model  cp = new Model();
-        IntVar x0 = cp.intVar(new int[]{186191402,186191412});
-        IntVar x1 = cp.intVar(new int[]{186191402,186191412});
-        IntVar x2 = cp.intVar(new int[]{186191402,186191412});
+        int rhs = -2147483647;
+        Model cp = new Model();
+        IntVar x0 = cp.intVar(new int[]{186191402, 186191412});
+        IntVar x1 = cp.intVar(new int[]{186191402, 186191412});
+        IntVar x2 = cp.intVar(new int[]{186191402, 186191412});
 
         cp.post(cp.sum(new IntVar[]{x0, x1, x2}, "<=", rhs));
         cp.getSolver().propagate(); // throws a spurious inconsistency
     }
+
     /**
      * Here we consider the <= operator. Here, it is problematic as it fails to
      * detect an inconsistency (even one which is obvious to an human brain)
      */
-    @Test(groups="1s", timeOut=60000, expectedExceptions = SolverException.class)
+    @Test(groups = "1s", timeOut = 60000, expectedExceptions = ContradictionException.class)
     public void secndSumLeShouldBeBoundZConsistent() throws ContradictionException {
-        int   rhs = 0;
-        Model  cp = new Model();
-        IntVar x0 = cp.intVar(new int[]{1551476532,551476534,551476537});
+        int rhs = 0;
+        Model cp = new Model();
+        IntVar x0 = cp.intVar(new int[]{1551476532, 551476534, 551476537});
         IntVar x1 = cp.intVar(new int[]{551476531});
-        IntVar x2 = cp.intVar(new int[]{551476531,551476533,551476535});
+        IntVar x2 = cp.intVar(new int[]{551476531, 551476533, 551476535});
         IntVar x3 = cp.intVar(new int[]{551476531});
         IntVar x4 = cp.intVar(new int[]{551476537});
 
         cp.post(cp.sum(new IntVar[]{x0, x1, x2, x3, x4}, "<=", rhs));
         cp.getSolver().propagate(); // does not detect inconsistency
     }
+
     /**
      * Same as above, for the '<' operator
      */
-    @Test(groups="1s", timeOut=60000, expectedExceptions = SolverException.class)
+    @Test(groups = "1s", timeOut = 60000, expectedExceptions = ContradictionException.class)
     public void firstSumLtShouldBeBoundZConsistent() throws ContradictionException {
-        int   rhs = -2147483647;
-        Model  cp = new Model();
-        IntVar x0 = cp.intVar(new int[]{186191402,186191412});
-        IntVar x1 = cp.intVar(new int[]{186191402,186191412});
-        IntVar x2 = cp.intVar(new int[]{186191402,186191412});
+        int rhs = -2147483647;
+        Model cp = new Model();
+        IntVar x0 = cp.intVar(new int[]{186191402, 186191412});
+        IntVar x1 = cp.intVar(new int[]{186191402, 186191412});
+        IntVar x2 = cp.intVar(new int[]{186191402, 186191412});
 
         cp.post(cp.sum(new IntVar[]{x0, x1, x2}, "<", rhs));
         cp.getSolver().propagate(); // does not detect inconsistency
     }
+
     /**
      * Same as above, for the '<' operator
      */
-    @Test(groups="1s", timeOut=60000, expectedExceptions = SolverException.class)
+    @Test(groups = "1s", timeOut = 60000)
     public void secndSumLtShouldBeBoundZ() throws ContradictionException {
-        int   rhs = 0;
-        Model  cp = new Model();
+        int rhs = 0;
+        Model cp = new Model();
         IntVar x0 = cp.intVar(new int[]{-461559231});
-        IntVar x1 = cp.intVar(new int[]{-461559228,-461559227});
-        IntVar x2 = cp.intVar(new int[]{-461559226,-461559224});
-        IntVar x3 = cp.intVar(new int[]{-461559234,-461559230});
-        IntVar x4 = cp.intVar(new int[]{-461559234,-461559232,-461559231,-461559224});
+        IntVar x1 = cp.intVar(new int[]{-461559228, -461559227});
+        IntVar x2 = cp.intVar(new int[]{-461559226, -461559224});
+        IntVar x3 = cp.intVar(new int[]{-461559234, -461559230});
+        IntVar x4 = cp.intVar(new int[]{-461559234, -461559232, -461559231, -461559224});
 
         cp.post(cp.sum(new IntVar[]{x0, x1, x2, x3, x4}, "<", rhs));
         cp.getSolver().propagate(); // throws a spurious inconsistency
@@ -596,10 +599,10 @@ public class SumTest {
      * here it is not the case (even though all possible solutions are
      * feasible).
      */
-    @Test(groups="1s", timeOut=60000, expectedExceptions = SolverException.class)
+    @Test(groups = "1s", timeOut = 60000)
     public void firstSumGeShouldBeBoundZConsistent3() throws ContradictionException {
-        int   rhs = -2147483647;
-        Model  cp = new Model();
+        int rhs = -2147483647;
+        Model cp = new Model();
         IntVar x0 = cp.intVar(new int[]{-5, 5});
         IntVar x1 = cp.intVar(new int[]{-5, 5});
         IntVar x2 = cp.intVar(new int[]{-5, 5});
@@ -609,14 +612,14 @@ public class SumTest {
         cp.getSolver().propagate(); // throws a spurious inconsistency
     }
 
-    @Test(groups="1s", timeOut=60000, expectedExceptions = SolverException.class)
+    @Test(groups = "1s", timeOut = 60000)
     public void secndSumGeShouldBeBoundZConsistent4() throws ContradictionException {
-        int   rhs = 0;
-        Model  cp = new Model();
-        IntVar x0=cp.intVar(new int[]{972708062,972708065,972708068,972708069});
-        IntVar x1=cp.intVar(new int[]{972708066});
-        IntVar x2=cp.intVar(new int[]{972708061,972708063,972708069});
-        IntVar x3=cp.intVar(new int[]{972708065});
+        int rhs = 0;
+        Model cp = new Model();
+        IntVar x0 = cp.intVar(new int[]{972708062, 972708065, 972708068, 972708069});
+        IntVar x1 = cp.intVar(new int[]{972708066});
+        IntVar x2 = cp.intVar(new int[]{972708061, 972708063, 972708069});
+        IntVar x3 = cp.intVar(new int[]{972708065});
 
         cp.post(cp.sum(new IntVar[]{x0, x1, x2, x3}, ">=", rhs));
         cp.getSolver().propagate(); // throws a spurious inconsistency
@@ -624,7 +627,7 @@ public class SumTest {
 
     /**
      * Voila comment sont rapportés mes contrexemples.
-     *
+     * <p>
      * ###########################
      * RHS : 0
      * ###########################
@@ -633,17 +636,56 @@ public class SumTest {
      * WITNESS   : x0={-530774850,-530774849,-530774844,-530774842,-530774840}, x1={-530774850,-530774845}, x2={-530774847}, x3={-530774847,-530774846,-530774844,-530774841}, x4={-530774840}
      * ###########################
      */
-    @Test(groups="1s", timeOut=60000, expectedExceptions = SolverException.class)
+    @Test(groups = "1s", timeOut = 60000, expectedExceptions = ContradictionException.class)
     public void thirdSumGeShouldBeBoundZConsistent() throws ContradictionException {
-        int   rhs = 0;
-        Model  cp = new Model();
-        IntVar x0=cp.intVar(new int[]{-530774850,-530774849,-530774844,-530774842,-530774840});
-        IntVar x1=cp.intVar(new int[]{-530774850,-530774845});
-        IntVar x2=cp.intVar(new int[]{-530774847});
-        IntVar x3=cp.intVar(new int[]{-530774847,-530774846,-530774844,-530774841});
-        IntVar x4=cp.intVar(new int[]{-530774840});
+        int rhs = 0;
+        Model cp = new Model();
+        IntVar x0 = cp.intVar(new int[]{-530774850, -530774849, -530774844, -530774842, -530774840});
+        IntVar x1 = cp.intVar(new int[]{-530774850, -530774845});
+        IntVar x2 = cp.intVar(new int[]{-530774847});
+        IntVar x3 = cp.intVar(new int[]{-530774847, -530774846, -530774844, -530774841});
+        IntVar x4 = cp.intVar(new int[]{-530774840});
 
         cp.post(cp.sum(new IntVar[]{x0, x1, x2, x3, x4}, ">=", rhs));
         cp.getSolver().propagate(); // devrait lancer une exception
+    }
+
+    @Test(groups = "10s")
+    public void testBigCoeffs1() throws ContradictionException {
+        for (int i = 0; i < 70; i++) {
+            int rhs = 0;
+            Model cp = new Model(Settings.init().setMinCardinalityForSumDecomposition(1001));
+            IntVar[] xs = cp.intVarArray(1000, IntVar.MIN_INT_BOUND, IntVar.MAX_INT_BOUND);
+
+            cp.post(cp.sum(xs, ">=", rhs));
+            cp.getSolver().setSearch(Search.randomSearch(xs, i));
+            Assert.assertNotNull(cp.getSolver().findSolution());
+        }
+    }
+
+    @Test(groups = "10s")
+    public void testBigCoeffs2() throws ContradictionException {
+        for (int i = 0; i < 70; i++) {
+            int rhs = 0;
+            Model cp = new Model(Settings.init().setMinCardinalityForSumDecomposition(1001));
+            IntVar[] xs = cp.intVarArray(1000, IntVar.MIN_INT_BOUND, IntVar.MAX_INT_BOUND);
+
+            cp.post(cp.sum(xs, "=", rhs));
+            cp.getSolver().setSearch(Search.randomSearch(xs, i));
+            Assert.assertNotNull(cp.getSolver().findSolution());
+        }
+    }
+
+    @Test(groups = "10s")
+    public void testBigCoeffs3() throws ContradictionException {
+        for (int i = 0; i < 70; i++) {
+            int rhs = 0;
+            Model cp = new Model(Settings.init().setMinCardinalityForSumDecomposition(1001));
+            IntVar[] xs = cp.intVarArray(1000, IntVar.MIN_INT_BOUND, IntVar.MAX_INT_BOUND);
+
+            cp.post(cp.sum(xs, "!=", rhs));
+            cp.getSolver().setSearch(Search.randomSearch(xs, i));
+            Assert.assertNotNull(cp.getSolver().findSolution());
+        }
     }
 }

--- a/solver/src/test/java/org/chocosolver/solver/constraints/ternary/TimesTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/ternary/TimesTest.java
@@ -10,12 +10,13 @@
 package org.chocosolver.solver.constraints.ternary;
 
 import org.chocosolver.memory.EnvironmentBuilder;
-import org.chocosolver.solver.Settings;
 import org.chocosolver.solver.Model;
+import org.chocosolver.solver.Settings;
 import org.chocosolver.solver.constraints.Constraint;
 import org.chocosolver.solver.constraints.Propagator;
 import org.chocosolver.solver.exception.ContradictionException;
 import org.chocosolver.solver.variables.IntVar;
+import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import static java.lang.Integer.MAX_VALUE;
@@ -42,92 +43,104 @@ public class TimesTest extends AbstractTernaryTest {
         return model.times(vars[0], vars[1], vars[2]);
     }
 
-	@Test(groups="1s", timeOut=60000)
-	public void testJL() {
-		Model s = new Model();
-		IntVar a = s.intVar("a", 0, 3, false);
-		IntVar b = s.intVar("b", -3, 3, false);
+    @Test(groups = "1s", timeOut = 60000)
+    public void testJL() {
+        Model s = new Model();
+        IntVar a = s.intVar("a", 0, 3, false);
+        IntVar b = s.intVar("b", -3, 3, false);
 
-		IntVar z = s.intVar("z", 3, 4, false);
-		s.arithm(z, "=", 3).post();
-		Constraint c = s.times(a, b, z);
-		c.post();
-		try {
-			s.getSolver().propagate();
-			assertFalse(a.contains(0));
-			for (Propagator p : c.getPropagators()) {
-				p.propagate(FULL_PROPAGATION.getMask());
-			}
-			assertFalse(a.contains(0));
-		} catch (ContradictionException e) {
-			assertFalse(true);
-		}
-	}
+        IntVar z = s.intVar("z", 3, 4, false);
+        s.arithm(z, "=", 3).post();
+        Constraint c = s.times(a, b, z);
+        c.post();
+        try {
+            s.getSolver().propagate();
+            assertFalse(a.contains(0));
+            for (Propagator p : c.getPropagators()) {
+                p.propagate(FULL_PROPAGATION.getMask());
+            }
+            assertFalse(a.contains(0));
+        } catch (ContradictionException e) {
+            assertFalse(true);
+        }
+    }
 
-	@Test(groups="10s", timeOut=60000)
-	public void testJL2(){
-		for(int i = 1 ; i < 100001; i*=10) {
-			Model s = new Model();
-			IntVar i1 = s.intVar("i1", 0, 465 * i, false);
-			IntVar i2 = s.intVar("i2", 0, 465 * i, false);
-			s.times(i1, 465 * i, i2).post();
-			while (s.getSolver().solve()) ;
-			assertEquals(s.getSolver().getSolutionCount(), 2);
-		}
-	}
+    @Test(groups = "10s", timeOut = 60000)
+    public void testJL2() {
+        for (int i = 1; i < 100001; i *= 10) {
+            Model s = new Model();
+            IntVar i1 = s.intVar("i1", 0, 465 * i, false);
+            IntVar i2 = s.intVar("i2", 0, 465 * i, false);
+            s.times(i1, 465 * i, i2).post();
+            while (s.getSolver().solve()) ;
+            assertEquals(s.getSolver().getSolutionCount(), 2);
+        }
+    }
 
-	@Test(groups="1s", timeOut=60000)
-	public void testJL3(){
-		for(int i = 1 ; i < 1000001; i*=10) {
-			Model s = new Model();
-			IntVar i1 = s.intVar("i1", 0, 465 * i, true);
-			IntVar i2 = s.intVar("i2", 0, 465 * i, true);
-			s.times(i1, 465 * i, i2).post();
-			while (s.getSolver().solve()) ;
-			assertEquals(s.getSolver().getSolutionCount(), 2);
-		}
-	}
+    @Test(groups = "1s", timeOut = 60000)
+    public void testJL3() {
+        for (int i = 1; i < 1000001; i *= 10) {
+            Model s = new Model();
+            IntVar i1 = s.intVar("i1", 0, 465 * i, true);
+            IntVar i2 = s.intVar("i2", 0, 465 * i, true);
+            s.times(i1, 465 * i, i2).post();
+            while (s.getSolver().solve()) ;
+            assertEquals(s.getSolver().getSolutionCount(), 2);
+        }
+    }
 
-	@Test(groups="10s", timeOut=60000)
-	public void testJL4() {
-		Model s = new Model();
-		IntVar i1 = s.intVar("i1", 0, 465, false);
-		IntVar i2 = s.intVar("i2", 0, 465 * 10000, false);
-		s.times(i1, 10000, i2).post();
-		while (s.getSolver().solve()) ;
-		assertEquals(s.getSolver().getSolutionCount(), 466);
-	}
-	@Test(groups="1s", timeOut=60000)
-	public void testJL5() {
-		Model s = new Model(
-				new EnvironmentBuilder()
-						.setWorldNumber(65536)
-						.setWorldSize(16)
-						.build(),
-				"");
-		IntVar i1 = s.intVar("i1", MIN_VALUE / 10, MAX_VALUE / 10, true);
-		IntVar i2 = s.intVar("i2", MIN_VALUE / 10, MAX_VALUE / 10, true);
-		s.times(i1, 10000, i2).post();
-		while (s.getSolver().solve()) ;
-		assertEquals(s.getSolver().getSolutionCount(), MAX_VALUE / 100000 * 2 + 1);
-	}
+    @Test(groups = "10s", timeOut = 60000)
+    public void testJL4() {
+        Model s = new Model();
+        IntVar i1 = s.intVar("i1", 0, 465, false);
+        IntVar i2 = s.intVar("i2", 0, 465 * 10000, false);
+        s.times(i1, 10000, i2).post();
+        while (s.getSolver().solve()) ;
+        assertEquals(s.getSolver().getSolutionCount(), 466);
+    }
 
-	@Test(groups="1s", timeOut=60000)
-	public void testJL6() {
-		Model s = new Model(Settings.init().setEnableTableSubstitution(false));
-		IntVar i1 = s.intVar("i1", new int[]{1, 55000});
-		IntVar i2 = s.intVar("i2", new int[]{1, 55000});
-		IntVar i3 = s.intVar("i3", new int[]{1, 55000});
-		s.times(i1, i2, i3).post();
-	}
+    @Test(groups = "1s", timeOut = 60000)
+    public void testJL5() {
+        Model s = new Model(
+                new EnvironmentBuilder()
+                        .setWorldNumber(65536)
+                        .setWorldSize(16)
+                        .build(),
+                "");
+        IntVar i1 = s.intVar("i1", MIN_VALUE / 10, MAX_VALUE / 10, true);
+        IntVar i2 = s.intVar("i2", MIN_VALUE / 10, MAX_VALUE / 10, true);
+        s.times(i1, 10000, i2).post();
+        while (s.getSolver().solve()) ;
+        assertEquals(s.getSolver().getSolutionCount(), MAX_VALUE / 100000 * 2 + 1);
+    }
 
-    @Test(groups="1s", timeOut=60000)
+    @Test(groups = "1s", timeOut = 60000)
+    public void testJL6() {
+        Model s = new Model(Settings.init().setEnableTableSubstitution(false));
+        IntVar i1 = s.intVar("i1", new int[]{1, 55000});
+        IntVar i2 = s.intVar("i2", new int[]{1, 55000});
+        IntVar i3 = s.intVar("i3", new int[]{1, 55000});
+        s.times(i1, i2, i3).post();
+    }
+
+    @Test(groups = "1s", timeOut = 60000)
     public void testJL7() {
-		Model s = new Model(Settings.init().setEnableTableSubstitution(false));
-		IntVar i1 = s.intVar("i1", new int[]{1, 10000});
-		IntVar i2 = s.intVar("i2", new int[]{1, 10000});
-		IntVar i3 = s.intVar("i3", new int[]{1, 10000});
-		s.times(i1, i2, i3).post();
-	}
+        Model s = new Model(Settings.init().setEnableTableSubstitution(false));
+        IntVar i1 = s.intVar("i1", new int[]{1, 10000});
+        IntVar i2 = s.intVar("i2", new int[]{1, 10000});
+        IntVar i3 = s.intVar("i3", new int[]{1, 10000});
+        s.times(i1, i2, i3).post();
+    }
+
+    @Test(groups = "1s", timeOut = 60000)
+    public void testJL8() {
+        Model s = new Model(Settings.init().setEnableTableSubstitution(false));
+        IntVar i1 = s.intVar("i1", new int[]{1, IntVar.MAX_INT_BOUND});
+        IntVar i2 = s.intVar("i2", new int[]{1, IntVar.MAX_INT_BOUND});
+        IntVar i3 = s.intVar("i3", new int[]{1, 10});
+        s.times(i1, i2, i3).post();
+        Assert.assertTrue(s.getSolver().solve());
+        Assert.assertFalse(s.getSolver().solve());
+    }
 
 }


### PR DESCRIPTION
 ...thanks to new domain modification methods.

It is very simple approach, that makes possible to either modify already existant propagators (probably at the expense of efficiency, but this needs to be tested) or the develop new propagators.

The methods deals with`long` in parameter by checking whether or not it can be cast into an `int`.
Depending on the method,  the consequence is different.

Consequently, it allows to better deal with underflow/overflow (but not to fix it in a general way).
In particular, it is  helpful when dealing with `sum` or `times` constraints.