### PR TITLE
Remove randomness by default of BBox strategies

### DIFF
--- a/parsers/src/main/java/org/chocosolver/parser/RegParser.java
+++ b/parsers/src/main/java/org/chocosolver/parser/RegParser.java
@@ -92,6 +92,12 @@ public abstract class RegParser implements IParser {
             usage = "Define the variable heuristic to use.")
     public SearchParams.VariableSelection varH = SearchParams.VariableSelection.DOMWDEG_CACD;
 
+    @SuppressWarnings("FieldMayBeFinal")
+    @Option(name = "-tie",
+            forbids = {"-varsel"},
+            usage = "Define the variable tie breaker to use with black-box strategies.")
+    private SearchParams.VariableTieBreaker tie = SearchParams.VariableTieBreaker.SMALLEST_DOMAIN;
+
     @Option(name = "-flush",
             forbids = {"-varsel"},
             usage = "Autoflush weights on black-box strategies (default: 32).")
@@ -172,6 +178,9 @@ public abstract class RegParser implements IParser {
 
     @Option(name = "-dfx", usage = "Force default explanation algorithm.")
     public boolean dftexp = false;
+
+    @Option(name = "-gpa", usage = "Use the Generating Partial Assignment procedure (default: false).")
+    public boolean gpa = false;
 
     /**
      * Default settings to apply
@@ -254,7 +263,7 @@ public abstract class RegParser implements IParser {
             System.out.printf("%s\n", Arrays.toString(args));
         }
         if(varsel == null){
-            varsel = new SearchParams.VarSelConf(varH, flushRate);
+            varsel = new SearchParams.VarSelConf(varH, tie, flushRate);
         }
         if(valsel == null){
             valsel = new SearchParams.ValSelConf(valH, best, bestRate, last);

--- a/parsers/src/main/java/org/chocosolver/parser/flatzinc/Flatzinc.java
+++ b/parsers/src/main/java/org/chocosolver/parser/flatzinc/Flatzinc.java
@@ -209,25 +209,40 @@ public class Flatzinc extends RegParser {
     @Override
     public void freesearch(Solver solver) {
         BlackBoxConfigurator bb = BlackBoxConfigurator.init();
-        boolean opt = solver.getObjectiveManager().isOptimization();
-        // variable selection
-        SearchParams.ValSelConf defaultValSel = new SearchParams.ValSelConf(
-                SearchParams.ValueSelection.MIN, opt, 1, opt);
-        SearchParams.VarSelConf defaultVarSel = new SearchParams.VarSelConf(
-                SearchParams.VariableSelection.DOMWDEG, Integer.MAX_VALUE);
-        bb.setIntVarStrategy((vars) -> defaultVarSel.make().apply(vars, defaultValSel.make().apply(vars[0].getModel())));
-        // restart policy
-        SearchParams.ResConf defaultResConf = new SearchParams.ResConf(
-                SearchParams.Restart.LUBY, 500, 50_000, true);
-        bb.setRestartPolicy(defaultResConf.make());
-        // other parameters
-        bb.setNogoodOnRestart(true)
-                .setRestartOnSolution(true)
-                .setExcludeObjective(true)
-                .setExcludeViews(false)
-                .setMetaStrategy(m -> Search.lastConflict(m, 1));
-        if (level.isLoggable(Level.INFO)) {
-            solver.log().println(bb.toString());
+        if (solver.getObjectiveManager().isOptimization()) {
+            // For COP
+            SearchParams.ValSelConf defaultValSel = new SearchParams.ValSelConf(
+                    SearchParams.ValueSelection.MIN, true, 16, true);
+            SearchParams.VarSelConf defaultVarSel = new SearchParams.VarSelConf(
+                    SearchParams.VariableSelection.DOMWDEG_CACD, SearchParams.VariableTieBreaker.SMALLEST_DOMAIN, 32);
+            bb.setIntVarStrategy((vars) -> defaultVarSel.make().apply(vars, defaultValSel.make().apply(vars[0].getModel())));
+            // restart policy
+            SearchParams.ResConf defaultResConf = new SearchParams.ResConf(
+                    SearchParams.Restart.GEOMETRIC, 5, 1.05, 50_000, true);
+            bb.setRestartPolicy(defaultResConf.make());
+            // complementary settings
+            bb.setNogoodOnRestart(true)
+                    .setRestartOnSolution(true)
+                    .setExcludeObjective(true)
+                    .setExcludeViews(false)
+                    .setMetaStrategy(m -> Search.lastConflict(m, 4));
+        }else{
+            // For CSP
+            SearchParams.ValSelConf defaultValSel = new SearchParams.ValSelConf(
+                    SearchParams.ValueSelection.MIN, false, 16, false);
+            SearchParams.VarSelConf defaultVarSel = new SearchParams.VarSelConf(
+                    SearchParams.VariableSelection.DOMWDEG, SearchParams.VariableTieBreaker.SMALLEST_DOMAIN, 32);
+            bb.setIntVarStrategy((vars) -> defaultVarSel.make().apply(vars, defaultValSel.make().apply(vars[0].getModel())));
+            // restart policy
+            SearchParams.ResConf defaultResConf = new SearchParams.ResConf(
+                    SearchParams.Restart.GEOMETRIC, 5, 1.05, 50_000, true);
+            bb.setRestartPolicy(defaultResConf.make());
+            // complementary settings
+            bb.setNogoodOnRestart(false)
+                    .setRestartOnSolution(false)
+                    .setExcludeObjective(true)
+                    .setExcludeViews(false)
+                    .setMetaStrategy(m -> Search.lastConflict(m, 1));
         }
         bb.make(solver.getModel());
     }

--- a/parsers/src/main/java/org/chocosolver/parser/flatzinc/ast/searches/IntSearch.java
+++ b/parsers/src/main/java/org/chocosolver/parser/flatzinc/ast/searches/IntSearch.java
@@ -61,7 +61,7 @@ public class IntSearch {
             case max_regret:
                 return new MaxRegret();
             case dom_w_deg:
-                return new DomOverWDeg<>(variables, variables[0].getModel().getSeed());
+                return new DomOverWDeg<>(variables);
             default:
                 System.err.println("% No implementation for " + varChoice.name() + ". Set default.");
                 return null;

--- a/parsers/src/main/java/org/chocosolver/parser/handlers/VarSelHandler.java
+++ b/parsers/src/main/java/org/chocosolver/parser/handlers/VarSelHandler.java
@@ -48,6 +48,7 @@ public class VarSelHandler extends OneArgumentOptionHandler<SearchParams.VarSelC
         if (pars.length == 3) {
             return new SearchParams.VarSelConf(
                     SearchParams.VariableSelection.valueOf(pars[0].toUpperCase()),
+                    SearchParams.VariableTieBreaker.valueOf(pars[1].toUpperCase()),
                     Integer.parseInt(pars[2])
             );
         }

--- a/parsers/src/test/java/org/chocosolver/parser/RegParserTest.java
+++ b/parsers/src/test/java/org/chocosolver/parser/RegParserTest.java
@@ -156,7 +156,7 @@ public class RegParserTest {
         Assert.assertNull(parser.varsel);
         p.parseArgument("-f", "-varsel", "[CHS,LARGEST_DOMAIN,64]", "/file");
         Assert.assertEquals(parser.varsel, new SearchParams.VarSelConf(
-                SearchParams.VariableSelection.CHS, 64));
+                SearchParams.VariableSelection.CHS, SearchParams.VariableTieBreaker.LARGEST_DOMAIN, 64));
     }
 
     @Test(groups = "1s")

--- a/solver/src/main/java/org/chocosolver/solver/ParallelPortfolio.java
+++ b/solver/src/main/java/org/chocosolver/solver/ParallelPortfolio.java
@@ -437,7 +437,7 @@ public class ParallelPortfolio {
                         SearchParams.ValueSelection.MIN, opt, 16, true);
                 intValSel = intValConf.make();
                 intVarConf = new SearchParams.VarSelConf(
-                        SearchParams.VariableSelection.DOMWDEG, 32);
+                        SearchParams.VariableSelection.DOMWDEG, SearchParams.VariableTieBreaker.SMALLEST_DOMAIN, 32);
                 intVarSel = intVarConf.make();
                 bb.setIntVarStrategy((vars) -> intVarSel.apply(vars, intValSel.apply(worker)));
                 bb.setMetaStrategy(m -> Search.lastConflict(m, 2));
@@ -451,7 +451,7 @@ public class ParallelPortfolio {
                         SearchParams.ValueSelection.MIN, opt, 16, true);
                 intValSel = intValConf.make();
                 intVarConf = new SearchParams.VarSelConf(
-                        SearchParams.VariableSelection.CHS, 32);
+                        SearchParams.VariableSelection.CHS, SearchParams.VariableTieBreaker.SMALLEST_DOMAIN, 32);
                 intVarSel = intVarConf.make();
                 bb.setIntVarStrategy((vars) -> intVarSel.apply(vars, intValSel.apply(worker)));
                 bb.setMetaStrategy(m -> Search.lastConflict(m, 2));
@@ -465,7 +465,7 @@ public class ParallelPortfolio {
                         SearchParams.ValueSelection.MIN, opt, 16, true);
                 intValSel = intValConf.make();
                 intVarConf = new SearchParams.VarSelConf(
-                        SearchParams.VariableSelection.DOMWDEG_CACD, 32);
+                        SearchParams.VariableSelection.DOMWDEG_CACD, SearchParams.VariableTieBreaker.SMALLEST_DOMAIN, 32);
                 intVarSel = intVarConf.make();
                 bb.setIntVarStrategy((vars) -> intVarSel.apply(vars, intValSel.apply(worker)));
                 bb.setMetaStrategy(m -> Search.lastConflict(m, 2));
@@ -479,7 +479,7 @@ public class ParallelPortfolio {
                         SearchParams.ValueSelection.MIN, opt, 16, true);
                 intValSel = intValConf.make();
                 intVarConf = new SearchParams.VarSelConf(
-                        SearchParams.VariableSelection.FRBA, 32);
+                        SearchParams.VariableSelection.FRBA, SearchParams.VariableTieBreaker.SMALLEST_DOMAIN, 32);
                 intVarSel = intVarConf.make();
                 bb.setIntVarStrategy((vars) -> intVarSel.apply(vars, intValSel.apply(worker)));
                 bb.setMetaStrategy(m -> Search.lastConflict(m, 2));
@@ -493,7 +493,7 @@ public class ParallelPortfolio {
                         SearchParams.ValueSelection.MIN, opt, 16, true);
                 intValSel = intValConf.make();
                 intVarConf = new SearchParams.VarSelConf(
-                        SearchParams.VariableSelection.ACTIVITY, 32);
+                        SearchParams.VariableSelection.ACTIVITY, SearchParams.VariableTieBreaker.LARGEST_DOMAIN, 32);
                 intVarSel = intVarConf.make();
                 bb.setIntVarStrategy((vars) -> intVarSel.apply(vars, intValSel.apply(worker)));
                 bb.setMetaStrategy(m -> Search.lastConflict(m, 2));
@@ -504,7 +504,7 @@ public class ParallelPortfolio {
                         SearchParams.ValueSelection.MIN, opt, 16, true);
                 intValSel = intValConf.make();
                 intVarConf = new SearchParams.VarSelConf(
-                        SearchParams.VariableSelection.DOMWDEG_CACD, 32);
+                        SearchParams.VariableSelection.DOMWDEG_CACD, SearchParams.VariableTieBreaker.LARGEST_DOMAIN, 32);
                 intVarSel = intVarConf.make();
                 bb.setIntVarStrategy((vars) -> intVarSel.apply(vars, intValSel.apply(worker)));
                 bb.setMetaStrategy(m -> Search.lastConflict(m, 2));
@@ -515,7 +515,7 @@ public class ParallelPortfolio {
                         SearchParams.ValueSelection.MIN, opt, 16, true);
                 intValSel = intValConf.make();
                 intVarConf = new SearchParams.VarSelConf(
-                        SearchParams.VariableSelection.DOMWDEG, 32);
+                        SearchParams.VariableSelection.DOMWDEG, SearchParams.VariableTieBreaker.LARGEST_DOMAIN, 32);
                 intVarSel = intVarConf.make();
                 bb.setIntVarStrategy((vars) -> intVarSel.apply(vars, intValSel.apply(worker)));
                 bb.setMetaStrategy(m -> Search.lastConflict(m, 2));
@@ -529,7 +529,7 @@ public class ParallelPortfolio {
                         SearchParams.ValueSelection.MIN, opt, 16, true);
                 intValSel = intValConf.make();
                 intVarConf = new SearchParams.VarSelConf(
-                        SearchParams.VariableSelection.FRBA, 32);
+                        SearchParams.VariableSelection.FRBA, SearchParams.VariableTieBreaker.LARGEST_DOMAIN, 32);
                 intVarSel = intVarConf.make();
                 bb.setIntVarStrategy((vars) -> intVarSel.apply(vars, intValSel.apply(worker)));
                 bb.setMetaStrategy(m -> Search.lastConflict(m, 2));
@@ -540,7 +540,7 @@ public class ParallelPortfolio {
                         SearchParams.ValueSelection.MIN, opt, 16, true);
                 intValSel = intValConf.make();
                 intVarConf = new SearchParams.VarSelConf(
-                        SearchParams.VariableSelection.CHS, 32);
+                        SearchParams.VariableSelection.CHS, SearchParams.VariableTieBreaker.SMALLEST_DOMAIN, 32);
                 intVarSel = intVarConf.make();
                 bb.setIntVarStrategy((vars) -> intVarSel.apply(vars, intValSel.apply(worker)));
                 bb.setMetaStrategy(m -> Search.lastConflict(m, 1));

--- a/solver/src/main/java/org/chocosolver/solver/search/strategy/BlackBoxConfigurator.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/strategy/BlackBoxConfigurator.java
@@ -13,8 +13,6 @@ import org.chocosolver.solver.Model;
 import org.chocosolver.solver.ResolutionPolicy;
 import org.chocosolver.solver.Solver;
 import org.chocosolver.solver.search.restart.AbstractRestart;
-import org.chocosolver.solver.search.restart.GeometricalCutoff;
-import org.chocosolver.solver.search.restart.Restarter;
 import org.chocosolver.solver.search.strategy.selectors.values.RealDomainMax;
 import org.chocosolver.solver.search.strategy.selectors.values.RealDomainMin;
 import org.chocosolver.solver.search.strategy.selectors.variables.Cyclic;
@@ -161,11 +159,12 @@ public class BlackBoxConfigurator {
         SearchParams.ValSelConf defaultValSel = new SearchParams.ValSelConf(
                 SearchParams.ValueSelection.MIN, false, 16, true);
         SearchParams.VarSelConf defaultVarSel = new SearchParams.VarSelConf(
-                SearchParams.VariableSelection.DOMWDEG_CACD, 32);
+                SearchParams.VariableSelection.DOMWDEG_CACD, SearchParams.VariableTieBreaker.LARGEST_DOMAIN, 32);
         bb.setIntVarStrategy((vars) -> defaultVarSel.make().apply(vars, defaultValSel.make().apply(vars[0].getModel())));
         // restart policy
-        bb.setRestartPolicy(s -> new Restarter(new GeometricalCutoff(5, 1.05),
-                                    c -> s.getFailCount() >= c, 50_000, true));
+        SearchParams.ResConf defaultResConf = new SearchParams.ResConf(
+                SearchParams.Restart.GEOMETRIC, 5, 1.05, 50_000, true);
+        bb.setRestartPolicy(defaultResConf.make());
         // complementary settings
         bb.setNogoodOnRestart(true)
                 .setRestartOnSolution(false)
@@ -186,7 +185,7 @@ public class BlackBoxConfigurator {
         SearchParams.ValSelConf defaultValSel = new SearchParams.ValSelConf(
                 SearchParams.ValueSelection.MIN, true, 16, true);
         SearchParams.VarSelConf defaultVarSel = new SearchParams.VarSelConf(
-                SearchParams.VariableSelection.DOMWDEG, 32);
+                SearchParams.VariableSelection.DOMWDEG, SearchParams.VariableTieBreaker.SMALLEST_DOMAIN, 32);
         bb.setIntVarStrategy((vars) -> defaultVarSel.make().apply(vars, defaultValSel.make().apply(vars[0].getModel())));
         // restart policy
         SearchParams.ResConf defaultResConf = new SearchParams.ResConf(

--- a/solver/src/main/java/org/chocosolver/solver/search/strategy/Search.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/strategy/Search.java
@@ -187,7 +187,7 @@ public class Search {
      * <a href="https://dblp.org/rec/conf/ecai/BoussemartHLS04">https://dblp.org/rec/conf/ecai/BoussemartHLS04</a>
      */
     public static AbstractStrategy<SetVar> domOverWDegSearch(SetVar... vars) {
-        return setVarSearch(new DomOverWDeg<>(vars, 0), new SetDomainMin(), true, vars);
+        return setVarSearch(new DomOverWDeg<>(vars), new SetDomainMin(), true, vars);
     }
 
     /**
@@ -200,7 +200,7 @@ public class Search {
      * <a href="https://dblp.org/rec/conf/ictai/WattezLPT19">https://dblp.org/rec/conf/ictai/WattezLPT19</a>
      */
     public static AbstractStrategy<SetVar> domOverWDegRefSearch(SetVar... vars) {
-        return setVarSearch(new DomOverWDegRef<>(vars, 0), new SetDomainMin(), true, vars);
+        return setVarSearch(new DomOverWDegRef<>(vars), new SetDomainMin(), true, vars);
     }
 
     /**
@@ -214,7 +214,7 @@ public class Search {
      * <a href="https://dblp.org/rec/conf/sac/HabetT19">https://dblp.org/rec/conf/sac/HabetT19</a>
      */
     public static AbstractStrategy<SetVar> conflictHistorySearch(SetVar... vars) {
-        return setVarSearch(new ConflictHistorySearch<>(vars, 0), new SetDomainMin(), true, vars);
+        return setVarSearch(new ConflictHistorySearch<>(vars), new SetDomainMin(), true, vars);
     }
 
     /**
@@ -482,7 +482,9 @@ public class Search {
             }
             valueSelector = new IntDomainLast(solution, valueSelector, null);
         }
-        return intVarSearch(new DomOverWDeg<>(vars, 0), valueSelector, vars);
+        return intVarSearch(
+                new DomOverWDegRef<>(vars),
+                valueSelector, vars);
     }
 
     /**
@@ -496,7 +498,7 @@ public class Search {
      * <a href="https://dblp.org/rec/conf/ecai/BoussemartHLS04">https://dblp.org/rec/conf/ecai/BoussemartHLS04</a>
      */
     public static AbstractStrategy<IntVar> domOverWDegSearch(IntVar... vars) {
-        return intVarSearch(new DomOverWDeg<>(vars, 0), new IntDomainMin(), vars);
+        return intVarSearch(new DomOverWDeg<>(vars), new IntDomainMin(), vars);
     }
 
     /**
@@ -509,7 +511,7 @@ public class Search {
      * <a href="https://dblp.org/rec/conf/ictai/WattezLPT19">https://dblp.org/rec/conf/ictai/WattezLPT19</a>
      */
     public static AbstractStrategy<IntVar> domOverWDegRefSearch(IntVar... vars) {
-        return intVarSearch(new DomOverWDegRef<>(vars, 0), new IntDomainMin(), vars);
+        return intVarSearch(new DomOverWDegRef<>(vars), new IntDomainMin(), vars);
     }
 
     /**
@@ -543,7 +545,7 @@ public class Search {
      * <a href="https://dblp.org/rec/conf/sac/HabetT19">https://dblp.org/rec/conf/sac/HabetT19</a>
      */
     public static AbstractStrategy<IntVar> conflictHistorySearch(IntVar... vars) {
-        return intVarSearch(new ConflictHistorySearch<>(vars, 0), new IntDomainMin(), vars);
+        return intVarSearch(new ConflictHistorySearch<>(vars), new IntDomainMin(), vars);
     }
 
     /**

--- a/solver/src/main/java/org/chocosolver/solver/search/strategy/selectors/variables/AbstractFailureBasedVariableSelector.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/strategy/selectors/variables/AbstractFailureBasedVariableSelector.java
@@ -9,24 +9,20 @@
  */
 package org.chocosolver.solver.search.strategy.selectors.variables;
 
-import gnu.trove.list.array.TIntArrayList;
 import gnu.trove.map.TObjectDoubleMap;
 import gnu.trove.map.hash.TObjectDoubleHashMap;
-import org.chocosolver.memory.IEnvironment;
-import org.chocosolver.memory.IStateInt;
-import org.chocosolver.solver.Solver;
 import org.chocosolver.solver.constraints.Propagator;
 import org.chocosolver.solver.exception.ContradictionException;
 import org.chocosolver.solver.search.loop.monitors.IMonitorContradiction;
-import org.chocosolver.solver.search.loop.monitors.IMonitorRestart;
 import org.chocosolver.solver.variables.IVariableMonitor;
 import org.chocosolver.solver.variables.Variable;
 import org.chocosolver.solver.variables.events.IEventType;
 
-import java.util.*;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.HashMap;
 import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
-import java.util.stream.Collectors;
 
 /**
  * <p>
@@ -35,8 +31,9 @@ import java.util.stream.Collectors;
  * @author Charles Prud'homme
  * @since 26/02/2020.
  */
-public abstract class AbstractCriterionBasedVariableSelector<V extends Variable> implements VariableSelector<V>,
-        IVariableMonitor<V>, IMonitorContradiction, IMonitorRestart {
+public abstract class AbstractFailureBasedVariableSelector<V extends Variable>
+        extends AbstractScoreBasedValueSelector<V>
+        implements IVariableMonitor<V>, IMonitorContradiction {
 
     /**
      * An element helps to keep 2 things up to date:
@@ -63,33 +60,6 @@ public abstract class AbstractCriterionBasedVariableSelector<V extends Variable>
                 return w;
             };
 
-    protected static final int FLUSH_TOPS = 20;
-    protected static final double FLUSH_RATIO = .9 * FLUSH_TOPS;
-    protected int flushThs;
-
-    protected final HashSet<Object> tops = new HashSet<>();
-    protected int loop = 0;
-
-    /**
-     * Randomness to break ties
-     */
-    private final java.util.Random random;
-    /***
-     * Pointer to the last free variable
-     */
-    private final IStateInt last;
-    /**
-     * Temporary. Stores index of variables with the same (best) score
-     */
-    private final TIntArrayList bests = new TIntArrayList();
-    /**
-     * A reference to the Solver
-     */
-    protected final Solver solver;
-    /**
-     * Needed to save operations
-     */
-    final IEnvironment environment;
     /**
      * The number of conflicts which have occurred since the beginning of the search.
      */
@@ -103,7 +73,7 @@ public abstract class AbstractCriterionBasedVariableSelector<V extends Variable>
      */
     private final HashMap<Variable, Integer> observed = new HashMap<>();
     /**
-     * Scoring for each variables, is updated dynamically.
+     * Scoring for each variable, is updated dynamically.
      */
     final TObjectDoubleMap<Variable> weights = new TObjectDoubleHashMap<>(15, 1.5f, 0.);
     /**
@@ -124,51 +94,16 @@ public abstract class AbstractCriterionBasedVariableSelector<V extends Variable>
         }
     };
 
-    public AbstractCriterionBasedVariableSelector(V[] vars, long seed, int flush) {
-        this.random = new java.util.Random(seed);
-        this.solver = vars[0].getModel().getSolver();
-        this.environment = vars[0].getModel().getEnvironment();
-        this.last = environment.makeInt(vars.length - 1);
-        this.flushThs = flush;
-    }
 
-    @Override
-    public final V getVariable(V[] vars) {
-        V best = null;
-        bests.resetQuick();
-        double w = Double.NEGATIVE_INFINITY;
-        int to = last.get();
-        for (int idx = 0; idx <= to; idx++) {
-            int domSize = vars[idx].getDomainSize();
-            if (domSize > 1) {
-                double weight = weight(vars[idx]) / domSize;
-                //System.out.printf("%3f%n", weight);
-                if (w < weight) {
-                    bests.resetQuick();
-                    bests.add(idx);
-                    w = weight;
-                } else if (w == weight) {
-                    bests.add(idx);
-                }
-            } else {
-                // swap
-                V tmp = vars[to];
-                vars[to] = vars[idx];
-                vars[idx] = tmp;
-                idx--;
-                to--;
-            }
-        }
-        last.set(to);
-        if (bests.size() > 0) {
-            //System.out.printf("%s%n", bests);
-            int currentVar = bests.get(random.nextInt(bests.size()));
-            best = vars[currentVar];
-        }
-        return best;
+    /**
+     * Create a failure based variable selector
+     * @param vars scope variables
+     * @param tieBreaker a tiebreaker when scores are equal
+     * @param flushRate the number of restarts before cleaning the scores
+     */
+    public AbstractFailureBasedVariableSelector(V[] vars, Comparator<V> tieBreaker, int flushRate) {
+        super(vars, tieBreaker, flushRate);
     }
-
-    protected abstract double weight(V v);
 
     @Override
     public final void onContradiction(ContradictionException cex) {
@@ -231,35 +166,6 @@ public abstract class AbstractCriterionBasedVariableSelector<V extends Variable>
     int remapInc() {
         return 0;
     }
-
-    /**
-     * This method sorts elements wrt to their weight.
-     * If 90% of the top 20 elements remain unchanged, then weights are flushed
-     *
-     * @return <i>true</i> if the weights should be flushed
-     */
-    protected boolean flushWeights(TObjectDoubleMap<?> q) {
-        //if(true)return false;
-        List<Variable> temp = weights.keySet().stream()
-                .sorted(Comparator.comparingDouble(q::get))
-                .limit(FLUSH_TOPS)
-                .collect(Collectors.toList());
-        long cnt = temp.stream().filter(tops::contains).count();
-        if (cnt >= FLUSH_RATIO) {
-            loop++;
-        } else {
-            loop = 0;
-        }
-        tops.clear();
-        if (loop == flushThs) {
-            loop = 0;
-            return true;
-        } else {
-            tops.addAll(temp);
-            return false;
-        }
-    }
-
     //////////////////////////////////////////////////////////////////////
     ////////////////// THIS IS RELATED TO INCREMENTAL FUTVARS ////////////
     //////////////////////////////////////////////////////////////////////

--- a/solver/src/main/java/org/chocosolver/solver/search/strategy/selectors/variables/AbstractScoreBasedValueSelector.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/strategy/selectors/variables/AbstractScoreBasedValueSelector.java
@@ -1,0 +1,110 @@
+/*
+ * This file is part of choco-solver, http://choco-solver.org/
+ *
+ * Copyright (c) 2023, IMT Atlantique. All rights reserved.
+ *
+ * Licensed under the BSD 4-clause license.
+ *
+ * See LICENSE file in the project root for full license information.
+ */
+package org.chocosolver.solver.search.strategy.selectors.variables;
+
+import org.chocosolver.memory.IEnvironment;
+import org.chocosolver.memory.IStateInt;
+import org.chocosolver.solver.Solver;
+import org.chocosolver.solver.search.loop.monitors.IMonitorRestart;
+import org.chocosolver.solver.variables.Variable;
+
+import java.util.Comparator;
+
+/**
+ * Score-based variable selector.
+ * <br/>
+ *
+ * @author Charles Prud'homme
+ * @since 26/05/2023
+ */
+public abstract class AbstractScoreBasedValueSelector<V extends Variable> implements VariableSelector<V>, IMonitorRestart {
+    /**
+     * A reference to the Solver
+     */
+    protected final Solver solver;
+    /**
+     * Needed to save operations
+     */
+    final IEnvironment environment;
+    /***
+     * Pointer to the last free variable
+     */
+    private final IStateInt last;
+
+    /**
+     * Default tie breaker: lexical ordering
+     */
+    private final Comparator<V> tieBreaker;
+
+    private final int flushRate;
+
+    /**
+     * Create a value selector based on the score of each variable
+     *
+     * @param vars       variables to branch on
+     * @param tieBreaker a tiebreaker when scores are equal
+     * @param flushRate  the rate at which scores are flushed, based on restart number
+     */
+    public AbstractScoreBasedValueSelector(V[] vars, Comparator<V> tieBreaker, int flushRate) {
+        this.solver = vars[0].getModel().getSolver();
+        this.environment = vars[0].getModel().getEnvironment();
+        this.last = environment.makeInt(vars.length - 1);
+        this.tieBreaker = tieBreaker;
+        this.flushRate = flushRate;
+    }
+
+    @Override
+    public final V getVariable(V[] vars) {
+        V best = null;
+        double w = Double.NEGATIVE_INFINITY;
+        int to = last.get();
+        for (int idx = 0; idx <= to; idx++) {
+            int domSize = vars[idx].getDomainSize();
+            if (domSize > 1) {
+                double weight = score(vars[idx]) / domSize;
+                if (w < weight || (w == weight && tieBreaker.compare(vars[idx], best) < 0)) {
+                    best = vars[idx];
+                    w = weight;
+                }
+            } else {
+                // swap
+                V tmp = vars[to];
+                vars[to] = vars[idx];
+                vars[idx] = tmp;
+                idx--;
+                to--;
+            }
+        }
+        last.set(to);
+        return best;
+    }
+
+    /**
+     * Compute the score of a variable
+     *
+     * @param v a variable
+     * @return a score
+     */
+    protected abstract double score(V v);
+
+    @Override
+    public void afterRestart() {
+        if (solver.getRestartCount() % (flushRate + 1) == flushRate) {
+            flushScores();
+        }
+    }
+
+    /**
+     *
+     */
+    protected abstract void flushScores();
+
+
+}

--- a/solver/src/main/java/org/chocosolver/solver/search/strategy/selectors/variables/DomOverWDegRef.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/strategy/selectors/variables/DomOverWDegRef.java
@@ -14,6 +14,8 @@ import org.chocosolver.solver.variables.IntVar;
 import org.chocosolver.solver.variables.Variable;
 import org.chocosolver.util.tools.VariableUtils;
 
+import java.util.Comparator;
+
 /**
  * Implementation of refined DowOverWDeg.
  *
@@ -26,28 +28,28 @@ public class DomOverWDegRef<V extends Variable> extends DomOverWDeg<V> {
 
     /**
      * Creates a DomOverWDegRef variable selector with "CACD" as weight incrementer.
+     * The default tiebreaker is lexical ordering.
+     * The default flush rate is 32.
      *
      * @param variables decision variables
-     * @param seed      seed for breaking ties randomly
      */
-    public DomOverWDegRef(V[] variables, long seed) {
-        super(variables, seed);
+    public DomOverWDegRef(V[] variables) {
+        this(variables, (v1, v2) -> 0, 32);
     }
 
     /**
      * Creates a DomOverWDegRef variable selector with "CACD" as weight incrementer.
      *
-     * @param variables decision variables
-     * @param seed      seed for breaking ties randomly
-     * @param flushThs flush threshold, when reached, it flushes scores
+     * @param variables  scope variables
+     * @param tieBreaker a tiebreaker comparator when two variables have the same score
+     * @param flushRate  the number of restarts before forgetting scores
      */
-    public DomOverWDegRef(V[] variables, long seed, int flushThs) {
-        super(variables, seed, flushThs);
+    public DomOverWDegRef(V[] variables, Comparator<V> tieBreaker, int flushRate) {
+        super(variables, tieBreaker, flushRate);
     }
 
     /**
-     * @implNote
-     * This is the reason this class exists.
+     * @implNote This is the reason this class exists.
      * The only difference with {@link DomOverWDeg} is the increment
      * which is not 1 for each variable.
      */

--- a/solver/src/test/java/org/chocosolver/solver/search/ObjectiveTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/search/ObjectiveTest.java
@@ -443,7 +443,7 @@ public class ObjectiveTest {
         solver.attach(solution);
         int[] t = new int[2];
 
-        solver.setSearch(new IntStrategy(ticks, new DomOverWDeg(ticks, 0L),
+        solver.setSearch(new IntStrategy(ticks, new DomOverWDeg<>(ticks),
             new IntDomainLast(solution, new IntDomainBest(),
             (x, v) -> {
                 int c = 0;

--- a/solver/src/test/java/org/chocosolver/solver/search/loop/LNSTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/search/loop/LNSTest.java
@@ -319,7 +319,7 @@ public class LNSTest {
 
 
         // Set up basic search for first sol.
-        Move basicsearch = new MoveBinaryDFS(new IntStrategy(decvars, new DomOverWDeg<>(decvars, 992634), new IntDomainMin()));
+        Move basicsearch = new MoveBinaryDFS(new IntStrategy(decvars, new DomOverWDeg<>(decvars), new IntDomainMin()));
         Solver solver = model.getSolver();
         solver.setMove(basicsearch);
 
@@ -332,7 +332,7 @@ public class LNSTest {
         in.init(); // Should this be necessary?
 
         //   Type of search within LNS neighbourhoods
-        Move innersearch = new MoveBinaryDFS(new IntStrategy(decvars, new DomOverWDeg<>(decvars, 0L), new IntDomainMin()));
+        Move innersearch = new MoveBinaryDFS(new IntStrategy(decvars, new DomOverWDeg<>(decvars), new IntDomainMin()));
 
         MoveLNS lns = new MoveLNS(innersearch, in, new BacktrackCounter(model, 50));
 


### PR DESCRIPTION
The main idea is to define how ties are broken in black-box strategies.
Previously, ties were broken randomly, which is a kind of admission of powerlessness.
I propose, with this PR,  to make possible to declare a tie-breaker if needed or let the default one which is based on  lexical ordering (=variables input order).
Note that this change has few mainly an impact on fresh start when no score are recorded, but as it drives the search to different search space, it may have a huge impact (+ or -) on efficiency.
However, now, we can tweak it.
