### PR TITLE
Reduce object creation during propagation

### DIFF
--- a/.github/workflows/benchmarking.yml
+++ b/.github/workflows/benchmarking.yml
@@ -23,7 +23,7 @@ jobs:
 
   evaluate:
     needs: trigger
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     if: ${{needs.trigger.outputs.output1}} == 'true'
     steps:
       - uses: actions/setup-java@v3

--- a/.github/workflows/maven-test.yml
+++ b/.github/workflows/maven-test.yml
@@ -38,7 +38,7 @@ jobs:
         run: mvn -B --file pom.xml package -Pcoverage -DtestFailureIgnore=true -Dgroups=${{ matrix.group }}
   test-parser:
     needs: [ test-solver ]
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     # Tests matrix
     strategy:
       #fail-fast: false
@@ -67,7 +67,7 @@ jobs:
 
   test-mzn:
     needs: [ test-solver ]
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     # Tests matrix
     strategy:
       #fail-fast: false

--- a/solver/src/main/java/org/chocosolver/solver/constraints/binary/PropGreaterOrEqualX_Y.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/binary/PropGreaterOrEqualX_Y.java
@@ -31,7 +31,6 @@ public final class PropGreaterOrEqualX_Y extends Propagator<IntVar> {
     private final IntVar x;
     private final IntVar y;
 
-    @SuppressWarnings({"unchecked"})
     public PropGreaterOrEqualX_Y(IntVar[] vars) {
         super(vars, PropagatorPriority.BINARY, true);
         this.x = vars[0];
@@ -41,9 +40,9 @@ public final class PropGreaterOrEqualX_Y extends Propagator<IntVar> {
     @Override
     public int getPropagationConditions(int vIdx) {
         if (vIdx == 0) {
-            return IntEventType.combine(IntEventType.INSTANTIATE, IntEventType.DECUPP);
+            return IntEventType.upperBoundAndInst();
         } else {
-            return IntEventType.combine(IntEventType.INSTANTIATE, IntEventType.INCLOW);
+            return IntEventType.lowerBoundAndInst();
         }
     }
 

--- a/solver/src/main/java/org/chocosolver/solver/constraints/binary/PropGreaterOrEqualX_YC.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/binary/PropGreaterOrEqualX_YC.java
@@ -33,7 +33,6 @@ public final class PropGreaterOrEqualX_YC extends Propagator<IntVar> {
     private final IntVar y;
     private final int cste;
 
-    @SuppressWarnings({"unchecked"})
     public PropGreaterOrEqualX_YC(IntVar[] vars, int c) {
         super(vars, PropagatorPriority.BINARY, true);
         this.x = vars[0];
@@ -44,9 +43,9 @@ public final class PropGreaterOrEqualX_YC extends Propagator<IntVar> {
     @Override
     public int getPropagationConditions(int vIdx) {
         if (vIdx == 0) {
-            return IntEventType.combine(IntEventType.INSTANTIATE, IntEventType.DECUPP);
+            return IntEventType.upperBoundAndInst();
         } else {
-            return IntEventType.combine(IntEventType.INSTANTIATE, IntEventType.INCLOW);
+            return IntEventType.lowerBoundAndInst();
         }
     }
 

--- a/solver/src/main/java/org/chocosolver/solver/constraints/binary/PropLessOrEqualXY_C.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/binary/PropLessOrEqualXY_C.java
@@ -32,7 +32,6 @@ public final class PropLessOrEqualXY_C extends Propagator<IntVar> {
     private final IntVar y;
     private final int cste;
 
-    @SuppressWarnings({"unchecked"})
     public PropLessOrEqualXY_C(IntVar[] vars, int c) {
         super(vars, PropagatorPriority.BINARY, true);
         this.x = vars[0];
@@ -42,7 +41,7 @@ public final class PropLessOrEqualXY_C extends Propagator<IntVar> {
 
     @Override
     public int getPropagationConditions(int vIdx) {
-        return IntEventType.combine(IntEventType.INSTANTIATE, IntEventType.INCLOW);
+        return IntEventType.lowerBoundAndInst();
     }
 
     @Override

--- a/solver/src/main/java/org/chocosolver/solver/constraints/extension/nary/ValidityChecker.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/extension/nary/ValidityChecker.java
@@ -26,13 +26,13 @@ public class ValidityChecker implements IntComparator {
     protected IntVar[] vars;
     public int[] sortedidx;
     protected int arity;
-    protected ArraySort sorter;
+    protected ArraySort<?> sorter;
 
     public ValidityChecker(int ari, IntVar[] vars) {
         arity = ari;
         this.vars = new IntVar[arity];
         sortedidx = new int[arity];
-        sorter = new ArraySort(arity, false, true);
+        sorter = new ArraySort<>(arity, false, true);
         for (int i = 0; i < vars.length; i++) {
             this.vars[i] = vars[i];
             sortedidx[i] = i;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/graph/cost/trees/lagrangian/KruskalMSTFinder.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/graph/cost/trees/lagrangian/KruskalMSTFinder.java
@@ -49,7 +49,7 @@ public class KruskalMSTFinder extends AbstractTreeFinder {
     protected double[][] distMatrix;
 
     //sort
-    protected ArraySort sorter;
+    protected ArraySort<?> sorter;
     protected IntComparator comparator;
 
     //***********************************************************************************
@@ -73,14 +73,8 @@ public class KruskalMSTFinder extends AbstractTreeFinder {
         useful = new BitSet(n);
         lca = new LCAGraphManager(ccN);
         //sort
-        sorter = new ArraySort(n * n, false, true);
-        comparator = (i1, i2) -> {
-            if (costs[i1] < costs[i2])
-                return -1;
-            else if (costs[i1] > costs[i2])
-                return 1;
-            else return 0;
-        };
+        sorter = new ArraySort<>(n * n, false, true);
+        comparator = (i1, i2) -> Double.compare(costs[i1], costs[i2]);
     }
 
     //***********************************************************************************

--- a/solver/src/main/java/org/chocosolver/solver/constraints/graph/cost/trees/lagrangian/KruskalMSTGAC.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/graph/cost/trees/lagrangian/KruskalMSTGAC.java
@@ -50,7 +50,7 @@ public class KruskalMSTGAC extends AbstractTreeFinder {
     private final int[] fifo;
 
     //sort
-    private final ArraySort sorter;
+    private final ArraySort<?> sorter;
     private final IntComparator comparator;
 
     //***********************************************************************************
@@ -76,14 +76,8 @@ public class KruskalMSTGAC extends AbstractTreeFinder {
         repCosts = new double[n][n];
         fifo = new int[n];
         //sort
-        sorter = new ArraySort(n * n, false, true);
-        comparator = (i1, i2) -> {
-            if (costs[i1] < costs[i2])
-                return -1;
-            else if (costs[i1] > costs[i2])
-                return 1;
-            else return 0;
-        };
+        sorter = new ArraySort<>(n * n, false, true);
+        comparator = (i1, i2) -> Double.compare(costs[i1], costs[i2]);
     }
 
     private void sortArcs(double[][] costMatrix) {

--- a/solver/src/main/java/org/chocosolver/solver/constraints/nary/alldifferent/algo/AlgoAllDiffBC.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/nary/alldifferent/algo/AlgoAllDiffBC.java
@@ -13,9 +13,9 @@ import org.chocosolver.solver.constraints.Propagator;
 import org.chocosolver.solver.exception.ContradictionException;
 import org.chocosolver.solver.variables.IntVar;
 import org.chocosolver.util.sort.ArraySort;
+import org.chocosolver.util.tools.MathUtils;
 
 import java.util.Comparator;
-import org.chocosolver.util.tools.MathUtils;
 
 public class AlgoAllDiffBC {
 
@@ -28,12 +28,12 @@ public class AlgoAllDiffBC {
 
     private Interval[] intervals, minsorted, maxsorted;
 
-    private final Propagator aCause;
+    private final Propagator<?> aCause;
     private IntVar[] vars;
 
     private ArraySort<Interval> sorter;
 
-    public AlgoAllDiffBC(Propagator cause) {
+    public AlgoAllDiffBC(Propagator<?> cause) {
         this.aCause = cause;
     }
 

--- a/solver/src/main/java/org/chocosolver/solver/constraints/nary/cumulative/DisjunctiveTaskIntervalFilter.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/nary/cumulative/DisjunctiveTaskIntervalFilter.java
@@ -9,31 +9,34 @@
  */
 package org.chocosolver.solver.constraints.nary.cumulative;
 
-import gnu.trove.list.array.TIntArrayList;
 import org.chocosolver.solver.constraints.Propagator;
 import org.chocosolver.solver.exception.ContradictionException;
 import org.chocosolver.solver.variables.IntVar;
 import org.chocosolver.util.objects.setDataStructures.ISet;
 import org.chocosolver.util.objects.setDataStructures.ISetIterator;
 import org.chocosolver.util.sort.ArraySort;
+import org.chocosolver.util.sort.IntComparator;
 
 /**
  * @author Jean-Guillaume FAGES
  */
-public class DisjunctiveTaskIntervalFilter extends CumulFilter{
+public class DisjunctiveTaskIntervalFilter extends CumulFilter {
 
     //***********************************************************************************
     // VARIABLES
     //***********************************************************************************
-
-    private final TIntArrayList list = new TIntArrayList();
-
+    private final ArraySort<?> sort;
+    private final StartComparator comp;
+    private final int[] tsks;
     //***********************************************************************************
     // CONSTRUCTOR
     //***********************************************************************************
 
     public DisjunctiveTaskIntervalFilter(int nbMaxTasks) {
         super(nbMaxTasks);
+        sort = new ArraySort<>(nbMaxTasks, false, true);
+        comp = new StartComparator();
+        tsks = new int[nbMaxTasks];
     }
 
     //***********************************************************************************
@@ -43,31 +46,30 @@ public class DisjunctiveTaskIntervalFilter extends CumulFilter{
     @Override
     public void filter(IntVar[] s, IntVar[] d, IntVar[] e, IntVar[] h, IntVar capa, ISet tasks, Propagator<IntVar> aCause) throws ContradictionException {
         // filtering algorithm for disjunctive constraint
-        capa.updateUpperBound(1,aCause);
+        capa.updateUpperBound(1, aCause);
         // remove tasks that do not consume any resource
-        list.reset();//clear();
+        int tskSize = 0;
         ISetIterator tIter = tasks.iterator();
-        while (tIter.hasNext()){
+        while (tIter.hasNext()) {
             int t = tIter.nextInt();
-            if(d[t].getLB()>0 && h[t].getLB()>0){
-                list.add(t);
+            if (d[t].getLB() > 0 && h[t].getLB() > 0) {
+                tsks[tskSize++] = t;
             }
         }
-        int[] tsks = list.toArray();
-        ArraySort sort = new ArraySort(tsks.length,false,true);
-        sort.sort(tsks, tsks.length, (i1, i2) -> s[i1].getLB()-s[i2].getLB());
+        comp.setS(s);
+        sort.sort(tsks, tskSize, comp);
         // run energetic reasoning
-        for (int x=0;x<tsks.length;x++){
+        for (int x = 0; x < tskSize; x++) {
             int task1 = tsks[x];
-            for(int y=0;y<tsks.length;y++) {
+            for (int y = 0; y < tskSize; y++) {
                 if (x != y) {
                     int task2 = tsks[y];
                     int t1 = s[task1].getLB();
                     int t2 = e[task2].getUB();
-                    if(e[task1].getLB()>s[task2].getUB()){
-                        s[task1].updateLowerBound(e[task2].getLB(),aCause);
-                        e[task2].updateUpperBound(s[task1].getUB(),aCause);
-                    }else if (t1 < t2 && (t1 < e[task2].getLB() || t2 > s[task1].getUB())) {
+                    if (e[task1].getLB() > s[task2].getUB()) {
+                        s[task1].updateLowerBound(e[task2].getLB(), aCause);
+                        e[task2].updateUpperBound(s[task1].getUB(), aCause);
+                    } else if (t1 < t2 && (t1 < e[task2].getLB() || t2 > s[task1].getUB())) {
                         int W = 0;
                         for (int task3 : tsks) {
                             if (task3 != task1 && task3 != task2) {
@@ -90,4 +92,18 @@ public class DisjunctiveTaskIntervalFilter extends CumulFilter{
             }
         }
     }
+
+    private static class StartComparator implements IntComparator {
+        IntVar[] s;
+
+        void setS(IntVar[] s) {
+            this.s = s;
+        }
+
+        @Override
+        public int compare(int i1, int i2) {
+            return s[i1].getLB() - s[i2].getLB();
+        }
+    }
+
 }

--- a/solver/src/main/java/org/chocosolver/solver/constraints/nary/cumulative/DisjunctiveTaskIntervalFilter.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/nary/cumulative/DisjunctiveTaskIntervalFilter.java
@@ -71,7 +71,8 @@ public class DisjunctiveTaskIntervalFilter extends CumulFilter {
                         e[task2].updateUpperBound(s[task1].getUB(), aCause);
                     } else if (t1 < t2 && (t1 < e[task2].getLB() || t2 > s[task1].getUB())) {
                         int W = 0;
-                        for (int task3 : tsks) {
+                        for (int z = 0; z < tskSize; z++) {
+                            int task3 = tsks[z];
                             if (task3 != task1 && task3 != task2) {
                                 if (s[task3].getLB() >= t2) {
                                     break;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/nary/cumulative/NRJCumulFilter.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/nary/cumulative/NRJCumulFilter.java
@@ -28,7 +28,7 @@ public class NRJCumulFilter extends CumulFilter{
 	//***********************************************************************************
 
 	private final int[] sor_array;
-	private final ArraySort sorter;
+	private final ArraySort<?> sorter;
 	private final IntComparator comparator;
 	private final int[] slb;
 	private final int[] dlb;
@@ -42,7 +42,7 @@ public class NRJCumulFilter extends CumulFilter{
 	public NRJCumulFilter(int n){
 		super(n);
 		sor_array = new int[n];
-		sorter = new ArraySort(n,false,true);
+		sorter = new ArraySort<>(n,false,true);
 		slb = new int[n];
 		dlb = new int[n];
 		eub = new int[n];

--- a/solver/src/main/java/org/chocosolver/solver/constraints/nary/cumulative/PropCumulative.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/nary/cumulative/PropCumulative.java
@@ -99,7 +99,7 @@ public class PropCumulative extends Propagator<IntVar> {
     @Override
     public int getPropagationConditions(int idx) {
         if (idx == vars.length - 1) {
-            return IntEventType.combine(IntEventType.INSTANTIATE, IntEventType.DECUPP);
+            return IntEventType.upperBoundAndInst();
         }
         return IntEventType.boundAndInst();
     }
@@ -209,7 +209,7 @@ public class PropCumulative extends Propagator<IntVar> {
     /**
      * Return the index of an IntVar
      *
-     * @param pivot
+     * @param pivot variable
      */
     private int getInd(IntVar pivot) {
         int ind = -1;
@@ -218,7 +218,7 @@ public class PropCumulative extends Propagator<IntVar> {
                 ind = i;
             }
         }
-        if (ind == -1) throw new UnsupportedOperationException("Unfindable pivot variable ");
+        if (ind == -1) throw new UnsupportedOperationException("pivot variable cannot be found");
         return ind;
     }
 

--- a/solver/src/main/java/org/chocosolver/solver/constraints/nary/cumulative/SweepHeiSortCumulFilter.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/nary/cumulative/SweepHeiSortCumulFilter.java
@@ -30,7 +30,7 @@ public class SweepHeiSortCumulFilter extends SweepCumulFilter {
 	//***********************************************************************************
 
 	private final int[] sortedTasks;
-	private final ArraySort taskSorter;
+	private final ArraySort<?> taskSorter;
 	private final IntComparator comparator;
 
 	//***********************************************************************************
@@ -40,7 +40,7 @@ public class SweepHeiSortCumulFilter extends SweepCumulFilter {
 	public SweepHeiSortCumulFilter(int n){
 		super(n);
 		sortedTasks = new int[n];
-		taskSorter = new ArraySort(n,false,true);
+		taskSorter = new ArraySort<>(n,false,true);
 		comparator = (i1, i2) -> hlb[map[i2]]-hlb[map[i1]];
 	}
 

--- a/solver/src/main/java/org/chocosolver/solver/constraints/nary/knapsack/PropKnapsackKatriel01.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/nary/knapsack/PropKnapsackKatriel01.java
@@ -112,10 +112,10 @@ public class PropKnapsackKatriel01 extends Propagator<IntVar> {
             return IntEventType.boundAndInst();
         } else if (vIdx == n) {
             // updates on the max weight
-            return IntEventType.combine(IntEventType.DECUPP, IntEventType.INSTANTIATE);
+            return IntEventType.upperBoundAndInst();
         } else /* vIdx == n + 1 */ {
             // updates on the energy variable
-            return IntEventType.combine(IntEventType.INCLOW, IntEventType.INSTANTIATE);
+            return IntEventType.lowerBoundAndInst();
         }
     }
 

--- a/solver/src/main/java/org/chocosolver/solver/constraints/nary/sort/PropKeysorting.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/nary/sort/PropKeysorting.java
@@ -52,7 +52,7 @@ public final class PropKeysorting extends Propagator<IntVar> {
     private final int[] CUR;
     private boolean prune;
 
-    protected final ArraySort sorter;
+    private final ArraySort<?> sorter;
     private final IntComparator sortmincomp1 = (i, j) -> {
         int z = 0;
         while (z <= k && XLB[i][z] == XLB[j][z]) {
@@ -134,7 +134,7 @@ public final class PropKeysorting extends Propagator<IntVar> {
         this.ARRAY = new int[n];
         this.CUR = new int[k + 1];
 
-        sorter = new ArraySort(n, false, true);
+        sorter = new ArraySort<>(n, false, true);
     }
 
 
@@ -265,7 +265,7 @@ public final class PropKeysorting extends Propagator<IntVar> {
         }
         sorter.sort(SORTMAX, n, sortmaxcomp1);
         y = n - 1;
-        for (int i = n - 1; i > +0; i--) {
+        for (int i = n - 1; i > 0; i--) {
             x = SORTMAX[i];
             while (y >= 0 && lexLt(XUB[x], YLB[y], k + 1)) {
                 y--;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/nary/sum/PropSum.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/nary/sum/PropSum.java
@@ -124,9 +124,17 @@ public class PropSum extends Propagator<IntVar> {
             case NQ:
                 return IntEventType.instantiation();
             case LE:
-                return IntEventType.combine(IntEventType.INSTANTIATE, vIdx < pos ? IntEventType.INCLOW : IntEventType.DECUPP);
+                if(vIdx < pos){
+                    return IntEventType.lowerBoundAndInst();
+                }else{
+                    return IntEventType.upperBoundAndInst();
+                }
             case GE:
-                return IntEventType.combine(IntEventType.INSTANTIATE, vIdx < pos ? IntEventType.DECUPP : IntEventType.INCLOW);
+                if(vIdx < pos){
+                    return IntEventType.upperBoundAndInst();
+                }else{
+                    return IntEventType.lowerBoundAndInst();
+                }
             default:
                 return IntEventType.boundAndInst();
         }

--- a/solver/src/main/java/org/chocosolver/solver/constraints/nary/sum/PropSumBool.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/nary/sum/PropSumBool.java
@@ -9,14 +9,14 @@
  */
 package org.chocosolver.solver.constraints.nary.sum;
 
-import static org.chocosolver.solver.constraints.PropagatorPriority.BINARY;
-import static org.chocosolver.util.tools.ArrayUtils.concat;
-
 import org.chocosolver.solver.constraints.Operator;
 import org.chocosolver.solver.exception.ContradictionException;
 import org.chocosolver.solver.variables.BoolVar;
 import org.chocosolver.solver.variables.IntVar;
 import org.chocosolver.solver.variables.events.IntEventType;
+
+import static org.chocosolver.solver.constraints.PropagatorPriority.BINARY;
+import static org.chocosolver.util.tools.ArrayUtils.concat;
 
 /**
  * A propagator for SUM(x_i) = y + b, where x_i are boolean variables
@@ -40,11 +40,12 @@ public class PropSumBool extends PropSum {
      * Coefficients are induced by <code>pos</code>:
      * those before <code>pos</code> (included) are equal to 1,
      * the other ones are equal to -1.
-     * @param variables list of boolean variables
-     * @param pos position of the last positive (induced) coefficient
-     * @param o operator
-     * @param sum resulting variable
-     * @param b bound to respect
+     *
+     * @param variables        list of boolean variables
+     * @param pos              position of the last positive (induced) coefficient
+     * @param o                operator
+     * @param sum              resulting variable
+     * @param b                bound to respect
      * @param reactOnFineEvent set to <tt>true</tt> to react on fine events
      */
     protected PropSumBool(BoolVar[] variables, int pos, Operator o, IntVar sum, int b, boolean reactOnFineEvent) {
@@ -57,11 +58,12 @@ public class PropSumBool extends PropSum {
      * Coefficients are induced by <code>pos</code>:
      * those before <code>pos</code> (included) are equal to 1,
      * the other ones are equal to -1.
+     *
      * @param variables list of boolean variables
-     * @param pos position of the last positive (induced) coefficient
-     * @param o operator
-     * @param sum resulting variable
-     * @param b bound to respect
+     * @param pos       position of the last positive (induced) coefficient
+     * @param o         operator
+     * @param sum       resulting variable
+     * @param b         bound to respect
      */
     public PropSumBool(BoolVar[] variables, int pos, Operator o, IntVar sum, int b) {
         this(variables, pos, o, sum, b, false);
@@ -73,9 +75,17 @@ public class PropSumBool extends PropSum {
             case NQ:
                 return IntEventType.INSTANTIATE.getMask();
             case LE:
-                return IntEventType.combine(IntEventType.INSTANTIATE, vIdx == l - 1 ? IntEventType.DECUPP : IntEventType.VOID);
+                if (vIdx == l - 1) {
+                    return IntEventType.upperBoundAndInst();
+                } else {
+                    return IntEventType.instantiation();
+                }
             case GE:
-                return IntEventType.combine(IntEventType.INSTANTIATE, vIdx == l - 1 ? IntEventType.INCLOW : IntEventType.VOID);
+                if (vIdx == l - 1) {
+                    return IntEventType.lowerBoundAndInst();
+                } else {
+                    return IntEventType.instantiation();
+                }
             default:
                 return IntEventType.boundAndInst();
         }
@@ -107,7 +117,6 @@ public class PropSumBool extends PropSum {
         sumUB = ub - sum.getLB();
     }
 
-    @SuppressWarnings({"NullableProblems"})
     @Override
     protected void filterOnEq() throws ContradictionException {
         int F = b - sumLB;
@@ -157,7 +166,6 @@ public class PropSumBool extends PropSum {
     }
 
 
-    @SuppressWarnings({"NullableProblems"})
     @Override
     protected void filterOnLeq() throws ContradictionException {
         int F = b - sumLB;
@@ -196,7 +204,6 @@ public class PropSumBool extends PropSum {
         }
     }
 
-    @SuppressWarnings({"NullableProblems"})
     @Override
     protected void filterOnGeq() throws ContradictionException {
         int F = b - sumLB;
@@ -252,10 +259,10 @@ public class PropSumBool extends PropSum {
     }
 
     @Override
-    protected PropSum opposite(){
-        BoolVar[] bvars = new BoolVar[vars.length-1];
+    protected PropSum opposite() {
+        BoolVar[] bvars = new BoolVar[vars.length - 1];
         //noinspection SuspiciousSystemArraycopy
         System.arraycopy(vars, 0, bvars, 0, bvars.length);
-        return new PropSumBool(bvars, pos, nop(o), vars[vars.length-1], b + nb(o), reactToFineEvt);
+        return new PropSumBool(bvars, pos, nop(o), vars[vars.length - 1], b + nb(o), reactToFineEvt);
     }
 }

--- a/solver/src/main/java/org/chocosolver/solver/constraints/nary/sum/PropSumWithLong.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/nary/sum/PropSumWithLong.java
@@ -77,16 +77,16 @@ public class PropSumWithLong extends Propagator<IntVar> {
      * the other ones are equal to -1.
      *
      * @param variables list of integer variables
-     * @param pos position of the last positive coefficient
-     * @param o operator amng EQ, LE, GE and NE
-     * @param b bound to respect
+     * @param pos       position of the last positive coefficient
+     * @param o         operator amng EQ, LE, GE and NE
+     * @param b         bound to respect
      */
     public PropSumWithLong(IntVar[] variables, int pos, Operator o, long b) {
         this(variables, pos, o, b, computePriority(variables.length), false);
     }
 
 
-    PropSumWithLong(IntVar[] variables, int pos, Operator o, long b, PropagatorPriority priority, boolean reactOnFineEvent){
+    PropSumWithLong(IntVar[] variables, int pos, Operator o, long b, PropagatorPriority priority, boolean reactOnFineEvent) {
         super(variables, priority, reactOnFineEvent);
         this.pos = pos;
         this.o = o;
@@ -98,6 +98,7 @@ public class PropSumWithLong extends Propagator<IntVar> {
 
     /**
      * Compute the priority of the propagator wrt the number of involved variables
+     *
      * @param nbvars number of variables
      * @return the priority
      */
@@ -119,9 +120,17 @@ public class PropSumWithLong extends Propagator<IntVar> {
             case NQ:
                 return IntEventType.instantiation();
             case LE:
-                return IntEventType.combine(IntEventType.INSTANTIATE, vIdx < pos ? IntEventType.INCLOW : IntEventType.DECUPP);
+                if (vIdx < pos) {
+                    return IntEventType.lowerBoundAndInst();
+                } else {
+                    return IntEventType.upperBoundAndInst();
+                }
             case GE:
-                return IntEventType.combine(IntEventType.INSTANTIATE, vIdx < pos ? IntEventType.DECUPP : IntEventType.INCLOW);
+                if (vIdx < pos) {
+                    return IntEventType.upperBoundAndInst();
+                } else {
+                    return IntEventType.lowerBoundAndInst();
+                }
             default:
                 return IntEventType.boundAndInst();
         }
@@ -142,7 +151,7 @@ public class PropSumWithLong extends Propagator<IntVar> {
             sumLB += lb;
             sumUB += ub;
             I[i] = (ub - lb);
-            if(maxI < I[i])maxI = I[i];
+            if (maxI < I[i]) maxI = I[i];
         }
         for (; i < l; i++) { // then the negative ones
             lb = -vars[i].getUB();
@@ -150,7 +159,7 @@ public class PropSumWithLong extends Propagator<IntVar> {
             sumLB += lb;
             sumUB += ub;
             I[i] = (ub - lb);
-            if(maxI < I[i])maxI = I[i];
+            if (maxI < I[i]) maxI = I[i];
         }
     }
 
@@ -162,6 +171,7 @@ public class PropSumWithLong extends Propagator<IntVar> {
 
     /**
      * Execute filtering wrt the operator
+     *
      * @throws ContradictionException if contradiction is detected
      */
     protected void filter() throws ContradictionException {
@@ -184,6 +194,7 @@ public class PropSumWithLong extends Propagator<IntVar> {
 
     /**
      * Apply filtering when operator is EQ
+     *
      * @throws ContradictionException if contradiction is detected
      */
     protected void filterOnEq() throws ContradictionException {
@@ -222,7 +233,7 @@ public class PropSumWithLong extends Propagator<IntVar> {
                             anychange = true;
                         }
                     }
-                    if(maxI < I[i])maxI = I[i];
+                    if (maxI < I[i]) maxI = I[i];
                     i++;
                 }
                 // then negative ones
@@ -247,7 +258,7 @@ public class PropSumWithLong extends Propagator<IntVar> {
                             anychange = true;
                         }
                     }
-                    if(maxI < I[i])maxI = I[i];
+                    if (maxI < I[i]) maxI = I[i];
                     i++;
                 }
             }
@@ -256,11 +267,12 @@ public class PropSumWithLong extends Propagator<IntVar> {
                 this.setPassive();
                 return;
             }
-        }while (anychange) ;
+        } while (anychange);
     }
 
     /**
      * Apply filtering when operator is LE
+     *
      * @throws ContradictionException if contradiction is detected
      */
     protected void filterOnLeq() throws ContradictionException {
@@ -285,7 +297,7 @@ public class PropSumWithLong extends Propagator<IntVar> {
                         I[i] = nub - lb;
                     }
                 }
-                if(maxI < I[i])maxI = I[i];
+                if (maxI < I[i]) maxI = I[i];
                 i++;
             }
             // then negative ones
@@ -299,7 +311,7 @@ public class PropSumWithLong extends Propagator<IntVar> {
                         I[i] = nub - lb;
                     }
                 }
-                if(maxI < I[i])maxI = I[i];
+                if (maxI < I[i]) maxI = I[i];
                 i++;
             }
         }
@@ -310,6 +322,7 @@ public class PropSumWithLong extends Propagator<IntVar> {
 
     /**
      * Apply filtering when operator is GE
+     *
      * @throws ContradictionException if contradiction is detected
      */
     protected void filterOnGeq() throws ContradictionException {
@@ -319,7 +332,7 @@ public class PropSumWithLong extends Propagator<IntVar> {
         if (model.getSolver().isLearnOff() && E < 0) {
             fails();
         }
-        if(maxI > E) {
+        if (maxI > E) {
             maxI = 0;
             long lb, ub;
             int i = 0;
@@ -334,7 +347,7 @@ public class PropSumWithLong extends Propagator<IntVar> {
                         I[i] = ub - nlb;
                     }
                 }
-                if(maxI < I[i])maxI = I[i];
+                if (maxI < I[i]) maxI = I[i];
                 i++;
             }
             // then negative ones
@@ -348,7 +361,7 @@ public class PropSumWithLong extends Propagator<IntVar> {
                         I[i] = ub - nlb;
                     }
                 }
-                if(maxI < I[i])maxI = I[i];
+                if (maxI < I[i]) maxI = I[i];
                 i++;
             }
         }
@@ -359,6 +372,7 @@ public class PropSumWithLong extends Propagator<IntVar> {
 
     /**
      * Apply filtering when operator is NE
+     *
      * @throws ContradictionException if contradiction is detected
      */
     protected void filterOnNeq() throws ContradictionException {
@@ -403,11 +417,12 @@ public class PropSumWithLong extends Propagator<IntVar> {
 
     /**
      * Whether the current state of the scalar product is entailed
+     *
      * @param sumLB sum of lower bounds
      * @param sumUB sum of upper bounds
      * @return the entailment check
      */
-    public ESat check(long sumLB, long sumUB){
+    public ESat check(long sumLB, long sumUB) {
         switch (o) {
             case NQ:
                 if (sumUB < b || sumLB > b) {
@@ -460,8 +475,8 @@ public class PropSumWithLong extends Propagator<IntVar> {
         return linComb.toString();
     }
 
-    public static long nb(Operator co){
-        switch (co){
+    public static long nb(Operator co) {
+        switch (co) {
             case LE:
                 return 1;
             case GE:
@@ -471,8 +486,8 @@ public class PropSumWithLong extends Propagator<IntVar> {
         }
     }
 
-    public static Operator nop(Operator co){
-        switch (co){
+    public static Operator nop(Operator co) {
+        switch (co) {
             case LE:
                 return Operator.GE;
             case GE:
@@ -482,7 +497,7 @@ public class PropSumWithLong extends Propagator<IntVar> {
         }
     }
 
-    protected PropSumWithLong opposite(){
+    protected PropSumWithLong opposite() {
         return new PropSumWithLong(vars, pos, nop(o), b + nb(o));
     }
 }

--- a/solver/src/main/java/org/chocosolver/solver/constraints/real/PropScalarMixed.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/real/PropScalarMixed.java
@@ -110,13 +110,22 @@ public class PropScalarMixed extends Propagator<Variable> {
                 if (VariableUtils.isReal(vars[vIdx])) {
                     return c[vIdx] > 0 ? RealEventType.INCLOW.getMask() : RealEventType.DECUPP.getMask();
                 } else {
-                    return IntEventType.combine(IntEventType.INSTANTIATE, c[vIdx] > 0 ? IntEventType.INCLOW : IntEventType.DECUPP);
+                    if (c[vIdx] > 0) {
+                        return IntEventType.lowerBoundAndInst();
+                    } else {
+                        return IntEventType.upperBoundAndInst();
+                    }
+
                 }
             case GE:
                 if (VariableUtils.isReal(vars[vIdx])) {
                     return c[vIdx] > 0 ? RealEventType.DECUPP.getMask() : RealEventType.INCLOW.getMask();
                 } else {
-                    return IntEventType.combine(IntEventType.INSTANTIATE, c[vIdx] > 0 ? IntEventType.DECUPP : IntEventType.INCLOW);
+                    if(c[vIdx] > 0){
+                        return IntEventType.upperBoundAndInst();
+                    }else{
+                        return IntEventType.lowerBoundAndInst();
+                    }
                 }
             default:
                 if (VariableUtils.isReal(vars[vIdx])) {
@@ -447,26 +456,17 @@ public class PropScalarMixed extends Propagator<Variable> {
                 if (sumLB <= b) {
                     return ESat.TRUE;
                 }
-                if (sumLB > b) {
-                    return ESat.FALSE;
-                }
-                return ESat.UNDEFINED;
+                return ESat.FALSE;
             case GE:
                 if (sumUB >= b) {
                     return ESat.TRUE;
                 }
-                if (sumUB < b) {
-                    return ESat.FALSE;
-                }
-                return ESat.UNDEFINED;
+                return ESat.FALSE;
             default:
                 if (sumLB <= b && b <= sumUB) {
                     return ESat.TRUE;
                 }
-                if (sumUB < b || sumLB > b) {
-                    return ESat.FALSE;
-                }
-                return ESat.UNDEFINED;
+                return ESat.FALSE;
         }
     }
 

--- a/solver/src/main/java/org/chocosolver/solver/constraints/real/PropScalarMixed.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/real/PropScalarMixed.java
@@ -121,9 +121,9 @@ public class PropScalarMixed extends Propagator<Variable> {
                 if (VariableUtils.isReal(vars[vIdx])) {
                     return c[vIdx] > 0 ? RealEventType.DECUPP.getMask() : RealEventType.INCLOW.getMask();
                 } else {
-                    if(c[vIdx] > 0){
+                    if (c[vIdx] > 0) {
                         return IntEventType.upperBoundAndInst();
-                    }else{
+                    } else {
                         return IntEventType.lowerBoundAndInst();
                     }
                 }
@@ -453,20 +453,29 @@ public class PropScalarMixed extends Propagator<Variable> {
     protected ESat check(double sumLB, double sumUB) {
         switch (o) {
             case LE:
-                if (sumLB <= b) {
+                if (sumUB <= b) {
                     return ESat.TRUE;
                 }
-                return ESat.FALSE;
+                if (sumLB > b) {
+                    return ESat.FALSE;
+                }
+                return ESat.UNDEFINED;
             case GE:
-                if (sumUB >= b) {
+                if (sumLB >= b) {
                     return ESat.TRUE;
                 }
-                return ESat.FALSE;
+                if (sumUB < b) {
+                    return ESat.FALSE;
+                }
+                return ESat.UNDEFINED;
             default:
-                if (sumLB <= b && b <= sumUB) {
+                if (sumUB <= b && sumLB >= b) {
                     return ESat.TRUE;
                 }
-                return ESat.FALSE;
+                if (sumLB > b || sumUB < b) {
+                    return ESat.FALSE;
+                }
+                return ESat.UNDEFINED;
         }
     }
 

--- a/solver/src/main/java/org/chocosolver/solver/search/strategy/strategy/SetTimes.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/strategy/strategy/SetTimes.java
@@ -28,8 +28,6 @@ import org.chocosolver.util.ESat;
 import java.util.Arrays;
 import java.util.HashMap;
 
-import static org.chocosolver.solver.variables.events.IntEventType.*;
-
 public class SetTimes extends Propagator<IntVar> implements VariableSelector<IntVar>, IMonitorUpBranch {
     private final Task[] tasks;
     private final HashMap<IntVar, Integer> notSelectable;
@@ -88,7 +86,7 @@ public class SetTimes extends Propagator<IntVar> implements VariableSelector<Int
 
     @Override
     public int getPropagationConditions(int vIdx) {
-        return IntEventType.combine(INCLOW, INSTANTIATE);
+        return IntEventType.lowerBoundAndInst();
     }
 
     @Override

--- a/solver/src/main/java/org/chocosolver/solver/variables/events/IntEventType.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/events/IntEventType.java
@@ -28,7 +28,7 @@ import org.chocosolver.solver.ICause;
  * for example if one propagator removes values 1,2 and 3 from V={1, 2, 3, 4, 5},
  * it can be seen either by a sequence of 3 REMOVE OR one INCLOW.
  * Both express the same operations, one with 3 items the second with only one
- *
+ * <p>
  * Now, the purposes:
  * <ol>
  *     <li>
@@ -89,9 +89,9 @@ import org.chocosolver.solver.ICause;
  * </pre>
  * your propagator will be informed anytime one of its variable is modified by any events.
  * Later, when your propagator is actually executed, the aggregated events mask is given as input
- * (2nd parameter of {@link org.chocosolver.solver.constraints.Propagator#propagate(int i,int m)}),
+ * (2nd parameter of {@link org.chocosolver.solver.constraints.Propagator#propagate(int i, int m)}),
  * and here you can adapt the algorithm to the events got.
- *
+ * <p>
  * Indeed, you can have a merge event made of {@link #DECUPP} and {@link #INCLOW} and {@link #REMOVE} which indicates that:
  * <ol>
  *    <li>the upper bound of the variable i has decreased,</li>
@@ -167,10 +167,27 @@ public enum IntEventType implements IEventType {
     private static final int IDI = combine(BOUND, INSTANTIATE);
 
     /**
+     * Combination of masks for bound + instantiate events
+     */
+    private static final int II = combine(INCLOW, INSTANTIATE);
+
+    /**
+     * Combination of masks for bound + instantiate events
+     */
+    private static final int DI = combine(DECUPP, INSTANTIATE);
+
+    /**
      * Combines into a single mask some evts.
+     *
      * @param evts list of events to combine
      * @return mask expressing the combination of evts
+     * @deprecated change visibility to protected
+     * @see #all()
+     * @see #boundAndInst()
+     * @see #lowerBoundAndInst()
+     * @see #upperBoundAndInst()
      */
+    @Deprecated
     public static int combine(IntEventType... evts) {
         int mask = 0;
         for (int i = 0; i < evts.length; i++) {
@@ -191,6 +208,20 @@ public enum IntEventType implements IEventType {
      */
     public static int boundAndInst() {
         return IDI;
+    }
+
+    /**
+     * @return the bound and instantiation events' mask
+     */
+    public static int lowerBoundAndInst() {
+        return II;
+    }
+
+    /**
+     * @return the bound and instantiation events' mask
+     */
+    public static int upperBoundAndInst() {
+        return DI;
     }
 
     /**


### PR DESCRIPTION
In order to reduce the duration of the "mzn" test suite , because it is very unstable, I investigate objects creation during propagation and found out 2 memory leaks.
Once corrected, the `testThemAll` tests went from 5m30 to 4m30 on my machine (decrease of about 18%).

@fhermeni I also fixed a leak that you noticed.