### PR TITLE
Stop maintaining the domain size for IntervalIntVarImpl.

### DIFF
--- a/solver/src/main/java/org/chocosolver/solver/variables/impl/IntervalIntVarImpl.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/impl/IntervalIntVarImpl.java
@@ -51,10 +51,6 @@ public final class IntervalIntVarImpl extends AbstractVariable implements IntVar
      */
     private final IStateInt UB;
     /**
-     * Current size of domain
-     */
-    private final IStateInt SIZE;
-    /**
      * To iterate over removed values
      */
     private IIntervalDelta delta = NoDelta.singleton;
@@ -92,7 +88,6 @@ public final class IntervalIntVarImpl extends AbstractVariable implements IntVar
         IEnvironment env = model.getEnvironment();
         this.LB = env.makeInt(min);
         this.UB = env.makeInt(max);
-        this.SIZE = env.makeInt(max - min + 1);
     }
 
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -220,7 +215,6 @@ public final class IntervalIntVarImpl extends AbstractVariable implements IntVar
             }
             this.LB.set(value);
             this.UB.set(value);
-            this.SIZE.set(1);
             this.notifyPropagators(e, cause);
             return true;
         }
@@ -258,7 +252,6 @@ public final class IntervalIntVarImpl extends AbstractVariable implements IntVar
                 if (reactOnRemoval) {
                     delta.add(old, value - 1, cause);
                 }
-                SIZE.add(old - value);
                 LB.set(value);
                 if (isInstantiated()) {
                     e = IntEventType.INSTANTIATE;
@@ -301,7 +294,6 @@ public final class IntervalIntVarImpl extends AbstractVariable implements IntVar
                 if (reactOnRemoval) {
                     delta.add(value + 1, old, cause);
                 }
-                SIZE.add(value - old);
                 UB.set(value);
 
                 if (isInstantiated()) {
@@ -348,7 +340,6 @@ public final class IntervalIntVarImpl extends AbstractVariable implements IntVar
                 d += ub - oub;
                 UB.set(ub);
             }
-            SIZE.add(d);
             if (isInstantiated()) {
                 e = IntEventType.INSTANTIATE;
             }
@@ -360,7 +351,7 @@ public final class IntervalIntVarImpl extends AbstractVariable implements IntVar
 
     @Override
     public boolean isInstantiated() {
-        return SIZE.get() == 1;
+        return LB.get() == UB.get();
     }
 
     @Override
@@ -404,7 +395,7 @@ public final class IntervalIntVarImpl extends AbstractVariable implements IntVar
 
     @Override
     public int getDomainSize() {
-        return SIZE.get();
+        return UB.get() - LB.get() + 1;
     }
 
     @Override
@@ -468,7 +459,7 @@ public final class IntervalIntVarImpl extends AbstractVariable implements IntVar
 
     @Override
     public String toString() {
-        if (SIZE.get() == 1) {
+        if (LB.get() == UB.get()) {
             return String.format("%s = %d", name, getLB());
         }
         return String.format("%s = [%d,%d]", name, getLB(), getUB());


### PR DESCRIPTION
For such variables, the solver used to track the lower-bound, the upper-bound and the domain size to provide quick access to the domain size. This decision had however a significant impact in terms of memory usage. It requires to have an additional StoredInt per variable and for every bound change, 2 values where saved into the stack.

In this patch, the domain size is no longer stored but computed on demand. In terms of performance, getDomainSize() performs now 2 get() and one subtraction while it used to perform one get(). On the other side it saves one StoredInt, and only one value is saved into the stack when a bound is updated.

After some internal experiments on (packing and scheduling) problems having around 100,000 bounded variables and 50,000 enum variables, this reduces the memory consumption of my JVM by about 30% with no performance degradation.