### PR TITLE
Improve PropNValue.contains().

### DIFF
--- a/solver/src/main/java/org/chocosolver/solver/constraints/nary/nvalue/PropNValue.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/nary/nvalue/PropNValue.java
@@ -24,6 +24,7 @@ import org.chocosolver.util.objects.setDataStructures.SetFactory;
 import org.chocosolver.util.objects.setDataStructures.SetType;
 import org.chocosolver.util.tools.ArrayUtils;
 
+import java.util.Arrays;
 import java.util.Random;
 
 /**
@@ -55,6 +56,7 @@ public class PropNValue extends Propagator<IntVar> {
             }
         }
         concernedValues = set.toArray();
+        Arrays.sort(concernedValues);
         possibleValues = SetFactory.makeStoredSet(SetType.BITSET, min, model);
         mandatoryValues = SetFactory.makeStoredSet(SetType.BITSET, min, model);
         listForRandomPick = new TIntArrayList();
@@ -75,17 +77,8 @@ public class PropNValue extends Propagator<IntVar> {
         }
     }
 
-    private int contains(int v) {
-        for(int i = 0; i < concernedValues.length; i++) {
-            if(concernedValues[i] == v) {
-                return i;
-            }
-        }
-        return -1;
-    }
-
     private void instantiateTo(int idxVar, int value) {
-        int idxConcernedValue = contains(value);
+        int idxConcernedValue = Arrays.binarySearch(concernedValues, value);
         mandatoryValues.add(vars[idxVar].getValue());
         witness[idxConcernedValue] = idxVar;
         for(int i = 0; i < concernedValues.length; i++) {
@@ -141,7 +134,7 @@ public class PropNValue extends Propagator<IntVar> {
             ISetIterator iterator = possibleValues.iterator();
             while(iterator.hasNext()) {
                 int value = iterator.nextInt();
-                int idxConcernedValue = contains(value);
+                int idxConcernedValue = Arrays.binarySearch(concernedValues, value);
                 if(
                     witness[idxConcernedValue] == NO_WITNESS
                         || !vars[witness[idxConcernedValue]].contains(concernedValues[idxConcernedValue])


### PR DESCRIPTION
This used to run in O(n). Given the array is read-only, it is ok to sort it and use Arrays.binarySearch() to perform in O(log(n)).

For an internal benchmark with 128 values to watch, contains() was the bottleneck (5% of the service latency), now it is < 1%.