### PR TITLE
Make computeDecision and makeIntDecision public

### DIFF
--- a/solver/src/main/java/org/chocosolver/solver/propagation/PropagationEngine.java
+++ b/solver/src/main/java/org/chocosolver/solver/propagation/PropagationEngine.java
@@ -64,7 +64,7 @@ public class PropagationEngine {
     /**
      * The last propagator executed
      */
-    Propagator<?> lastProp;
+    protected Propagator<?> lastProp;
     /**
      * One bit per queue: true if the queue is not empty.
      */

--- a/solver/src/main/java/org/chocosolver/solver/search/strategy/strategy/AbstractStrategy.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/strategy/strategy/AbstractStrategy.java
@@ -75,7 +75,7 @@ public abstract class AbstractStrategy<V extends Variable>  {
      * @param var a variable
      * @return a decision to be applied to variable var
      */
-    protected Decision<V> computeDecision(V var) {
+    public Decision<V> computeDecision(V var) {
         return null;
     }
 
@@ -94,7 +94,7 @@ public abstract class AbstractStrategy<V extends Variable>  {
      * @param val value to branch on
      * @return an assignment decision object (var = val) for integer variables
      */
-    protected final IntDecision makeIntDecision(IntVar var, int val){
+    public final IntDecision makeIntDecision(IntVar var, int val){
         return var.getModel().getSolver().getDecisionPath().makeIntDecision(var, DecisionOperatorFactory.makeIntEq(),val);
     }
 }

--- a/solver/src/main/java/org/chocosolver/solver/search/strategy/strategy/MultiArmedBanditSequencer.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/strategy/strategy/MultiArmedBanditSequencer.java
@@ -84,7 +84,7 @@ public class MultiArmedBanditSequencer<V extends Variable> extends AbstractStrat
     }
 
     @Override
-    protected Decision<V> computeDecision(V variable) {
+    public Decision<V> computeDecision(V variable) {
         if (variable == null || variable.isInstantiated()) {
             return null;
         }


### PR DESCRIPTION
Some strategies like ConflictOrderingSearch are composite and require to call computeDecision(Var) of another strategy. Such method currently has a protected visibility.

This works because ConflictOrderingSearch is in the same package as AbstractStrategy, but not if one define a similar strategy within a different project/package. Setting these methods visibility to public allow such developments.