### PR TITLE
Add variable set scope to search to make strategy sequencer faster

### DIFF
--- a/parsers/src/main/java/org/chocosolver/parser/RegParser.java
+++ b/parsers/src/main/java/org/chocosolver/parser/RegParser.java
@@ -212,8 +212,7 @@ public abstract class RegParser implements IParser {
         Solver solver = m.getSolver();
         if (solver.getSearch() != null) {
             THashSet<Variable> dvars = new THashSet<>();
-            dvars.addAll(Arrays.asList(solver.getSearch().getVariables()));
-            int k = 0;
+            dvars.addAll(solver.getSearch().getScope());
             IntVar[] ivars = m.streamVars()
                     .filter(VariableUtils::isInt)
                     .filter(v -> !VariableUtils.isConstant(v))

--- a/solver/src/main/java/org/chocosolver/solver/search/strategy/strategy/AbstractStrategy.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/strategy/strategy/AbstractStrategy.java
@@ -29,7 +29,7 @@ import java.util.Set;
 public abstract class AbstractStrategy<V extends Variable>  {
 
     protected final V[] vars;
-    protected Set<V> scope;
+    protected final Set<V> scope;
 
     @SafeVarargs
     protected AbstractStrategy(V... variables) {

--- a/solver/src/main/java/org/chocosolver/solver/search/strategy/strategy/AbstractStrategy.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/strategy/strategy/AbstractStrategy.java
@@ -15,6 +15,10 @@ import org.chocosolver.solver.search.strategy.decision.IntDecision;
 import org.chocosolver.solver.variables.IntVar;
 import org.chocosolver.solver.variables.Variable;
 
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
 /**
  * A search strategy provides decisions to go down in the search space.
  * The main method is {@link #computeDecision(Variable)} which returns the next decision to apply.
@@ -25,10 +29,16 @@ import org.chocosolver.solver.variables.Variable;
 public abstract class AbstractStrategy<V extends Variable>  {
 
     protected final V[] vars;
+    protected Set<V> scope;
 
     @SafeVarargs
     protected AbstractStrategy(V... variables) {
         this.vars = variables.clone();
+        this.scope = new HashSet<>(Arrays.asList(variables));
+    }
+
+    public final boolean contains(V var) {
+        return scope.contains(var);
     }
 
     /**
@@ -84,6 +94,13 @@ public abstract class AbstractStrategy<V extends Variable>  {
      */
     public V[] getVariables() {
         return vars;
+    }
+
+    /**
+     * @return set of variables
+     */
+    public Set<V> getScope() {
+        return scope;
     }
 
     /**

--- a/solver/src/main/java/org/chocosolver/solver/search/strategy/strategy/ConflictOrderingSearch.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/strategy/strategy/ConflictOrderingSearch.java
@@ -67,8 +67,6 @@ public class ConflictOrderingSearch<V extends Variable> extends AbstractStrategy
      */
     int pcft;
 
-    protected Set<V> scope;
-
     //***********************************************************************************
     // CONSTRUCTORS
     //***********************************************************************************
@@ -89,7 +87,6 @@ public class ConflictOrderingSearch<V extends Variable> extends AbstractStrategy
         prev = new TIntArrayList();
         next = new TIntArrayList();
         pcft = -1;
-        this.scope = new HashSet<>(Arrays.asList(mainStrategy.vars));
     }
 
     //***********************************************************************************

--- a/solver/src/main/java/org/chocosolver/solver/search/strategy/strategy/LastConflict.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/strategy/strategy/LastConflict.java
@@ -60,8 +60,6 @@ public class LastConflict<V extends Variable> extends AbstractStrategy<V> implem
      */
     private final V[] conflictingVariables;
 
-    protected Set<Variable> scope;
-
     //***********************************************************************************
     // CONSTRUCTORS
     //***********************************************************************************
@@ -77,7 +75,6 @@ public class LastConflict<V extends Variable> extends AbstractStrategy<V> implem
         assert k > 0 : "parameter K of last conflict must be strictly positive!";
         this.model = model;
         this.mainStrategy = mainStrategy;
-        this.scope = new HashSet<>(Arrays.asList(mainStrategy.vars));
         //noinspection unchecked
         conflictingVariables = (V[])new Variable[k];
         nbCV = 0;

--- a/solver/src/main/java/org/chocosolver/solver/search/strategy/strategy/StrategiesSequencer.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/strategy/strategy/StrategiesSequencer.java
@@ -83,7 +83,7 @@ public class StrategiesSequencer<U extends Variable> extends AbstractStrategy<U>
         int idx = (index==null)?0:index.get();
         Decision<U> decision = null;
         while (decision == null && idx < strategies.length) {
-            if (contains(strategies[idx].vars, variable)) {
+            if (strategies[idx].contains(variable)) {
                 decision = strategies[idx].computeDecision(variable);
             }
             idx++;

--- a/solver/src/main/java/org/chocosolver/solver/search/strategy/strategy/StrategiesSequencer.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/strategy/strategy/StrategiesSequencer.java
@@ -91,15 +91,6 @@ public class StrategiesSequencer<U extends Variable> extends AbstractStrategy<U>
         return decision;
     }
 
-    private static boolean contains(Variable[] vars, Variable variable) {
-        for (Variable v : vars) {
-            if (v.equals(variable)) {
-                return true;
-            }
-        }
-        return false;
-    }
-
     /**
      * {@inheritDoc}
      * Iterates over the declared sub-strategies and gets the overall current decision.

--- a/solver/src/main/java/org/chocosolver/solver/search/strategy/strategy/WarmStart.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/strategy/strategy/WarmStart.java
@@ -19,6 +19,7 @@ import org.chocosolver.solver.variables.IntVar;
 import org.chocosolver.solver.variables.Variable;
 
 import java.util.HashMap;
+import java.util.Set;
 
 /**
  * A class to store warm_start hints.
@@ -151,6 +152,11 @@ public class WarmStart extends AbstractStrategy<Variable> implements IMonitorSol
     @Override
     public Variable[] getVariables() {
         return mainStrategy.getVariables();
+    }
+
+    @Override
+    public Set<Variable> getScope() {
+        return mainStrategy.getScope();
     }
 
     @Override


### PR DESCRIPTION
Should accelerate the usage of strategysequencer

I let the redundant V[] attribute to reduce impact on code and for compatibility purpose. However, if memory is an issue, a LinkedHashSet could replace the array and the set.