### PR TITLE
Make possible to rewrite discrete expressions with rules

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,7 +8,7 @@ NEXT MILESTONE
 -------------------
 
 ### Major features:
-
+- Correcting the lack of filtering in `PropIncreasing` 
 ### Deprecated API (to be removed in next release):
 From `Solver`:
 - `Propagate getPropagate()`

--- a/solver/src/main/java/org/chocosolver/solver/constraints/nary/lex/PropIncreasing.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/nary/lex/PropIncreasing.java
@@ -47,15 +47,19 @@ public class PropIncreasing extends Propagator<IntVar> {
             for (int j = vars.length - 1; j > 0; j--) {
                 vars[j - 1].updateUpperBound(vars[j].getUB() - strict, this);
             }
+            left = vars.length - 1;
+            right = 0;
         } else {
             int i = left;
             left = vars.length - 1;
             int j = right;
             right = 0;
-            while (i < vars.length - 1 && vars[i + 1].updateLowerBound(vars[i].getLB() + strict, this)) {
+            while (i < vars.length - 1) {
+                vars[i + 1].updateLowerBound(vars[i].getLB() + strict, this);
                 i++;
             }
-            while (j > 0 && vars[j - 1].updateUpperBound(vars[j].getUB() - strict, this)) {
+            while (j > 0) {
+                vars[j - 1].updateUpperBound(vars[j].getUB() - strict, this);
                 j--;
             }
         }

--- a/solver/src/main/java/org/chocosolver/solver/expression/discrete/arithmetic/BiArExpression.java
+++ b/solver/src/main/java/org/chocosolver/solver/expression/discrete/arithmetic/BiArExpression.java
@@ -44,11 +44,11 @@ public class BiArExpression implements ArExpression {
     /**
      * The first expression this expression relies on
      */
-    private final ArExpression e1;
+    private ArExpression e1;
     /**
      * The second expression this expression relies on
      */
-    private final ArExpression e2;
+    private ArExpression e2;
 
     /**
      * Builds a binary expression
@@ -110,10 +110,10 @@ public class BiArExpression implements ArExpression {
                     bounds = VariableUtils.boundsForPow(v1, v2);
                     me = model.intVar(model.generateName("pow_exp_"), bounds[0], bounds[1]);
                     Tuples tuples = new Tuples(true);
-                    for(int val1 : v1){
-                        for(int val2 : v2){
-                            int res = (int)Math.pow(val1, val2);
-                            if(me.contains(res)) {
+                    for (int val1 : v1) {
+                        for (int val2 : v2) {
+                            int res = (int) Math.pow(val1, val2);
+                            if (me.contains(res)) {
                                 tuples.add(val1, val2, res);
                             }
                         }
@@ -150,6 +150,17 @@ public class BiArExpression implements ArExpression {
     @Override
     public ArExpression[] getExpressionChild() {
         return new ArExpression[]{e1, e2};
+    }
+
+    @Override
+    public ExpOperator getOperator() {
+        return op;
+    }
+
+    @Override
+    public void set(int idx, ArExpression e) {
+        if (idx == 0) this.e1 = e;
+        if (idx == 1) this.e2 = e;
     }
 
     @Override

--- a/solver/src/main/java/org/chocosolver/solver/expression/discrete/arithmetic/ExpOperator.java
+++ b/solver/src/main/java/org/chocosolver/solver/expression/discrete/arithmetic/ExpOperator.java
@@ -1,0 +1,21 @@
+/*
+ * This file is part of choco-solver, http://choco-solver.org/
+ *
+ * Copyright (c) 2022, IMT Atlantique. All rights reserved.
+ *
+ * Licensed under the BSD 4-clause license.
+ *
+ * See LICENSE file in the project root for full license information.
+ */
+package org.chocosolver.solver.expression.discrete.arithmetic;
+
+/**
+ * An interface that is implemented by expressions to defined specific operators.
+ * This interface is only required to ease rewriting expressions.
+ * <br/>
+ *
+ * @author Charles Prud'homme
+ * @since 30/11/2022
+ */
+public interface ExpOperator {
+}

--- a/solver/src/main/java/org/chocosolver/solver/expression/discrete/arithmetic/NaArExpression.java
+++ b/solver/src/main/java/org/chocosolver/solver/expression/discrete/arithmetic/NaArExpression.java
@@ -136,6 +136,18 @@ public class NaArExpression implements ArExpression {
     }
 
     @Override
+    public ExpOperator getOperator() {
+        return op;
+    }
+
+    @Override
+    public void set(int idx, ArExpression e) {
+        if (idx >= 0 && idx < es.length) {
+            this.es[idx] = e;
+        }
+    }
+
+    @Override
     public String toString() {
         return op.name() + "(" + es[0].toString() + ",... ," + es[es.length - 1].toString() + ")";
     }

--- a/solver/src/main/java/org/chocosolver/solver/expression/discrete/arithmetic/Rule.java
+++ b/solver/src/main/java/org/chocosolver/solver/expression/discrete/arithmetic/Rule.java
@@ -1,0 +1,62 @@
+/*
+ * This file is part of choco-solver, http://choco-solver.org/
+ *
+ * Copyright (c) 2022, IMT Atlantique. All rights reserved.
+ *
+ * Licensed under the BSD 4-clause license.
+ *
+ * See LICENSE file in the project root for full license information.
+ */
+package org.chocosolver.solver.expression.discrete.arithmetic;
+
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+/**
+ * Class that defines an expression's rewriting rule.
+ * It is composed of a predicate that serves as a pattern detector
+ * and a function to transform an expression into another one.
+ * <br/>
+ * It also provides predefined predicates and functions to limit verbosity.
+ * <br/>
+ *
+ * @author Charles Prud'homme
+ * @since 30/11/2022
+ */
+public class Rule<E extends ArExpression> {
+    final Predicate<E> predicate;
+    final Function<E, E> rewriter;
+
+    public Rule(Predicate<E> predicate, Function<E, E> rewriter) {
+        this.predicate = predicate;
+        this.rewriter = rewriter;
+    }
+
+    /**
+     * Predicate that take an operator as parameter
+     *
+     * @param op operator to match
+     * @return an operator-based predicate
+     */
+    public static Predicate<ArExpression> isOperator(ExpOperator op) {
+        return e -> e.getOperator().equals(op);
+    }
+
+    /**
+     * Pre-defined to function to apply when: 1) the expression has two children and 2) both are equivalent.
+     *
+     * @param function function to apply to replace the pair by one expression involving only one occurrence
+     * @return a function
+     */
+    public static Function<ArExpression, ArExpression> twoIdentical(Function<ArExpression, ArExpression> function) {
+        return e -> {
+            if (e.getNoChild() == 2) {
+                ArExpression[] es = e.getExpressionChild();
+                if (es[0].equals(es[1])) {
+                    return function.apply(es[0]);
+                }
+            }
+            return e;
+        };
+    }
+}

--- a/solver/src/main/java/org/chocosolver/solver/expression/discrete/arithmetic/UnArExpression.java
+++ b/solver/src/main/java/org/chocosolver/solver/expression/discrete/arithmetic/UnArExpression.java
@@ -43,7 +43,7 @@ public class UnArExpression implements ArExpression {
     /**
      * The expression this expression relies on
      */
-    private final ArExpression e;
+    private ArExpression e;
 
     /**
      * Builds a unary expression
@@ -74,6 +74,16 @@ public class UnArExpression implements ArExpression {
     @Override
     public ArExpression[] getExpressionChild() {
         return new ArExpression[]{e};
+    }
+
+    @Override
+    public ExpOperator getOperator() {
+        return op;
+    }
+
+    @Override
+    public void set(int idx, ArExpression e) {
+        if (idx == 0) this.e = e;
     }
 
     @Override

--- a/solver/src/main/java/org/chocosolver/solver/expression/discrete/arithmetic/UnCArExpression.java
+++ b/solver/src/main/java/org/chocosolver/solver/expression/discrete/arithmetic/UnCArExpression.java
@@ -44,7 +44,7 @@ public class UnCArExpression implements ArExpression {
     /**
      * The first expression this expression relies on
      */
-    private final ArExpression e1;
+    private ArExpression e1;
     /**
      * The second expression this expression relies on
      */
@@ -155,6 +155,11 @@ public class UnCArExpression implements ArExpression {
     @Override
     public ArExpression[] getExpressionChild() {
         return new ArExpression[]{e1};
+    }
+
+    @Override
+    public void set(int idx, ArExpression e) {
+        if (idx == 0) this.e1 = e;
     }
 
     @Override

--- a/solver/src/main/java/org/chocosolver/solver/expression/discrete/logical/BiLoExpression.java
+++ b/solver/src/main/java/org/chocosolver/solver/expression/discrete/logical/BiLoExpression.java
@@ -12,6 +12,8 @@ package org.chocosolver.solver.expression.discrete.logical;
 import org.chocosolver.solver.Model;
 import org.chocosolver.solver.constraints.Constraint;
 import org.chocosolver.solver.exception.SolverException;
+import org.chocosolver.solver.expression.discrete.arithmetic.ArExpression;
+import org.chocosolver.solver.expression.discrete.arithmetic.ExpOperator;
 import org.chocosolver.solver.expression.discrete.relational.ReExpression;
 import org.chocosolver.solver.variables.BoolVar;
 import org.chocosolver.solver.variables.IntVar;
@@ -32,12 +34,13 @@ public class BiLoExpression extends LoExpression {
     /**
      * The first expression this expression relies on
      */
-    private final ReExpression e1;
+    private ReExpression e1;
 
     /**
      * The second expression this expression relies on
      */
-    private final ReExpression e2;
+    private ReExpression e2;
+
     /**
      * Builds a n-ary expression
      *
@@ -86,6 +89,16 @@ public class BiLoExpression extends LoExpression {
     }
 
     @Override
+    public int getNoChild() {
+        return 2;
+    }
+
+    @Override
+    public ArExpression[] getExpressionChild() {
+        return new ArExpression[]{e1, e2};
+    }
+
+    @Override
     public Constraint decompose() {
         BoolVar v1 = e1.boolVar();
         BoolVar v2 = e2.boolVar();
@@ -104,6 +117,22 @@ public class BiLoExpression extends LoExpression {
     @Override
     public boolean beval(int[] values, Map<IntVar, Integer> map) {
         return op.eval(e1.beval(values, map), e2.beval(values, map));
+    }
+
+    @Override
+    public ExpOperator getOperator() {
+        return op;
+    }
+
+    @Override
+    public void set(int idx, ArExpression e) {
+        this.substitute(idx, (ReExpression) e);
+    }
+
+    @Override
+    public void substitute(int idx, ReExpression e) {
+        if (idx == 0) this.e1 = e;
+        if (idx == 1) this.e2 = e;
     }
 
     @Override

--- a/solver/src/main/java/org/chocosolver/solver/expression/discrete/logical/LoExpression.java
+++ b/solver/src/main/java/org/chocosolver/solver/expression/discrete/logical/LoExpression.java
@@ -10,8 +10,11 @@
 package org.chocosolver.solver.expression.discrete.logical;
 
 import org.chocosolver.solver.Model;
+import org.chocosolver.solver.expression.discrete.arithmetic.ExpOperator;
 import org.chocosolver.solver.expression.discrete.relational.ReExpression;
 import org.chocosolver.solver.variables.BoolVar;
+
+import java.util.List;
 
 /**
  * <p>
@@ -25,7 +28,7 @@ public abstract class LoExpression implements ReExpression {
     /**
      * List of available operator for relational expression
      */
-    public enum Operator {
+    public enum Operator implements ExpOperator {
         /**
          * less than
          */
@@ -105,4 +108,12 @@ public abstract class LoExpression implements ReExpression {
      * If necessary, it creates intermediary variable and posts intermediary constraints
      */
     public abstract BoolVar boolVar();
+
+    /**
+     * Replace the sub-expression at position <i>idx</i> in the expression by <i>e</i>.
+     * @param idx index of the expression to replace
+     * @param e the new expression
+     * @implSpec This method is only supposed to be used by {{@link #rewrite(List)}
+     */
+    public abstract void substitute(int idx, ReExpression e);
 }

--- a/solver/src/main/java/org/chocosolver/solver/expression/discrete/logical/NaLoExpression.java
+++ b/solver/src/main/java/org/chocosolver/solver/expression/discrete/logical/NaLoExpression.java
@@ -11,6 +11,8 @@ package org.chocosolver.solver.expression.discrete.logical;
 
 import org.chocosolver.solver.Model;
 import org.chocosolver.solver.constraints.Constraint;
+import org.chocosolver.solver.expression.discrete.arithmetic.ArExpression;
+import org.chocosolver.solver.expression.discrete.arithmetic.ExpOperator;
 import org.chocosolver.solver.expression.discrete.relational.ReExpression;
 import org.chocosolver.solver.variables.BoolVar;
 import org.chocosolver.solver.variables.IntVar;
@@ -137,6 +139,33 @@ public class NaLoExpression extends LoExpression {
             eval = op.eval(eval, es[i].beval(values, map));
         }
         return eval;
+    }
+
+    @Override
+    public int getNoChild() {
+        return es.length;
+    }
+
+    @Override
+    public ArExpression[] getExpressionChild() {
+        return es;
+    }
+
+    @Override
+    public ExpOperator getOperator() {
+        return op;
+    }
+
+    @Override
+    public void set(int idx, ArExpression e) {
+        substitute(idx, (ReExpression) e);
+    }
+
+    @Override
+    public void substitute(int idx, ReExpression e) {
+        if (idx >= 0 && idx < es.length) {
+            this.es[idx] = e;
+        }
     }
 
     @Override

--- a/solver/src/main/java/org/chocosolver/solver/expression/discrete/logical/UnLoExpression.java
+++ b/solver/src/main/java/org/chocosolver/solver/expression/discrete/logical/UnLoExpression.java
@@ -12,6 +12,8 @@ package org.chocosolver.solver.expression.discrete.logical;
 import org.chocosolver.solver.Model;
 import org.chocosolver.solver.constraints.Constraint;
 import org.chocosolver.solver.exception.SolverException;
+import org.chocosolver.solver.expression.discrete.arithmetic.ArExpression;
+import org.chocosolver.solver.expression.discrete.arithmetic.ExpOperator;
 import org.chocosolver.solver.expression.discrete.relational.ReExpression;
 import org.chocosolver.solver.variables.BoolVar;
 import org.chocosolver.solver.variables.IntVar;
@@ -32,12 +34,13 @@ public class UnLoExpression extends LoExpression {
     /**
      * The first expression this expression relies on
      */
-    private final ReExpression e;
+    private ReExpression e;
+
     /**
      * Builds a n-ary expression
      *
      * @param op an operator
-     * @param e an expression
+     * @param e  an expression
      */
     public UnLoExpression(Operator op, ReExpression e) {
         super(e.getModel(), op);
@@ -57,7 +60,7 @@ public class UnLoExpression extends LoExpression {
                 me = model.boolNotView(b);
             } else {
                 throw new UnsupportedOperationException(
-                    "Unary logical expressions does not support " + op.name());
+                        "Unary logical expressions does not support " + op.name());
             }
         }
         return me;
@@ -84,7 +87,32 @@ public class UnLoExpression extends LoExpression {
     }
 
     @Override
+    public int getNoChild() {
+        return 1;
+    }
+
+    @Override
+    public ArExpression[] getExpressionChild() {
+        return new ArExpression[]{e};
+    }
+
+    @Override
+    public ExpOperator getOperator() {
+        return op;
+    }
+
+    @Override
+    public void set(int idx, ArExpression e) {
+        this.substitute(idx, (ReExpression) e);
+    }
+
+    @Override
+    public void substitute(int idx, ReExpression e) {
+        if (idx == 0) this.e = e;
+    }
+
+    @Override
     public String toString() {
-        return op.name() + "(" + e.toString()+ ")";
+        return op.name() + "(" + e.toString() + ")";
     }
 }

--- a/solver/src/main/java/org/chocosolver/solver/expression/discrete/relational/NaReExpression.java
+++ b/solver/src/main/java/org/chocosolver/solver/expression/discrete/relational/NaReExpression.java
@@ -13,6 +13,7 @@ import org.chocosolver.solver.Model;
 import org.chocosolver.solver.constraints.Constraint;
 import org.chocosolver.solver.exception.SolverException;
 import org.chocosolver.solver.expression.discrete.arithmetic.ArExpression;
+import org.chocosolver.solver.expression.discrete.arithmetic.ExpOperator;
 import org.chocosolver.solver.variables.BoolVar;
 import org.chocosolver.solver.variables.IntVar;
 import org.chocosolver.util.tools.ArrayUtils;
@@ -55,7 +56,7 @@ public class NaReExpression implements ReExpression {
      * Builds a nary expression
      *
      * @param op an operator
-     * @param e an expression
+     * @param e  an expression
      * @param es some expressions
      */
     public NaReExpression(Operator op, ArExpression e, ArExpression... es) {
@@ -83,7 +84,7 @@ public class NaReExpression implements ReExpression {
     public BoolVar boolVar() {
         if (me == null) {
             IntVar[] vs = Arrays.stream(es).map(ArExpression::intVar).toArray(IntVar[]::new);
-            me = model.boolVar(model.generateName(op+"_exp_"));
+            me = model.boolVar(model.generateName(op + "_exp_"));
             if (op == Operator.EQ) {
                 if (vs.length == 2) {
                     model.reifyXeqY(vs[0], vs[1], me);
@@ -92,15 +93,15 @@ public class NaReExpression implements ReExpression {
                     model.nValues(vs, count).post();
                     model.reifyXeqC(count, 1, me);
                 }
-            }else if(op == Operator.IN){
+            } else if (op == Operator.IN) {
                 BoolVar[] reifs = model.boolVarArray(vs.length - 1);
-                for(int i = 1; i < vs.length; i++) {
-                    model.reifyXeqY(vs[0], vs[i], reifs[i-1]);
+                for (int i = 1; i < vs.length; i++) {
+                    model.reifyXeqY(vs[0], vs[i], reifs[i - 1]);
                 }
-                model.addClausesSumBoolArrayGreaterEqVar(reifs,me);
+                model.addClausesSumBoolArrayGreaterEqVar(reifs, me);
             } else {
                 throw new UnsupportedOperationException(
-                    "Binary arithmetic expressions does not support " + op.name());
+                        "Binary arithmetic expressions does not support " + op.name());
             }
         }
         return me;
@@ -116,15 +117,15 @@ public class NaReExpression implements ReExpression {
         IntVar[] vs = Arrays.stream(es).map(ArExpression::intVar).toArray(IntVar[]::new);
         switch (op) {
             case EQ:
-                if(vs.length == 2){
+                if (vs.length == 2) {
                     return model.arithm(vs[0], "=", vs[1]);
-                }else {
+                } else {
                     return model.allEqual(vs);
                 }
             case IN:
                 return model.count(vs[0],
                         Arrays.copyOfRange(vs, 1, vs.length),
-                        model.intVar(op+"_idx", 1, vs.length-1));
+                        model.intVar(op + "_idx", 1, vs.length - 1));
         }
         throw new SolverException("Unexpected case");
     }
@@ -149,6 +150,28 @@ public class NaReExpression implements ReExpression {
                 throw new IllegalStateException("Unexpected value: " + op);
         }
         return eval;
+    }
+
+    @Override
+    public int getNoChild() {
+        return es.length;
+    }
+
+    @Override
+    public ArExpression[] getExpressionChild() {
+        return es;
+    }
+
+    @Override
+    public ExpOperator getOperator() {
+        return op;
+    }
+
+    @Override
+    public void set(int idx, ArExpression e) {
+        if (idx >= 0 && idx < es.length) {
+            this.es[idx] = e;
+        }
     }
 
     @Override

--- a/solver/src/main/java/org/chocosolver/solver/expression/discrete/relational/ReExpression.java
+++ b/solver/src/main/java/org/chocosolver/solver/expression/discrete/relational/ReExpression.java
@@ -14,6 +14,7 @@ import org.chocosolver.solver.constraints.Constraint;
 import org.chocosolver.solver.constraints.extension.Tuples;
 import org.chocosolver.solver.constraints.extension.TuplesFactory;
 import org.chocosolver.solver.expression.discrete.arithmetic.ArExpression;
+import org.chocosolver.solver.expression.discrete.arithmetic.ExpOperator;
 import org.chocosolver.solver.expression.discrete.arithmetic.IfArExpression;
 import org.chocosolver.solver.expression.discrete.logical.BiLoExpression;
 import org.chocosolver.solver.expression.discrete.logical.LoExpression;
@@ -41,7 +42,7 @@ public interface ReExpression extends ArExpression {
     /**
      * List of available operator for relational expression
      */
-    enum Operator {
+    enum Operator implements ExpOperator {
         /**
          * less than
          */
@@ -164,7 +165,6 @@ public interface ReExpression extends ArExpression {
      * @param map mapping between variables of the topmost expression and position in <i>values</i>
      * @return an evaluation of this relational expression based on a tuple
      */
-    @SuppressWarnings("SuspiciousMethodCalls")
     default boolean beval(int[] values, Map<IntVar, Integer> map){
         assert this instanceof BoolVar;
         return values[map.get(this)] == 1;

--- a/solver/src/main/java/org/chocosolver/solver/expression/discrete/relational/UnCReExpression.java
+++ b/solver/src/main/java/org/chocosolver/solver/expression/discrete/relational/UnCReExpression.java
@@ -15,6 +15,7 @@ import org.chocosolver.solver.constraints.Constraint;
 import org.chocosolver.solver.exception.SolverException;
 import org.chocosolver.solver.expression.discrete.arithmetic.ArExpression;
 import org.chocosolver.solver.expression.discrete.arithmetic.BiArExpression;
+import org.chocosolver.solver.expression.discrete.arithmetic.ExpOperator;
 import org.chocosolver.solver.expression.discrete.arithmetic.NaArExpression;
 import org.chocosolver.solver.variables.BoolVar;
 import org.chocosolver.solver.variables.IntVar;
@@ -55,7 +56,7 @@ public class UnCReExpression implements ReExpression {
     /**
      * The first expression this expression relies on
      */
-    private final ArExpression e1;
+    private ArExpression e1;
     /**
      * The second expression this expression relies on
      */
@@ -213,6 +214,26 @@ public class UnCReExpression implements ReExpression {
     }
 
     @Override
+    public int getNoChild() {
+        return 1;
+    }
+
+    @Override
+    public ArExpression[] getExpressionChild() {
+        return new ArExpression[]{e1};
+    }
+
+    @Override
+    public ExpOperator getOperator() {
+        return op;
+    }
+
+    @Override
+    public void set(int idx, ArExpression e) {
+        if (idx == 0) this.e1 = e;
+    }
+
+    @Override
     public String toString() {
         return op.name() + "(" + e1.toString() + "," + e2 + ")";
     }
@@ -220,6 +241,7 @@ public class UnCReExpression implements ReExpression {
     /**
      * Creates, or returns if already existing, the SAT variable corresponding
      * to the relationship.
+     *
      * @return the SAT variable of this relation
      */
     public int satVar() {

--- a/solver/src/main/java/org/chocosolver/util/objects/setDataStructures/iterable/IntIterableSetUtils.java
+++ b/solver/src/main/java/org/chocosolver/util/objects/setDataStructures/iterable/IntIterableSetUtils.java
@@ -423,7 +423,7 @@ public class IntIterableSetUtils {
         setr.clear();
         int s1 = set1.SIZE >> 1;
         int s2 = set2.SIZE >> 1;
-        if (s1 > 0 && s2 > 0) {
+        if (s1 >= 0 && s2 >= 0) {
             setr.grow(set1.SIZE);
             int i = 0, j = 0;
             int lbi, ubi, lbj, ubj, lb, ub;
@@ -485,7 +485,7 @@ public class IntIterableSetUtils {
         boolean change = false;
         int s1 = set1.SIZE >> 1;
         int s2 = set2.SIZE >> 1;
-        if (s1 > 0 && s2 > 0) {
+        if (s1 >= 0 && s2 >= 0) {
             int i = 0, j = 0;
             int s = 0, c = 0;
             int[] e = new int[set1.SIZE];

--- a/solver/src/test/java/org/chocosolver/solver/expression/discrete/RuleTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/expression/discrete/RuleTest.java
@@ -1,0 +1,72 @@
+/*
+ * This file is part of choco-solver, http://choco-solver.org/
+ *
+ * Copyright (c) 2022, IMT Atlantique. All rights reserved.
+ *
+ * Licensed under the BSD 4-clause license.
+ *
+ * See LICENSE file in the project root for full license information.
+ */
+package org.chocosolver.solver.expression.discrete;
+
+import org.chocosolver.solver.Model;
+import org.chocosolver.solver.constraints.binary.PropGreaterOrEqualXY_C;
+import org.chocosolver.solver.constraints.binary.PropScale;
+import org.chocosolver.solver.constraints.unary.PropEqualXC;
+import org.chocosolver.solver.expression.discrete.arithmetic.ArExpression;
+import org.chocosolver.solver.expression.discrete.arithmetic.Rule;
+import org.chocosolver.solver.expression.discrete.logical.LoExpression;
+import org.chocosolver.solver.expression.discrete.relational.ReExpression;
+import org.chocosolver.solver.variables.BoolVar;
+import org.chocosolver.solver.variables.IntVar;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * <br/>
+ *
+ * @author Charles Prud'homme
+ * @since 30/11/2022
+ */
+public class RuleTest {
+
+    @Test(groups = "1s")
+    public void testRewrite1() {
+        Model model = new Model("rewrite1");
+        IntVar x = model.intVar("x", 0, 10);
+        IntVar y = model.intVar("y", 0, 10);
+
+        List<Rule<ArExpression>> rules = new ArrayList<>();
+        rules.add(new Rule<>(
+                Rule.isOperator(ArExpression.Operator.ADD),
+                Rule.twoIdentical(e -> e.mul(2))));
+        rules.add(new Rule<>(
+                Rule.isOperator(ArExpression.Operator.SUB),
+                Rule.twoIdentical(e -> model.intVar(0))));
+
+        ReExpression exp = x.add(x).eq(y.sub(y));
+        Assert.assertTrue(exp.decompose().getPropagator(0) instanceof PropScale);
+        exp = exp.rewrite(rules);
+        System.out.printf("%s\n", exp);
+        Assert.assertTrue(exp.decompose().getPropagator(0) instanceof PropEqualXC);
+    }
+
+    @Test(groups = "1s")
+    public void testRewrite2() {
+        Model model = new Model("rewrite2");
+        BoolVar x = model.boolVar("x");
+        BoolVar y = model.boolVar("y");
+
+        List<Rule<ArExpression>> rules = new ArrayList<>();
+        rules.add(new Rule<>(
+                Rule.isOperator(LoExpression.Operator.OR),
+                Rule.twoIdentical(e -> e)));
+
+        ReExpression exp = x.or(x).or(x).or(y).rewrite(rules);
+        System.out.printf("%s\n", exp);
+        Assert.assertTrue(exp.decompose().getPropagator(0) instanceof PropGreaterOrEqualXY_C);
+    }
+}

--- a/solver/src/test/java/org/chocosolver/util/objects/setDataStructures/iterable/IntIterableRangeSetTest.java
+++ b/solver/src/test/java/org/chocosolver/util/objects/setDataStructures/iterable/IntIterableRangeSetTest.java
@@ -684,6 +684,30 @@ public class IntIterableRangeSetTest {
         }
     }
 
+    @Test(groups = "1s", timeOut = 60000)
+    public void testUnion3() {
+        IntIterableRangeSet set = IntIterableSetUtils.union(new IntIterableRangeSet(), new IntIterableRangeSet(0));
+        Assert.assertEquals(set.size(), 1);
+    }
+
+    @Test(groups = "1s", timeOut = 60000)
+    public void testUnion4() {
+        IntIterableRangeSet set = new IntIterableRangeSet();
+        IntIterableSetUtils.unionOf(set, new IntIterableRangeSet(0));
+        Assert.assertEquals(set.size(), 1);
+    }
+
+    @Test(groups = "1s", timeOut = 60000)
+    public void testUnion5() {
+        IntIterableRangeSet set = new IntIterableRangeSet(0);
+        IntIterableSetUtils.unionOf(set, new IntIterableRangeSet());
+        Assert.assertEquals(set.size(), 1);
+    }
+
+    @Test(groups = "1s", timeOut = 60000)
+    public void testIncludedIn1() {
+        Assert.assertTrue(IntIterableSetUtils.includedIn(new IntIterableRangeSet(), new IntIterableRangeSet(0)));
+    }
 
     @Test(groups = "1s", timeOut = 60000)
     public void testRemoveBetween1() {
@@ -825,7 +849,7 @@ public class IntIterableRangeSetTest {
         Assert.assertTrue(cop.isEqualToObserved());
     }
 
-    class PassiveCopySet extends AbstractSet {
+    static class PassiveCopySet extends AbstractSet {
 
         private final ISet set;
         private final ISet values;


### PR DESCRIPTION
This pull request address makes it possible to define rewriting rules to transform an expression.
One has to define one or more couples, each composed of a predicate (to detect a pattern) and a function (to transform the expression detected). Then a call to `e.rewrite(...)` transform in-place the expression.

I also (started to) define some pre-defined predicates and functions, like `Rule.isOperator(...)` and `Rule.twoIdentical(...)`.

Basic example:

```java
Model model = new Model("rewrite1");                                       
IntVar x = model.intVar("x", 0, 10);                                       
IntVar y = model.intVar("y", 0, 10);                                       
                                                                           
List<Rule<ArExpression>> rules = new ArrayList<>();                        
rules.add(new Rule<>(                                                      
        Rule.isOperator(ArExpression.Operator.ADD),                        
        Rule.twoIdentical(e -> e.mul(2))));                                
rules.add(new Rule<>(                                                      
        Rule.isOperator(ArExpression.Operator.SUB),                        
        Rule.twoIdentical(e -> model.intVar(0))));                         
                                                                           
ReExpression exp = x.add(x).eq(y.sub(y)).rewrite(rules);                                  
System.out.printf("%s\n", exp);                                            
```

Related to: #979  #953 
@arnaud-m if you want to play with the branch, you're welcome, this is a draft PR, waiting for feedbacks.