### PR TITLE
Fix bug in removeAllValuesBut and removeValues and for enumerated domain variables

### DIFF
--- a/solver/src/main/java/org/chocosolver/solver/variables/impl/BitsetArrayIntVarImpl.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/impl/BitsetArrayIntVarImpl.java
@@ -275,11 +275,12 @@ public final class BitsetArrayIntVarImpl extends AbstractVariable implements Int
             hasChanged |= fixpoint;
         } while (fixpoint);
         // now deal with holes
+        int to = UB.get() - 1;
         boolean hasRemoved = false;
         int count = SIZE.get();
         int value;
         // iterate over the values in the domain, remove the ones that are not in values
-        for (int index = INDICES.nextSetBit(nlb + 1); index > -1 && index <= nub; index = INDICES.nextSetBit(index + 1)) {
+        for (int index = INDICES.nextSetBit(LB.get() + 1); index > -1 && index <= to; index = INDICES.nextSetBit(index + 1)) {
             value = VALUES[index];
             if (!values.contains(value)) {
                 model.getSolver().getEventObserver().removeValue(this, value, cause);

--- a/solver/src/main/java/org/chocosolver/solver/variables/impl/BitsetArrayIntVarImpl.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/impl/BitsetArrayIntVarImpl.java
@@ -191,30 +191,35 @@ public final class BitsetArrayIntVarImpl extends AbstractVariable implements Int
     @Override
     public boolean removeValues(IntIterableSet values, ICause cause) throws ContradictionException {
         assert cause != null;
-        int olb = getLB();
-        int oub = getUB();
-        int nlb = values.nextValue(olb - 1);
-        int nub = values.previousValue(oub + 1);
-        if (nlb > oub || nub < olb) {
-            return false;
-        }
-        int i;
-        // look for the new lb
-        while (nlb == olb && olb < Integer.MAX_VALUE) {
-            i = INDICES.nextSetBit(V2I.get(olb) + 1);
-            olb = i > -1 ? VALUES[i] : Integer.MAX_VALUE;
+        boolean hasChanged = false, fixpoint;
+        int nlb, nub;
+        do {
+            int olb = getLB();
+            int oub = getUB();
             nlb = values.nextValue(olb - 1);
-        }
-        if (nlb <= nub) {
-            // look for the new ub
-            while (nub == oub && oub > Integer.MIN_VALUE) {
-                i = INDICES.prevSetBit(V2I.get(oub) - 1);
-                oub = i > -1 ? VALUES[i] : Integer.MIN_VALUE;
-                nub = values.previousValue(oub + 1);
+            nub = values.previousValue(oub + 1);
+            if (!hasChanged && (nlb > oub || nub < olb)) {
+                return false;
             }
-        }
-        // the new bounds are now known, delegate to the right method
-        boolean hasChanged = updateBounds(olb, oub, cause);
+            int i;
+            // look for the new lb
+            while (nlb == olb && olb < Integer.MAX_VALUE) {
+                i = INDICES.nextSetBit(V2I.get(olb) + 1);
+                olb = i > -1 ? VALUES[i] : Integer.MAX_VALUE;
+                nlb = values.nextValue(olb - 1);
+            }
+            if (nlb <= nub) {
+                // look for the new ub
+                while (nub == oub && oub > Integer.MIN_VALUE) {
+                    i = INDICES.prevSetBit(V2I.get(oub) - 1);
+                    oub = i > -1 ? VALUES[i] : Integer.MIN_VALUE;
+                    nub = values.previousValue(oub + 1);
+                }
+            }
+            // the new bounds are now known, delegate to the right method
+            fixpoint = updateBounds(olb, oub, cause);
+            hasChanged |= fixpoint;
+        }while(fixpoint);
         // now deal with holes
         int value = nlb;
         int to = nub;
@@ -244,27 +249,32 @@ public final class BitsetArrayIntVarImpl extends AbstractVariable implements Int
 
     @Override
     public boolean removeAllValuesBut(IntIterableSet values, ICause cause) throws ContradictionException {
-        int olb = getLB();
-        int oub = getUB();
-        int nlb = values.nextValue(olb - 1);
-        int nub = values.previousValue(oub + 1);
-        int i;
-        // look for the new lb
-        while (nlb != olb && olb < Integer.MAX_VALUE && nlb < Integer.MAX_VALUE) {
-            i = INDICES.nextSetBit(V2I.get(olb) + 1);
-            olb = i > -1 ? VALUES[i] : Integer.MAX_VALUE;
+        boolean hasChanged = false, fixpoint;
+        int nlb, nub;
+        do {
+            int olb = getLB();
+            int oub = getUB();
             nlb = values.nextValue(olb - 1);
-        }
-        if (nlb <= nub) {
-            // look for the new ub
-            while (nub != oub && olb > Integer.MIN_VALUE && oub > Integer.MIN_VALUE) {
-                i = INDICES.prevSetBit(V2I.get(oub) - 1);
-                oub = i > -1 ? VALUES[i] : Integer.MIN_VALUE;
-                nub = values.previousValue(oub + 1);
+            nub = values.previousValue(oub + 1);
+            int i;
+            // look for the new lb
+            while (nlb != olb && olb < Integer.MAX_VALUE && nlb < Integer.MAX_VALUE) {
+                i = INDICES.nextSetBit(V2I.get(olb) + 1);
+                olb = i > -1 ? VALUES[i] : Integer.MAX_VALUE;
+                nlb = values.nextValue(olb - 1);
             }
-        }
-        // the new bounds are now known, delegate to the right method
-        boolean hasChanged = updateBounds(nlb, nub, cause);
+            if (nlb <= nub) {
+                // look for the new ub
+                while (nub != oub && olb > Integer.MIN_VALUE && oub > Integer.MIN_VALUE) {
+                    i = INDICES.prevSetBit(V2I.get(oub) - 1);
+                    oub = i > -1 ? VALUES[i] : Integer.MIN_VALUE;
+                    nub = values.previousValue(oub + 1);
+                }
+            }
+            // the new bounds are now known, delegate to the right method
+            fixpoint = updateBounds(nlb, nub, cause);
+            hasChanged |= fixpoint;
+        } while (fixpoint);
         // now deal with holes
         int to = UB.get() - 1;
         boolean hasRemoved = false;

--- a/solver/src/main/java/org/chocosolver/solver/variables/impl/BitsetArrayIntVarImpl.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/impl/BitsetArrayIntVarImpl.java
@@ -192,40 +192,39 @@ public final class BitsetArrayIntVarImpl extends AbstractVariable implements Int
     public boolean removeValues(IntIterableSet values, ICause cause) throws ContradictionException {
         assert cause != null;
         boolean hasChanged = false, fixpoint;
-        int nlb, nub;
+        int vlb, vub;
         do {
-            int olb = getLB();
-            int oub = getUB();
-            nlb = values.nextValue(olb - 1);
-            nub = values.previousValue(oub + 1);
-            if (!hasChanged && (nlb > oub || nub < olb)) {
+            int nlb = getLB();
+            int nub = getUB();
+            vlb = values.nextValue(nlb - 1);
+            vub = values.previousValue(nub + 1);
+            if (!hasChanged && (vlb > nub || vub < nlb)) {
                 return false;
             }
             int i;
             // look for the new lb
-            while (nlb == olb && olb < Integer.MAX_VALUE) {
-                i = INDICES.nextSetBit(V2I.get(olb) + 1);
-                olb = i > -1 ? VALUES[i] : Integer.MAX_VALUE;
-                nlb = values.nextValue(olb - 1);
+            while (vlb == nlb && nlb < Integer.MAX_VALUE) {
+                i = INDICES.nextSetBit(V2I.get(nlb) + 1);
+                nlb = i > -1 ? VALUES[i] : Integer.MAX_VALUE;
+                vlb = values.nextValue(nlb - 1);
             }
-            if (nlb <= nub) {
+            if (vlb <= vub) {
                 // look for the new ub
-                while (nub == oub && oub > Integer.MIN_VALUE) {
-                    i = INDICES.prevSetBit(V2I.get(oub) - 1);
-                    oub = i > -1 ? VALUES[i] : Integer.MIN_VALUE;
-                    nub = values.previousValue(oub + 1);
+                while (vub == nub && nub > Integer.MIN_VALUE) {
+                    i = INDICES.prevSetBit(V2I.get(nub) - 1);
+                    nub = i > -1 ? VALUES[i] : Integer.MIN_VALUE;
+                    vub = values.previousValue(nub + 1);
                 }
             }
             // the new bounds are now known, delegate to the right method
-            fixpoint = updateBounds(olb, oub, cause);
+            fixpoint = updateBounds(nlb, nub, cause);
             hasChanged |= fixpoint;
-        }while(fixpoint);
+        } while (fixpoint);
         // now deal with holes
-        int value = nlb;
-        int to = nub;
+        int value = vlb;
         boolean hasRemoved = false;
         int count = SIZE.get();
-        while (value <= to) {
+        while (value <= vub) {
             int index = V2I.get(value);
             if (index > -1 && this.INDICES.get(index)) {
                 model.getSolver().getEventObserver().removeValue(this, value, cause);
@@ -252,23 +251,23 @@ public final class BitsetArrayIntVarImpl extends AbstractVariable implements Int
         boolean hasChanged = false, fixpoint;
         int nlb, nub;
         do {
-            int olb = getLB();
-            int oub = getUB();
-            nlb = values.nextValue(olb - 1);
-            nub = values.previousValue(oub + 1);
+            int clb = getLB();
+            int cub = getUB();
+            nlb = values.nextValue(clb - 1);
+            nub = values.previousValue(cub + 1);
             int i;
             // look for the new lb
-            while (nlb != olb && olb < Integer.MAX_VALUE && nlb < Integer.MAX_VALUE) {
-                i = INDICES.nextSetBit(V2I.get(olb) + 1);
-                olb = i > -1 ? VALUES[i] : Integer.MAX_VALUE;
-                nlb = values.nextValue(olb - 1);
+            while (nlb != clb && clb < Integer.MAX_VALUE && nlb < Integer.MAX_VALUE) {
+                i = INDICES.nextSetBit(V2I.get(clb) + 1);
+                clb = i > -1 ? VALUES[i] : Integer.MAX_VALUE;
+                nlb = values.nextValue(clb - 1);
             }
             if (nlb <= nub) {
                 // look for the new ub
-                while (nub != oub && olb > Integer.MIN_VALUE && oub > Integer.MIN_VALUE) {
-                    i = INDICES.prevSetBit(V2I.get(oub) - 1);
-                    oub = i > -1 ? VALUES[i] : Integer.MIN_VALUE;
-                    nub = values.previousValue(oub + 1);
+                while (nub != cub && cub > Integer.MIN_VALUE && nub > Integer.MIN_VALUE) {
+                    i = INDICES.prevSetBit(V2I.get(cub) - 1);
+                    cub = i > -1 ? VALUES[i] : Integer.MIN_VALUE;
+                    nub = values.previousValue(cub + 1);
                 }
             }
             // the new bounds are now known, delegate to the right method
@@ -276,12 +275,11 @@ public final class BitsetArrayIntVarImpl extends AbstractVariable implements Int
             hasChanged |= fixpoint;
         } while (fixpoint);
         // now deal with holes
-        int to = UB.get() - 1;
         boolean hasRemoved = false;
         int count = SIZE.get();
         int value;
         // iterate over the values in the domain, remove the ones that are not in values
-        for (int index = INDICES.nextSetBit(LB.get() + 1); index > -1 && index <= to; index = INDICES.nextSetBit(index + 1)) {
+        for (int index = INDICES.nextSetBit(nlb + 1); index > -1 && index <= nub; index = INDICES.nextSetBit(index + 1)) {
             value = VALUES[index];
             if (!values.contains(value)) {
                 model.getSolver().getEventObserver().removeValue(this, value, cause);

--- a/solver/src/main/java/org/chocosolver/solver/variables/impl/BitsetIntVarImpl.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/impl/BitsetIntVarImpl.java
@@ -192,40 +192,39 @@ public final class BitsetIntVarImpl extends AbstractVariable implements IntVar {
     public boolean removeValues(IntIterableSet values, ICause cause) throws ContradictionException {
         assert cause != null;
         boolean hasChanged = false, fixpoint;
-        int nlb, nub;
+        int vlb, vub;
         do {
-            int olb = getLB();
-            int oub = getUB();
-            nlb = values.nextValue(olb - 1);
-            nub = values.previousValue(oub + 1);
-            if (!hasChanged && (nlb > oub || nub < olb)) {
+            int nlb = getLB();
+            int nub = getUB();
+            vlb = values.nextValue(nlb - 1);
+            vub = values.previousValue(nub + 1);
+            if (!hasChanged && (vlb > nub || vub < nlb)) {
                 return false;
             }
             int i;
             // look for the new lb
-            while (nlb == olb && olb < Integer.MAX_VALUE) {
-                i = VALUES.nextSetBit(nlb + 1 - OFFSET);
-                olb = i > -1 ? i + OFFSET : Integer.MAX_VALUE;
-                nlb = values.nextValue(olb - 1);
+            while (vlb == nlb && nlb < Integer.MAX_VALUE) {
+                i = VALUES.nextSetBit(vlb + 1 - OFFSET);
+                nlb = i > -1 ? i + OFFSET : Integer.MAX_VALUE;
+                vlb = values.nextValue(nlb - 1);
             }
-            if (nlb <= nub) {
+            if (vlb <= vub) {
                 // look for the new ub
-                while (nub == oub && oub > Integer.MIN_VALUE) {
-                    i = VALUES.prevSetBit(nub - 1 - OFFSET);
-                    oub = i > -1 ? i + OFFSET : Integer.MIN_VALUE;
-                    nub = values.previousValue(oub + 1);
+                while (vub == nub && nub > Integer.MIN_VALUE) {
+                    i = VALUES.prevSetBit(vub - 1 - OFFSET);
+                    nub = i > -1 ? i + OFFSET : Integer.MIN_VALUE;
+                    vub = values.previousValue(nub + 1);
                 }
             }
             // the new bounds are now known, delegate to the right method
-            fixpoint = updateBounds(olb, oub, cause);
+            fixpoint = updateBounds(nlb, nub, cause);
             hasChanged |= fixpoint;
-        }while(fixpoint);
+        } while(fixpoint);
         // now deal with holes
-        int value = nlb;
-        int to = nub;
+        int value = vlb;
         boolean hasRemoved = false;
         int count = SIZE.get();
-        while (value <= to) {
+        while (value <= vub) {
             int aValue = value - OFFSET;
             if (aValue >= 0 && aValue <= LENGTH && VALUES.get(aValue)) {
                 model.getSolver().getEventObserver().removeValue(this, value, cause);
@@ -262,23 +261,23 @@ public final class BitsetIntVarImpl extends AbstractVariable implements IntVar {
         boolean hasChanged = false, fixpoint;
         int nlb, nub;
         do {
-            int olb = getLB();
-            int oub = getUB();
-            nlb = values.nextValue(olb - 1);
-            nub = values.previousValue(oub + 1);
+            int clb = getLB();
+            int cub = getUB();
+            nlb = values.nextValue(clb - 1);
+            nub = values.previousValue(cub + 1);
             int i;
             // look for the new lb
-            while (nlb != olb && olb < Integer.MAX_VALUE && nlb < Integer.MAX_VALUE) {
+            while (nlb != clb && clb < Integer.MAX_VALUE && nlb < Integer.MAX_VALUE) {
                 i = VALUES.nextSetBit(nlb - OFFSET);
-                olb = i > -1 ? i + OFFSET : Integer.MAX_VALUE;
-                nlb = values.nextValue(olb - 1);
+                clb = i > -1 ? i + OFFSET : Integer.MAX_VALUE;
+                nlb = values.nextValue(clb - 1);
             }
             // look for the new ub
             if (nlb <= nub) {
-                while (nub != oub && oub > Integer.MIN_VALUE && nub > Integer.MIN_VALUE) {
+                while (nub != cub && cub > Integer.MIN_VALUE && nub > Integer.MIN_VALUE) {
                     i = VALUES.prevSetBit(nub - OFFSET);
-                    oub = i > -1 ? i + OFFSET : Integer.MIN_VALUE;
-                    nub = values.previousValue(oub + 1);
+                    cub = i > -1 ? i + OFFSET : Integer.MIN_VALUE;
+                    nub = values.previousValue(cub + 1);
                 }
             }
             // the new bounds are now known, delegate to the right method

--- a/solver/src/main/java/org/chocosolver/solver/variables/view/IntView.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/view/IntView.java
@@ -32,7 +32,7 @@ import static org.chocosolver.util.objects.setDataStructures.iterable.IntIterabl
 
 /**
  * Abstract class for defining integer views on integer variables
- *
+ * <br/>
  * "A view implements the same operations as a variable. A view stores a reference to a variable.
  * Invoking an operation on the view executes the appropriate operation on the view's variable."
  * <p/>

--- a/solver/src/main/java/org/chocosolver/solver/variables/view/IntView.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/view/IntView.java
@@ -168,35 +168,35 @@ public abstract class IntView<I extends IntVar> extends AbstractView<I> implemen
     public boolean removeValues(IntIterableSet values, ICause cause) throws ContradictionException {
         assert cause != null;
         boolean hasChanged = false, fixpoint;
-        int nlb, nub;
+        int vlb, vub;
         do {
-            int olb = getLB();
-            int oub = getUB();
-            nlb = values.nextValue(olb - 1);
-            nub = values.previousValue(oub + 1);
-            if (!hasChanged && (nlb > oub || nub < olb)) {
+            int nlb = getLB();
+            int nub = getUB();
+            vlb = values.nextValue(nlb - 1);
+            vub = values.previousValue(nub + 1);
+            if (!hasChanged && (vlb > nub || vub < nlb)) {
                 return false;
             }
-            if (nlb == olb) {
+            if (vlb == nlb) {
                 // look for the new lb
                 do {
-                    olb = nextValue(olb);
-                    nlb = values.nextValue(olb - 1);
-                } while (olb < Integer.MAX_VALUE && oub < Integer.MAX_VALUE && nlb == olb);
+                    nlb = nextValue(nlb);
+                    vlb = values.nextValue(nlb - 1);
+                } while (nlb < Integer.MAX_VALUE && nub < Integer.MAX_VALUE && vlb == nlb);
             }
-            if (nub == oub) {
+            if (vub == nub) {
                 // look for the new ub
                 do {
-                    oub = previousValue(oub);
-                    nub = values.previousValue(oub + 1);
-                } while (olb > Integer.MIN_VALUE && oub > Integer.MIN_VALUE && nub == oub);
+                    nub = previousValue(nub);
+                    vub = values.previousValue(nub + 1);
+                } while (nlb > Integer.MIN_VALUE && nub > Integer.MIN_VALUE && vub == nub);
             }
             // the new bounds are now known, delegate to the right method
-            fixpoint = updateBounds(olb, oub, cause);
+            fixpoint = updateBounds(nlb, nub, cause);
             hasChanged |= fixpoint;
         } while (fixpoint);
         // now deal with holes
-        int value = nlb, to = nub;
+        int value = vlb, to = vub;
         boolean hasRemoved = false;
         while (value <= to) {
             model.getSolver().getEventObserver().removeValue(this, value, cause);
@@ -244,10 +244,10 @@ public abstract class IntView<I extends IntVar> extends AbstractView<I> implemen
         boolean hasChanged = false, fixpoint;
         int nlb, nub;
         do {
-            int olb = getLB();
-            int oub = getUB();
-            nlb = values.nextValue(olb - 1);
-            nub = values.previousValue(oub + 1);
+            int clb = getLB();
+            int cub = getUB();
+            nlb = values.nextValue(clb - 1);
+            nub = values.previousValue(cub + 1);
             // the new bounds are now known, delegate to the right method
             fixpoint = updateBounds(nlb, nub, cause);
             hasChanged |= fixpoint;

--- a/solver/src/test/java/org/chocosolver/solver/variables/TaskTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/variables/TaskTest.java
@@ -11,7 +11,12 @@ package org.chocosolver.solver.variables;
 
 import org.chocosolver.solver.Cause;
 import org.chocosolver.solver.Model;
+import org.chocosolver.solver.Solver;
+import org.chocosolver.solver.constraints.Constraint;
+import org.chocosolver.solver.constraints.ternary.PropXplusYeqZ;
 import org.chocosolver.solver.exception.ContradictionException;
+import org.chocosolver.solver.search.strategy.Search;
+import org.chocosolver.solver.variables.impl.BitsetArrayIntVarImpl;
 import org.chocosolver.solver.variables.view.integer.IntOffsetView;
 import org.chocosolver.util.ESat;
 import org.testng.Assert;
@@ -41,7 +46,7 @@ public class TaskTest {
         task = new Task(start, duration, end);
     }
 
-    @Test(groups = "1s", timeOut=60000)
+    @Test(groups = "1s", timeOut = 60000)
     public void testDecreaseDuration() throws ContradictionException {
         checkVariable(duration, 0, 10);
         start.removeValue(0, Cause.Null);
@@ -52,7 +57,7 @@ public class TaskTest {
     }
 
 
-    @Test(groups = "1s", timeOut=60000)
+    @Test(groups = "1s", timeOut = 60000)
     public void testIncreaseDuration() throws ContradictionException {
         start.removeInterval(4, 5, Cause.Null);
         checkVariable(duration, 2, 10);
@@ -63,7 +68,7 @@ public class TaskTest {
         checkVariable(duration, 5, 10);
     }
 
-    @Test(groups = "1s", timeOut=60000)
+    @Test(groups = "1s", timeOut = 60000)
     public void testBadDomainFilteringOK() throws ContradictionException {
         Task task = new Task(end, duration, start);
         System.out.println(task);
@@ -73,7 +78,7 @@ public class TaskTest {
         checkVariable(end, 5, 5);
     }
 
-    @Test(groups = "1s", timeOut=60000, expectedExceptions = ContradictionException.class)
+    @Test(groups = "1s", timeOut = 60000, expectedExceptions = ContradictionException.class)
     public void testBadDomainFilteringKO() throws ContradictionException {
         IntVar start = model.intVar(5, 6);
         IntVar end = model.intVar(1, 2);
@@ -82,7 +87,7 @@ public class TaskTest {
     }
 
 
-    @Test(groups = "1s", timeOut=60000)
+    @Test(groups = "1s", timeOut = 60000)
     public void testUpdateStart() throws ContradictionException {
         duration.removeValue(10, Cause.Null);
         // we don't know which bound is updated
@@ -90,7 +95,7 @@ public class TaskTest {
         checkVariable(end, 5, 10);
     }
 
-    @Test(groups = "1s", timeOut=60000, expectedExceptions = ContradictionException.class)
+    @Test(groups = "1s", timeOut = 60000, expectedExceptions = ContradictionException.class)
     public void testRemoveValueSameVariable() throws ContradictionException {
         IntVar start = model.intVar(-5, 0);
         IntVar durationAndEnd = model.intVar(10);
@@ -98,7 +103,7 @@ public class TaskTest {
         start.removeValue(0, Cause.Null);
     }
 
-    @Test(groups = "1s", timeOut=60000)
+    @Test(groups = "1s", timeOut = 60000)
     public void testNegativeDuration() throws ContradictionException {
         IntVar start = model.intVar(0);
         IntVar end = model.intVar(-5);
@@ -109,7 +114,7 @@ public class TaskTest {
         System.out.println("odd behaviour: " + task);
     }
 
-    @Test(groups = "1s", timeOut=60000)
+    @Test(groups = "1s", timeOut = 60000)
     public void testCumulativeConstraintKO() {
         Task[] tasks = new Task[2];
         IntVar[] heights = model.intVarArray(2, 50, 75);
@@ -120,7 +125,7 @@ public class TaskTest {
         assertFalse(model.getSolver().solve());
     }
 
-    @Test(groups = "1s", timeOut=60000)
+    @Test(groups = "1s", timeOut = 60000)
     public void testCumulativeConstraint() {
         Task[] tasks = new Task[3];
         IntVar[] heights = model.intVarArray(3, 73, 75);
@@ -144,6 +149,7 @@ public class TaskTest {
 
     /**
      * Detect tasks overlapping between two tasks
+     *
      * @param one first task
      * @param two second check
      * @return if an overlapping exists between the tasks
@@ -163,8 +169,8 @@ public class TaskTest {
 
     private static boolean sameTaskVars(Task t1, Task t2) {
         return t1.getStart().getLB() == t2.getStart().getLB() && t1.getStart().getUB() == t2.getStart().getUB()
-            && t1.getDuration().getLB() == t2.getDuration().getLB() && t1.getDuration().getUB() == t2.getDuration().getUB()
-            && t1.getEnd().getLB() == t2.getEnd().getLB() && t1.getEnd().getUB() == t2.getEnd().getUB();
+                && t1.getDuration().getLB() == t2.getDuration().getLB() && t1.getDuration().getUB() == t2.getDuration().getUB()
+                && t1.getEnd().getLB() == t2.getEnd().getLB() && t1.getEnd().getUB() == t2.getEnd().getUB();
     }
 
     private static boolean hasTaskMonitor(Task task) {
@@ -182,7 +188,7 @@ public class TaskTest {
     private void specificToIVariableFactory(Model m) {
         // taskVar(IntVar s, IntVar d)
         IntVar s = m.intVar(0, 10);
-        IntVar d = m.intVar(1,5);
+        IntVar d = m.intVar(1, 5);
         Task t1 = m.taskVar(s, d);
         Assert.assertTrue(hasTaskMonitor(t1));
 
@@ -247,7 +253,7 @@ public class TaskTest {
         Assert.assertFalse(hasTaskMonitor(t14));
     }
 
-    @Test(groups = "1s", timeOut=60000)
+    @Test(groups = "1s", timeOut = 60000)
     public void testingTaskConstructors() {
         Model m = new Model();
 
@@ -259,5 +265,47 @@ public class TaskTest {
         specificToIVariableFactory(m);
     }
 
+
+    @Test(groups = "1s")
+    public void testMonitor1() {
+        Model model = new Model();
+        IntVar first = model.intVar("first", new int[]{1, 2, 3, 4, 5});
+        IntVar dur = model.intVar("dur", new int[]{1, 2, 4, 5});
+        IntVar last = model.intVar("last", 5, 6);
+        IntVar IV390 = model.intVar("IV390", 6);
+        new Constraint("", new PropXplusYeqZ(first, dur, last)).post();
+        new Task(first, dur, IV390);
+        Solver s = model.getSolver();
+        s.setSearch(Search.inputOrderLBSearch(last));  // <- for the issue
+        Assert.assertTrue(s.solve());
+    }
+
+    @Test(groups = "1s")
+    public void testMonitor2() {
+        Model model = new Model();
+        IntVar first = new BitsetArrayIntVarImpl("first", new int[]{1, 2, 3, 4, 5}, model);
+        IntVar dur = new BitsetArrayIntVarImpl("dur", new int[]{1, 2, 4, 5}, model);
+        IntVar last = model.intVar("last", 5, 6);
+        IntVar IV390 = model.intVar("IV390", 6);
+        new Constraint("", new PropXplusYeqZ(first, dur, last)).post();
+        new Task(first, dur, IV390);
+        Solver s = model.getSolver();
+        s.setSearch(Search.inputOrderLBSearch(last));  // <- for the issue
+        Assert.assertTrue(s.solve());
+    }
+
+    @Test(groups = "1s")
+    public void testMonitorAndView() {
+        Model model = new Model();
+        IntVar first = model.intOffsetView(model.intVar("first", new int[]{1, 2, 3, 4, 5}), 2);
+        IntVar dur = model.intOffsetView(model.intVar("dur", new int[]{1, 2, 4, 5}), 2);
+        IntVar last = model.intOffsetView(model.intVar("last", 5, 6), 2);
+        IntVar IV390 = model.intOffsetView(model.intVar("IV390", 6), 2);
+        new Constraint("", new PropXplusYeqZ(first, dur, last)).post();
+        new Task(first, dur, IV390);
+        Solver s = model.getSolver();
+        s.setSearch(Search.inputOrderLBSearch(last));  // <- for the issue
+        Assert.assertTrue(s.solve());
+    }
 }
 


### PR DESCRIPTION
I had this pernicious bug that occurs when the `removeAllValuesBut` method is called from  for enumerated domain variables. This occurs when the variable is also monitored (here, a task) : the bounds was not up to date. Which led to inconcistency.
To fix the bug, I encapsulate the internal `updateBounds` call in a loop to make sure that side effects (monitors or views) are capture at the right time.
I also fix a bug in removeValues.