### PR TITLE
Set Expressions (with Chainable Format) for Arithmetic and Relational Operations

### DIFF
--- a/examples/src/test/java/org/chocosolver/examples/set/expression/SetVarExpressionTest.java
+++ b/examples/src/test/java/org/chocosolver/examples/set/expression/SetVarExpressionTest.java
@@ -1,0 +1,372 @@
+package org.chocosolver.examples.set.expression;
+
+import org.chocosolver.solver.Model;
+import org.chocosolver.solver.exception.ContradictionException;
+import org.chocosolver.solver.variables.impl.SetVarExpression;
+import org.junit.Test;
+
+import java.util.Arrays;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class SetVarExpressionTest {
+
+    /** Basic
+     * ============= Relacional ============= values and sets
+     * EQ (Equals) -> set = n value | setA = setB
+     * NE (not equals) -> set != n values | setA != setB
+     * Contains -> set contains n values | setA contains setB
+     * NC (Not Contains) -> set notContains n values | setA notContains setB
+     * SUBSET  -> set = is a subset of a SuperSet (values or set)
+     *
+     * Basic relacionals => and, imp, or...
+     *
+     * ============= Basic Arithmetic =============
+     * UNION
+     * INTERSECT
+     *
+     * Simple and Compound -> a.eq((b.intersection(c.union(d)).union(e.intersection(f))).intersection(g)
+     *
+     * Another functions
+     * setCard - set Cardinality
+     * notEmpty - a set can't empty
+     * Empty
+     */
+
+    @Test
+    public void notEmptyTest() throws ContradictionException{
+        Model model = new Model();
+        SetVarExpression setA = new SetVarExpression(model,"setA", new int[]{}, new int[]{0, 1, 2, 3});
+
+//        model.notEmpty(setA).post(); Choco
+        setA.notEmpty().post();
+
+        model.getSolver().propagate();
+
+        model.notMember(0, setA).post();
+        model.notMember(1, setA).post();
+        model.notMember(3, setA).post();
+
+        model.getSolver().propagate();
+
+        assertTrue(setA.getValue().toArray()[0] == 2);
+    }
+
+    @Test()
+    public void setCardTest() throws ContradictionException {
+        Model model = new Model();
+        SetVarExpression setA = new SetVarExpression(model,"setA",new int[]{}, new int[]{1, 2, 3, 4, 5, 6, 7, 8, 9});
+
+//        setA.setCard(model.intVar(4)); Choco
+        setA.setCard(4).post();
+
+        int nbSol = 0;
+        while(model.getSolver().solve()) {
+            nbSol++;
+            assertEquals(setA.getValue().size(), 4);
+        }
+
+        model.getSolver().propagate();
+
+        assertEquals(nbSol, 126); // binomial coefficient, 4 in 9
+    }
+
+    @Test()
+    public void simpleEQTest01() throws ContradictionException {
+        Model model = new Model();
+        SetVarExpression setA = new SetVarExpression(model,"setA", new int[]{}, new int[]{1,2});
+        setA.eq(1).post();
+
+        model.getSolver().propagate();
+
+        assertTrue(Arrays.equals(setA.getValue().toArray(), new int[] {1}));
+    }
+
+    @Test()
+    public void simpleEQTest02() throws ContradictionException {
+        Model model = new Model();
+        SetVarExpression setA = new SetVarExpression(model,"setA", new int[]{}, new int[]{1,2});
+        SetVarExpression setB = new SetVarExpression(model,"setB", new int[]{}, new int[]{1,2});
+        setA.eq(1).imp(setB.eq(2)).post();
+        setA.eq(1).post();
+
+        model.getSolver().propagate();
+
+        assertTrue(Arrays.equals(setA.getValue().toArray(), new int[] {1}));
+        assertTrue(Arrays.equals(setB.getValue().toArray(), new int[] {2}));
+    }
+
+    @Test()
+    public void simpleEQTest03() throws ContradictionException {
+        Model model = new Model();
+        SetVarExpression setA = new SetVarExpression(model,"setA", new int[]{}, new int[]{0,1,2,3,4,5,6,7,8,9});
+        setA.eq(1,2,3).post();
+
+        model.getSolver().propagate();
+
+        assertTrue(Arrays.equals(setA.getValue().toArray(), new int[] {1,2,3}));
+    }
+
+    @Test()
+    public void simpleNETest01() throws ContradictionException {
+        Model model = new Model();
+        SetVarExpression setA = new SetVarExpression(model,"setA", new int[]{}, new int[]{1,2});
+        SetVarExpression setB = new SetVarExpression(model,"setB", new int[]{}, new int[]{1,2});
+        setA.eq(2).post();
+        setA.ne(1).imp(setB.eq(2)).post();
+
+        model.getSolver().propagate();
+
+        assertTrue(Arrays.equals(setA.getValue().toArray(), new int[] {2}));
+        assertTrue(Arrays.equals(setB.getValue().toArray(), new int[] {2}));
+    }
+
+    @Test()
+    public void simpleContainsTest01() throws ContradictionException {
+        Model model = new Model();
+        SetVarExpression setA = new SetVarExpression(model,"setA", new int[]{}, new int[]{0,1,2,3,4,5,6,7,8,9});
+        setA.contains(1,2,3).post();
+
+        model.getSolver().propagate();
+
+        assertTrue(Arrays.equals(setA.getLB().toArray(), new int[] {1,2,3}));
+    }
+
+    @Test()
+    public void simpleNotContainsTest01() throws ContradictionException {
+        Model model = new Model();
+        SetVarExpression setA = new SetVarExpression(model,"setA", new int[]{}, new int[]{0,1,2,3,4,5,6,7,8,9});
+        setA.notContains(1,2,3).post();
+
+        model.getSolver().propagate();
+
+        assertTrue(Arrays.equals(setA.getUB().toArray(), new int[] {0,4,5,6,7,8,9}));
+    }
+
+
+    @Test()
+    public void simpleSubSetTest01() throws ContradictionException {
+        Model model = new Model();
+        SetVarExpression setA = new SetVarExpression(model,"setA", new int[]{}, new int[]{0,1,2,3,4,5,6,7,8,9});
+        setA.subSet(1,2,3,4,5).post();
+
+        model.getSolver().propagate();
+
+        assertTrue(Arrays.equals(setA.getUB().toArray(), new int[] {1,2,3,4,5}));
+
+        setA.notEmpty().post();
+        setA.notContains(4,5).post();
+        model.getSolver().propagate();
+
+        assertTrue(Arrays.equals(setA.getUB().toArray(), new int[] {1,2,3}));
+    }
+
+    @Test()
+    public void biEqTest01() throws ContradictionException {
+        Model model = new Model();
+        SetVarExpression setA = new SetVarExpression(model,"setA", new int[]{}, new int[]{1,2,3,4,5});
+        SetVarExpression setB = new SetVarExpression(model,"setB", new int[]{}, new int[]{1,2,3,4,5});
+        setA.eq(setB).post();
+
+        setA.eq(1,2).post();
+
+        model.getSolver().propagate();
+
+        assertTrue(Arrays.equals(setA.getValue().toArray(), new int[] {1,2}));
+        assertTrue(Arrays.equals(setB.getValue().toArray(), new int[] {1,2}));
+    }
+
+    @Test()
+    public void biEQTest02() throws ContradictionException {
+        Model model = new Model();
+        SetVarExpression setA = new SetVarExpression(model,"setA", new int[]{}, new int[]{1,2,3,4,5});
+        SetVarExpression setB = new SetVarExpression(model,"setB", new int[]{}, new int[]{1,2,3,4,5});
+        SetVarExpression setC = new SetVarExpression(model,"setC", new int[]{}, new int[]{1,2,3,4,5});
+        SetVarExpression setD = new SetVarExpression(model,"setD", new int[]{}, new int[]{1,2,3,4,5});
+        setA.eq(setB).imp(setC.eq(setD)).post();
+        setA.eq(1,2,3).post();
+        setB.eq(1,2,3).post();
+        setC.eq(4,5).post();
+
+        model.getSolver().propagate();
+
+        assertTrue(Arrays.equals(setA.getValue().toArray(), new int[] {1,2,3}));
+        assertTrue(Arrays.equals(setB.getValue().toArray(), new int[] {1,2,3}));
+        assertTrue(Arrays.equals(setC.getValue().toArray(), new int[] {4,5}));
+        assertTrue(Arrays.equals(setD.getValue().toArray(), new int[] {4,5}));
+    }
+
+    @Test()
+    public void biEQTest03() throws ContradictionException {
+        Model model = new Model();
+        SetVarExpression setA = new SetVarExpression(model,"setA", new int[]{}, new int[]{0,1,2,3,4,5,6,7,8,9});
+        SetVarExpression setB = new SetVarExpression(model,"setB", 1,2,3);
+        setA.eq(setB).post();
+
+        model.getSolver().propagate();
+
+        assertTrue(Arrays.equals(setA.getValue().toArray(), setB.getValue().toArray()));
+    }
+
+    @Test()
+    public void biNETest01() throws ContradictionException {
+        Model model = new Model();
+        SetVarExpression setA = new SetVarExpression(model,"setA", new int[]{}, new int[]{1,2,3,4,5});
+        SetVarExpression setB = new SetVarExpression(model,"setB", new int[]{}, new int[]{1,2,3,4,5});
+        SetVarExpression setC = new SetVarExpression(model,"setC", 3,4);
+        SetVarExpression setD = new SetVarExpression(model,"setD", 1,2);
+
+        setA.eq(setC).post();
+        setA.ne(setD).imp(setB.eq(setD)).post();
+
+        model.getSolver().propagate();
+
+        assertTrue(Arrays.equals(setA.getValue().toArray(), new int[] {3,4}));
+        assertTrue(Arrays.equals(setB.getValue().toArray(), new int[] {1,2}));
+    }
+
+    @Test()
+    public void biContainsTest01() throws ContradictionException {
+        Model model = new Model();
+        SetVarExpression setA = new SetVarExpression(model,"setA", new int[]{}, new int[]{0,1,2,3,4,5,6,7,8,9});
+        SetVarExpression setB = new SetVarExpression(model,"setB", new int[]{}, new int[]{0,1,2,3,4,5,6,7,8,9});
+        setA.contains(setB).post();
+        setB.eq(1,2,3).post();
+
+        model.getSolver().propagate();
+
+        assertTrue(Arrays.equals(setB.getValue().toArray(), new int[] {1,2,3}));
+        assertTrue(Arrays.equals(setA.getLB().toArray(), new int[] {1,2,3}));
+        assertTrue(Arrays.equals(setA.getUB().toArray(), new int[] {0,1,2,3,4,5,6,7,8,9}));
+    }
+
+
+    @Test()
+    public void biNotContainsTest01() throws ContradictionException {
+        Model model = new Model();
+        SetVarExpression setA = new SetVarExpression(model,"setA", new int[]{}, new int[]{0,1,2,3,4,5,6,7,8,9});
+        SetVarExpression setB = new SetVarExpression(model,"setB", new int[]{}, new int[]{0,1,2,3,4,5,6,7,8,9});
+        setA.notContains(setB).post();
+        setB.eq(1,2,3).post();
+
+        model.getSolver().propagate();
+
+        assertTrue(Arrays.equals(setA.getUB().toArray(), new int[] {0,4,5,6,7,8,9}));
+    }
+
+    @Test()
+    public void biSubSetTest01() throws ContradictionException {
+        Model model = new Model();
+        SetVarExpression setA = new SetVarExpression(model,"setA", new int[]{}, new int[]{0,1,2,3,4,5,6,7,8,9});
+        SetVarExpression setB = new SetVarExpression(model,"setB", new int[]{}, new int[]{1,2,3,4,5});
+        setA.subSet(setB).post();
+
+        model.getSolver().propagate();
+
+        assertTrue(Arrays.equals(setA.getUB().toArray(), new int[] {1,2,3,4,5}));
+        assertTrue(Arrays.equals(setB.getUB().toArray(), new int[] {1,2,3,4,5}));
+
+        setA.notEmpty().post();
+        setA.notContains(4,5).post();
+        model.getSolver().propagate();
+
+        assertTrue(Arrays.equals(setA.getUB().toArray(), new int[] {1,2,3}));
+        assertTrue(Arrays.equals(setB.getUB().toArray(), new int[] {1,2,3,4,5}));
+    }
+
+    @Test()
+    public void unionTest01() throws ContradictionException {
+        Model model = new Model();
+        SetVarExpression setC = new SetVarExpression(model,"setC", new int[]{}, new int[]{1,3,5,7,9,11,13});
+        SetVarExpression setD = new SetVarExpression(model,"setD", new int[]{}, new int[]{4,5,6,7,10,12,14});
+        SetVarExpression setCD = new SetVarExpression(model,"setCD", new int[]{}, new int[]{0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20});
+
+        setCD.eq(setC.union(setD)).post();
+        model.getSolver().propagate();
+
+        assertTrue(Arrays.equals(setCD.getUB().toArray(), new int[] {1, 3, 4, 5, 6, 7, 9, 10, 11, 12, 13, 14}));
+    }
+
+    @Test()
+    public void intersectTest01() throws ContradictionException {
+        Model model = new Model();
+        SetVarExpression setCD = new SetVarExpression(model,"CD", new int[]{}, new int[]{1, 3, 4, 5, 6, 7, 9, 10, 11, 12, 13, 14});
+        SetVarExpression setB = new SetVarExpression(model,"setB", new int[]{}, new int[]{2,4,6,8,10,12,14});
+        SetVarExpression setBCD = new SetVarExpression(model,"setBCD", new int[]{}, new int[]{1,2,3,4,5,6,7,8,9,10,11,12,13,14});
+
+        setBCD.eq(setB.intersection(setCD)).post();
+        model.getSolver().propagate();
+
+        assertTrue(Arrays.equals(setBCD.getUB().toArray(), new int[] {4,6,10,12,14}));
+    }
+
+    @Test()
+    public void intersectAndUnionTest01() throws ContradictionException {
+        Model model = new Model();
+        SetVarExpression setC = new SetVarExpression(model,"setC", new int[]{}, new int[]{1,3,5,7,9,11,13});
+        SetVarExpression setD = new SetVarExpression(model,"setD", new int[]{}, new int[]{4,5,6,7,10,12,14});
+        SetVarExpression setB = new SetVarExpression(model,"setB", new int[]{}, new int[]{2,4,6,8,10,12,14});
+        SetVarExpression setBCD = new SetVarExpression(model,"setBCD", new int[]{}, new int[]{1,2,3,4,5,6,7,8,9,10,11,12,13,14});
+
+        setBCD.eq(setB.intersection(setC.union(setD))).post();
+        model.getSolver().propagate();
+
+        assertTrue(Arrays.equals(setBCD.getUB().toArray(), new int[] {4,6,10,12,14}));
+    }
+
+    @Test()
+    public void intersectTest02() throws ContradictionException {
+        Model model = new Model();
+        SetVarExpression setE = new SetVarExpression(model,"setE", new int[]{}, new int[]{3,5,9,11,15,17,19});
+        SetVarExpression setF = new SetVarExpression(model,"setF", new int[]{}, new int[]{4,8,12,16,20});
+        SetVarExpression setEF = new SetVarExpression(model,"setEF", new int[]{}, new int[]{3,4,5,8,9,11,12,15,16,17,19,20});
+
+        setEF.eq(setE.intersection(setF)).post();
+        model.getSolver().propagate();
+
+        assertTrue(Arrays.equals(setEF.getUB().toArray(), new int[] {}));
+    }
+
+
+    @Test()
+    public void intersectAndUnionTest02() throws ContradictionException {
+        Model model = new Model();
+        SetVarExpression setE = new SetVarExpression(model,"setE", new int[]{}, new int[]{3,5,9,11,15,17,19});
+        SetVarExpression setF = new SetVarExpression(model,"setF", new int[]{}, new int[]{4,8,12,16,20});
+        SetVarExpression setC = new SetVarExpression(model,"setC", new int[]{}, new int[]{1,3,5,7,9,11,13});
+        SetVarExpression setD = new SetVarExpression(model,"setD", new int[]{}, new int[]{4,5,6,7,10,12,14});
+        SetVarExpression setB = new SetVarExpression(model,"setB", new int[]{}, new int[]{2,4,6,8,10,12,14});
+
+        SetVarExpression setBCDEF = new SetVarExpression(model,"setBCDEF", new int[]{}, new int[]{
+                1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 19, 20});
+
+        setBCDEF.eq((setB.intersection(setC.union(setD)).union(setE.intersection(setF)))).post();
+        model.getSolver().propagate();
+
+        assertTrue(Arrays.equals(setBCDEF.getUB().toArray(), new int[] {4,6,10,12,14}));
+    }
+
+    @Test()
+    public void setExpressionTest01() throws ContradictionException {
+        Model model = new Model();
+        SetVarExpression setA = new SetVarExpression(model,"setA", new int[]{}, new int[]{1,2,3,4,5,6,7});
+        SetVarExpression setB = new SetVarExpression(model,"setB", new int[]{}, new int[]{2,4,6,8,10,12,14});
+        SetVarExpression setC = new SetVarExpression(model,"setC", new int[]{}, new int[]{1,3,5,7,9,11,13});
+        SetVarExpression setD = new SetVarExpression(model,"setD", new int[]{}, new int[]{4,5,6,7,10,12,14});
+        SetVarExpression setE = new SetVarExpression(model,"setE", new int[]{}, new int[]{3,5,9,11,15,17,19});
+        SetVarExpression setF = new SetVarExpression(model,"setF", new int[]{}, new int[]{4,8,12,16,20});
+        SetVarExpression setG = new SetVarExpression(model,"setG", new int[]{}, new int[]{2,6,10,14,18});
+
+        setA.eq((setB.intersection(setC.union(setD)).union(setE.intersection(setF))).intersection(setG)).post();
+        model.getSolver().propagate();
+
+        assertTrue(Arrays.equals(setA.getUB().toArray(), new int[] {6}));
+        assertTrue(Arrays.equals(setB.getUB().toArray(), new int[] {2, 4, 6, 8, 10, 12, 14}));
+        assertTrue(Arrays.equals(setC.getUB().toArray(), new int[] {1, 3, 5, 7, 9, 11, 13}));
+        assertTrue(Arrays.equals(setD.getUB().toArray(), new int[] {4, 5, 6, 7, 10, 12, 14}));
+        assertTrue(Arrays.equals(setE.getUB().toArray(), new int[] {3, 5, 9, 11, 15, 17, 19}));
+        assertTrue(Arrays.equals(setF.getUB().toArray(), new int[] {4, 8, 12, 16, 20}));
+        assertTrue(Arrays.equals(setG.getUB().toArray(), new int[] {2, 6, 10, 14, 18}));
+    }
+}

--- a/solver/src/main/java/org/chocosolver/solver/expression/discrete/set/BiArSetExpression.java
+++ b/solver/src/main/java/org/chocosolver/solver/expression/discrete/set/BiArSetExpression.java
@@ -1,0 +1,58 @@
+package org.chocosolver.solver.expression.discrete.set;
+
+import org.chocosolver.solver.Model;
+import org.chocosolver.solver.variables.SetVar;
+
+import java.util.Arrays;
+import java.util.stream.IntStream;
+
+/**
+ * BiArSetExpression - Binary Arithmetic Set Expression
+ *
+ * This class represents a binary arithmetic expression between two SetVarExpression instances.
+ * It supports set operations such as union (UNION) and intersection (INTERSECTION),
+ * returning a new SetVar as the result of the operation.
+ *
+ * Example:
+ * setA.eq(setB.union(setC)).post();
+ * setA.eq(setB.intersection(setC)).post();
+ */
+
+public class BiArSetExpression implements SetExpression {
+
+    private SetOperator op;
+    private SetExpression x;
+    private SetExpression y;
+    private Model model;
+    private SetVar xSet, ySet, resultSet;
+
+    public BiArSetExpression(SetOperator operator, SetExpression x, SetExpression y) {
+        this.op = operator;
+        this.x = x;
+        this.y = y;
+        this.xSet = x.getSetVar();
+        this.ySet = y.getSetVar();
+
+        this.model = xSet.getModel();
+    }
+
+    @Override
+    public SetVar getSetVar() {
+        if (resultSet == null) {
+            int[] setDomain = IntStream.concat(Arrays.stream(xSet.getUB().toArray()), Arrays.stream(ySet.getUB().toArray())).toArray();
+            resultSet = model.setVar(model.generateName("aux_setvar_"), new int[]{}, setDomain);
+
+            switch (op) {
+                case UNION:
+                    model.union(new SetVar[]{xSet, ySet}, resultSet).post();
+                    break;
+                case INTERSECTION:
+                    model.intersection(new SetVar[]{xSet, ySet}, resultSet).post();
+                    break;
+                default:
+                    throw new UnsupportedOperationException("Unsupported SetOperator: " + op);
+            }
+        }
+        return resultSet;
+    }
+}

--- a/solver/src/main/java/org/chocosolver/solver/expression/discrete/set/BiReSetExpression.java
+++ b/solver/src/main/java/org/chocosolver/solver/expression/discrete/set/BiReSetExpression.java
@@ -1,0 +1,104 @@
+package org.chocosolver.solver.expression.discrete.set;
+
+
+import org.chocosolver.solver.Model;
+import org.chocosolver.solver.constraints.Constraint;
+import org.chocosolver.solver.expression.discrete.relational.ReExpression;
+import org.chocosolver.solver.variables.BoolVar;
+import org.chocosolver.solver.variables.IntVar;
+import org.chocosolver.solver.variables.SetVar;
+
+import java.util.HashSet;
+
+import static org.chocosolver.solver.constraints.real.Ibex.TRUE;
+
+/**
+ * BiReSetExpression - Binary Relational Set Expression
+ *
+ * This class represents a binary relational expression between two SetVarExpression instances.
+ * It supports relational operations such as equality (EQ), inequality (NE), subset (SUBSET),
+ * and containment (CONTAINS). The operations can be composed and posted as constraints.
+ *
+ * Example:
+ * setA.eq(setB).post();
+ * setA.ne(setB).post();
+ */
+public class BiReSetExpression implements ReExpression {
+
+    private SetOperator op;
+    private SetExpression x;
+    private SetExpression y;
+    private Model model;
+    private SetVar xSet, ySet;
+
+    private Constraint constraint;
+
+    private BoolVar result;
+
+    public BiReSetExpression(SetOperator operator, SetExpression x, SetExpression y) {
+        this.op = operator;
+        this.model = x.getModel();
+        this.x = x;
+        this.y = y;
+        this.xSet = x.getSetVar();
+        this.ySet = y.getSetVar();
+    }
+
+    public Model getModel() {
+        return this.model;
+    }
+
+    @Override
+    public BoolVar boolVar() {
+        if (result == null) {
+            switch (op) {
+                case SUBSET:
+                    result = model.subsetEq(xSet, ySet).reify().eq(TRUE).boolVar();
+                    break;
+                case EQ:
+                    result = model.allEqual(xSet, ySet).reify().eq(TRUE).boolVar();
+                    break;
+                case NE:
+                    result = model.allDifferent(xSet, ySet).reify().eq(TRUE).boolVar();
+                    break;
+                case CONTAINS:
+                    result = model.subsetEq(ySet, xSet).reify().eq(TRUE).boolVar();
+                    break;
+                case NC:
+                    result = model.disjoint(ySet, xSet).reify().eq(TRUE).boolVar();
+                    break;
+                default:
+                    throw new UnsupportedOperationException("Unsupported SetOperator: " + op);
+            }
+        }
+        return result;
+    }
+
+    @Override
+    public void extractVar(HashSet<IntVar> variables) {
+    }
+
+    @Override
+    public Constraint decompose() {
+        switch (op) {
+            case SUBSET:
+                constraint = model.subsetEq(xSet, ySet);
+                break;
+            case EQ:
+                constraint = model.allEqual(xSet, ySet);
+                break;
+            case NE:
+                constraint = model.allDifferent(xSet, ySet);
+                break;
+            case CONTAINS:
+                constraint = model.subsetEq(ySet, xSet);
+                break;
+            case NC:
+                constraint = model.disjoint(xSet,ySet);
+                break;
+            default:
+                throw new UnsupportedOperationException("Unsupported SetOperator: " + op);
+        }
+        return constraint;
+    }
+}

--- a/solver/src/main/java/org/chocosolver/solver/expression/discrete/set/BiReSetExpression.java
+++ b/solver/src/main/java/org/chocosolver/solver/expression/discrete/set/BiReSetExpression.java
@@ -1,6 +1,5 @@
 package org.chocosolver.solver.expression.discrete.set;
 
-
 import org.chocosolver.solver.Model;
 import org.chocosolver.solver.constraints.Constraint;
 import org.chocosolver.solver.expression.discrete.relational.ReExpression;
@@ -9,8 +8,6 @@ import org.chocosolver.solver.variables.IntVar;
 import org.chocosolver.solver.variables.SetVar;
 
 import java.util.HashSet;
-
-import static org.chocosolver.solver.constraints.real.Ibex.TRUE;
 
 /**
  * BiReSetExpression - Binary Relational Set Expression
@@ -53,19 +50,19 @@ public class BiReSetExpression implements ReExpression {
         if (result == null) {
             switch (op) {
                 case SUBSET:
-                    result = model.subsetEq(xSet, ySet).reify().eq(TRUE).boolVar();
+                    result = model.subsetEq(xSet, ySet).reify();
                     break;
                 case EQ:
-                    result = model.allEqual(xSet, ySet).reify().eq(TRUE).boolVar();
+                    result = model.allEqual(xSet, ySet).reify();
                     break;
                 case NE:
-                    result = model.allDifferent(xSet, ySet).reify().eq(TRUE).boolVar();
+                    result = model.allDifferent(xSet, ySet).reify();
                     break;
                 case CONTAINS:
-                    result = model.subsetEq(ySet, xSet).reify().eq(TRUE).boolVar();
+                    result = model.subsetEq(ySet, xSet).reify();
                     break;
                 case NC:
-                    result = model.disjoint(ySet, xSet).reify().eq(TRUE).boolVar();
+                    result = model.disjoint(ySet, xSet).reify();
                     break;
                 default:
                     throw new UnsupportedOperationException("Unsupported SetOperator: " + op);
@@ -76,6 +73,7 @@ public class BiReSetExpression implements ReExpression {
 
     @Override
     public void extractVar(HashSet<IntVar> variables) {
+        throw new UnsupportedOperationException("extractVar() is not supported for BiReSetExpression.");
     }
 
     @Override

--- a/solver/src/main/java/org/chocosolver/solver/expression/discrete/set/SetExpression.java
+++ b/solver/src/main/java/org/chocosolver/solver/expression/discrete/set/SetExpression.java
@@ -1,0 +1,70 @@
+package org.chocosolver.solver.expression.discrete.set;
+
+import org.chocosolver.solver.Model;
+import org.chocosolver.solver.constraints.Constraint;
+import org.chocosolver.solver.expression.discrete.relational.ReExpression;
+import org.chocosolver.solver.expression.discrete.relational.UnCReExpression;
+import org.chocosolver.solver.variables.SetVar;
+
+public interface SetExpression {
+    default SetExpression union(SetExpression y){
+        return new BiArSetExpression(SetOperator.UNION, this, y);
+    }
+
+    default SetExpression intersection(SetExpression y){
+        return new BiArSetExpression(SetOperator.INTERSECTION, this, y);
+    }
+    default ReExpression subSet(SetExpression y) {
+        return new BiReSetExpression(SetOperator.SUBSET, this, y);
+    }
+    default ReExpression eq(SetExpression y) {
+        return new BiReSetExpression(SetOperator.EQ, this, y);
+    }
+    default ReExpression ne(SetExpression y) {
+        return new BiReSetExpression(SetOperator.NE, this, y);
+    }
+    default ReExpression contains(SetExpression y) {
+        return new BiReSetExpression(SetOperator.CONTAINS, this, y);
+    }
+
+    default ReExpression notContains(SetExpression y) {
+        return new BiReSetExpression(SetOperator.NC, this, y);
+    }
+
+
+    default ReExpression subSet(int...y) {
+        return new UnReSetExpression(SetOperator.SUBSET, this, y);
+    }
+    default ReExpression eq(int...y) {
+        return new UnReSetExpression(SetOperator.EQ, this, y);
+    }
+
+    default ReExpression notContains(int...y) {
+        return new UnReSetExpression(SetOperator.NC, this, y);
+    }
+
+    default ReExpression contains(int...y) {
+        return new UnReSetExpression(SetOperator.CONTAINS, this, y);
+    }
+
+    default ReExpression ne(int...y) {
+        return new UnReSetExpression(SetOperator.NE, this, y);
+    }
+
+    default Constraint notEmpty(){
+        SetVar set = this.getSetVar();
+        return getModel().notEmpty(set);
+    }
+
+    default UnCReExpression setCard(int valueCard){
+        SetVar set = this.getSetVar();
+        return set.getCard().eq(valueCard);
+    }
+
+    SetVar getSetVar();
+
+    default Model getModel() {
+        throw new UnsupportedOperationException("getModel() is not supported in this context");
+    }
+
+}

--- a/solver/src/main/java/org/chocosolver/solver/expression/discrete/set/SetExpression.java
+++ b/solver/src/main/java/org/chocosolver/solver/expression/discrete/set/SetExpression.java
@@ -6,62 +6,165 @@ import org.chocosolver.solver.expression.discrete.relational.ReExpression;
 import org.chocosolver.solver.expression.discrete.relational.UnCReExpression;
 import org.chocosolver.solver.variables.SetVar;
 
+/**
+ * Interface for set variable (*SetVar*) expressions.
+ * This interface enables the construction of relational and arithmetic expressions
+ * over sets, allowing operations such as union, intersection, and membership checks.
+ */
+
 public interface SetExpression {
-    default SetExpression union(SetExpression y){
+    /**
+     * Returns the union of this set with another set.
+     *
+     * @param y the other set expression.
+     * @return a new expression representing the union.
+     */
+    default SetExpression union(SetExpression y) {
         return new BiArSetExpression(SetOperator.UNION, this, y);
     }
 
-    default SetExpression intersection(SetExpression y){
+    /**
+     * Returns the intersection of this set with another set.
+     *
+     * @param y the other set expression.
+     * @return a new expression representing the intersection.
+     */
+    default SetExpression intersection(SetExpression y) {
         return new BiArSetExpression(SetOperator.INTERSECTION, this, y);
     }
+    /**
+     * Checks if this set is a subset of another set.
+     *
+     * @param y the other set expression.
+     * @return a boolean expression representing the subset relationship.
+     */
     default ReExpression subSet(SetExpression y) {
         return new BiReSetExpression(SetOperator.SUBSET, this, y);
     }
+
+    /**
+     * Checks if two sets are equal.
+     *
+     * @param y the other set expression.
+     * @return a boolean expression representing equality.
+     */
     default ReExpression eq(SetExpression y) {
         return new BiReSetExpression(SetOperator.EQ, this, y);
     }
+
+    /**
+     * Checks if two sets are different.
+     *
+     * @param y the other set expression.
+     * @return a boolean expression representing inequality.
+     */
     default ReExpression ne(SetExpression y) {
         return new BiReSetExpression(SetOperator.NE, this, y);
     }
+
+    /**
+     * Checks if this set contains another set.
+     *
+     * @param y the other set expression.
+     * @return a boolean expression representing the containment relation.
+     */
     default ReExpression contains(SetExpression y) {
         return new BiReSetExpression(SetOperator.CONTAINS, this, y);
     }
-
+    /**
+     * Checks if this set does not contain another set.
+     *
+     * @param y the other set expression.
+     * @return a boolean expression representing the non-membership relation.
+     */
     default ReExpression notContains(SetExpression y) {
         return new BiReSetExpression(SetOperator.NC, this, y);
     }
 
-
-    default ReExpression subSet(int...y) {
+    /**
+     * Checks if this set is a subset of a given set of integers.
+     *
+     * @param y the integer values to check.
+     * @return a boolean expression representing the subset relationship.
+     */
+    default ReExpression subSet(int... y) {
         return new UnReSetExpression(SetOperator.SUBSET, this, y);
     }
-    default ReExpression eq(int...y) {
+
+    /**
+     * Checks if this set is equal to a given set of integers.
+     *
+     * @param y the integer values to compare.
+     * @return a boolean expression representing equality.
+     */
+    default ReExpression eq(int... y) {
         return new UnReSetExpression(SetOperator.EQ, this, y);
     }
 
-    default ReExpression notContains(int...y) {
+    /**
+     * Checks if this set does not contain a given set of integers.
+     *
+     * @param y the integer values to check.
+     * @return a boolean expression representing non-membership.
+     */
+    default ReExpression notContains(int... y) {
         return new UnReSetExpression(SetOperator.NC, this, y);
     }
 
-    default ReExpression contains(int...y) {
+    /**
+     * Checks if this set contains a given set of integers.
+     *
+     * @param y the integer values to check.
+     * @return a boolean expression representing membership.
+     */
+    default ReExpression contains(int... y) {
         return new UnReSetExpression(SetOperator.CONTAINS, this, y);
     }
 
-    default ReExpression ne(int...y) {
+    /**
+     * Checks if this set is different from a given set of integers.
+     *
+     * @param y the integer values to compare.
+     * @return a boolean expression representing inequality.
+     */
+    default ReExpression ne(int... y) {
         return new UnReSetExpression(SetOperator.NE, this, y);
     }
 
-    default Constraint notEmpty(){
+    /**
+     * Returns a constraint ensuring that the set is not empty.
+     *
+     * @return a constraint enforcing the non-emptiness of the set.
+     */
+    default Constraint notEmpty() {
         SetVar set = this.getSetVar();
         return getModel().notEmpty(set);
     }
 
-    default UnCReExpression setCard(int valueCard){
+    /**
+     * Constrains the cardinality of the set to be equal to a specific value.
+     *
+     * @param valueCard the desired cardinality value.
+     * @return a unary relational expression enforcing the set cardinality.
+     */
+    default UnCReExpression setCard(int valueCard) {
         SetVar set = this.getSetVar();
         return set.getCard().eq(valueCard);
     }
 
+    /**
+     * Returns the set variable associated with this expression.
+     *
+     * @return the corresponding set variable.
+     */
     SetVar getSetVar();
+
+    /**
+     * Returns the model associated with this expression.
+     *
+     * @return the model of the expression.
+     * @throws UnsupportedOperationException if this method is not supported.
+     */
 
     default Model getModel() {
         throw new UnsupportedOperationException("getModel() is not supported in this context");

--- a/solver/src/main/java/org/chocosolver/solver/expression/discrete/set/SetOperator.java
+++ b/solver/src/main/java/org/chocosolver/solver/expression/discrete/set/SetOperator.java
@@ -1,0 +1,11 @@
+package org.chocosolver.solver.expression.discrete.set;
+
+public enum SetOperator {
+    SUBSET,
+    EQ,
+    NE,
+    CONTAINS,
+    NC,
+    UNION,
+    INTERSECTION
+}

--- a/solver/src/main/java/org/chocosolver/solver/expression/discrete/set/UnReSetExpression.java
+++ b/solver/src/main/java/org/chocosolver/solver/expression/discrete/set/UnReSetExpression.java
@@ -1,0 +1,104 @@
+package org.chocosolver.solver.expression.discrete.set;
+
+import org.chocosolver.solver.Model;
+import org.chocosolver.solver.constraints.Constraint;
+import org.chocosolver.solver.expression.discrete.relational.ReExpression;
+import org.chocosolver.solver.variables.BoolVar;
+import org.chocosolver.solver.variables.IntVar;
+import org.chocosolver.solver.variables.SetVar;
+
+import java.util.Arrays;
+import java.util.HashSet;
+
+import static org.chocosolver.solver.constraints.real.Ibex.TRUE;
+
+/**
+ * UnReSetExpression - Unary Relational Set Expression
+ *
+ * This class represents a unary relational expression for a SetVar and a set of values.
+ * It handles operations like equality (EQ), inequality (NE), subset (SUBSET), and containment (CONTAINS)
+ * with respect to a fixed set of integers.
+ *
+ * Example:
+ * setA.eq(1,2,3).post();
+ * setA.contains(1,2).post();
+ */
+public class UnReSetExpression implements ReExpression {
+    private SetOperator op;
+    private SetExpression x;
+    private int[] y;
+    private Model model;
+    private SetVar xSet, ySet;
+
+    private Constraint constraint;
+
+    private BoolVar result;
+
+    public UnReSetExpression(SetOperator operator, SetExpression x, int... y) {
+        this.op = operator;
+        this.model = x.getModel();
+        this.x = x;
+        this.y = y;
+        this.xSet = x.getSetVar();
+        this.ySet = model.setVar(Arrays.stream(y).toArray());
+    }
+
+    public Model getModel() {
+        return this.model;
+    }
+
+    @Override
+    public BoolVar boolVar() {
+        if (result == null) {
+            switch (op) {
+                case SUBSET:
+                    result = model.subsetEq(xSet, ySet).reify().eq(TRUE).boolVar();
+                    break;
+                case EQ:
+                    result = model.allEqual(xSet, ySet).reify().eq(TRUE).boolVar();
+                    break;
+                case NE:
+                    result = model.allDifferent(xSet, ySet).reify().eq(TRUE).boolVar();
+                    break;
+                case CONTAINS:
+                    result = model.subsetEq(ySet, xSet).reify().eq(TRUE).boolVar();
+                    break;
+                case NC:
+                    result = model.disjoint(ySet, xSet).reify().eq(TRUE).boolVar();
+                    break;
+                default:
+                    throw new UnsupportedOperationException("Unsupported SetOperator: " + op);
+            }
+        }
+        return result;
+    }
+
+    @Override
+    public void extractVar(HashSet<IntVar> variables) {
+
+    }
+
+    @Override
+    public Constraint decompose() {
+        switch (op) {
+            case SUBSET:
+                constraint = model.subsetEq(xSet, ySet);
+                break;
+            case EQ:
+                constraint = model.allEqual(xSet, ySet);
+                break;
+            case NE:
+                constraint = model.allDifferent(xSet, ySet);
+                break;
+            case CONTAINS:
+                constraint = model.subsetEq(ySet, xSet);
+                break;
+            case NC:
+                constraint = model.disjoint(xSet,ySet);
+                break;
+            default:
+                throw new UnsupportedOperationException("Unsupported SetOperator: " + op);
+        }
+        return constraint;
+    }
+}

--- a/solver/src/main/java/org/chocosolver/solver/expression/discrete/set/UnReSetExpression.java
+++ b/solver/src/main/java/org/chocosolver/solver/expression/discrete/set/UnReSetExpression.java
@@ -75,7 +75,7 @@ public class UnReSetExpression implements ReExpression {
 
     @Override
     public void extractVar(HashSet<IntVar> variables) {
-
+        throw new UnsupportedOperationException("extractVar() is not supported for UnReSetExpression.");
     }
 
     @Override

--- a/solver/src/main/java/org/chocosolver/solver/variables/impl/SetVarExpression.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/impl/SetVarExpression.java
@@ -1,0 +1,36 @@
+package org.chocosolver.solver.variables.impl;
+
+import org.chocosolver.solver.Model;
+import org.chocosolver.solver.expression.discrete.set.SetExpression;
+import org.chocosolver.util.objects.setDataStructures.SetType;
+
+
+/**
+ * SetVarExpression - SetVar Implementation with Expression Support
+ *
+ * This class extends SetVar to allow arithmetic and relational operations to be performed
+ * directly on set variables, facilitating composition of constraints and complex expressions
+ * such as union, intersection, equality, and subset relations.
+ *
+ * Example:
+ * setA.eq(1,2,3).post();
+ * setA.union(setB).post();
+ */
+
+public class SetVarExpression extends SetVarImpl implements SetExpression {
+    /**
+     This class is a copy of SetVarImpl that implements the SetExpression functions.
+     */
+
+    public SetVarExpression(Model model, String name, int[] valuesLB, int[] valuesUB){
+        super(name, valuesLB, SetType.BITSET, valuesUB, SetType.BITSET, model.ref());
+    }
+
+    public SetVarExpression(Model model, String name, int...domain){
+        super(name, domain, model.ref());
+    }
+    @Override
+    public SetVarImpl getSetVar(){
+        return this;
+    }
+}


### PR DESCRIPTION
**Set Expressions (with Chainable Format) for Arithmetic and Relational Operations**

I've been working with `SetVar` in `choco-Solver`. Unlike other types of variables, such as `RealVar` or `IntVar`, there was no direct way to compose operations such as equals (eq), not equals (ne), contains, not contains (nc), subset (subSet), union, or intersection directly in the model definition. While propagators allow for constructing such constraints, it was not as intuitive as it is for other variable types like `IntVar` and `RealVar`. These features are extremely useful in facilitating the composition of constraints.

Thus, I've worked on adding this feature for `SetVar`, based on the operations already available for other variable types. For example:

```java
realVar.eq(3).post();
```

However, such expressions were not possible for `SetVar`:

```java
setVar.eq(1, 2, 3).post();  // Not available... until now!
```

**Improvement**

I've implemented a new expression framework for `SetVar`, allowing the use of familiar operations directly on set variables. This change introduces support for the following operations:

Relational Operations:

- `eq` (Equals): `setA.eq(1, 2, 3)` or `setA.eq(setB)`.
- `ne` (Not Equals): `setA.ne(1, 2)` or `setA.ne(setB)`.
- `contains`: `setA.contains(1, 2)`.
- `nc` (notContains): `setA.notContains(1, 2)`.
- `subSet`: `setA.subSet(1, 2, 3)` or `setA.subSet(setB)`.

Arithmetic Set Operations:

`union`: `setA.union(setB)`
`intersection`: `setA.intersection(setB)`

This enhancement allows for the expression of complex set relations with simplified syntax, enabling combinations such as:

```java
setA.eq(setB.union(setC.intersection(setD))).post();
```

**Example Usage:**
```java
Model model = new Model();

// Define set variables
SetVarImplArExpression setA = new SetVarImplArExpression(model, "setA", new int[]{}, new int[]{0, 1, 2, 3});
SetVarImplArExpression setB = new SetVarImplArExpression(model, "setB", new int[]{}, new int[]{1, 2, 3});
SetVarImplArExpression setC = new SetVarImplArExpression(model, "setC", new int[]{}, new int[]{2, 3, 4, 5});

// Compose set expressions
setA.eq(setB.union(setC)).post();
model.getSolver().propagate();

// Assert the expected values in setA
assertTrue(Arrays.equals(setA.getUB().toArray(), new int[]{1, 2, 3, 4, 5}));
```

**Internal Changes:**

This change is implemented through three main components:

- Unary Set Expressions (`UnReSetExpression`): Handle relations between a set and a list of values, like `setVar.eq(1,2,3).post()`.
- Binary Set Expressions (`BiReSetExpression`): Manage operations between two `SetVar` instances, such as `setA.eq(setB).post()`.
- Binary Arithmetic Expressions (`BiArSetExpression`): Handle arithmetic operations like unions and intersections, e.g., `setA.eq(setB.union(setC)).post()`.

A new interface, `SetExpression`, inspired by other Choco-Solver expressions, allows `SetVarExpression` to be used in conjunction with these expression composition objects (`UnReSetExpression`, `BiReSetExpression`, and `BiArSetExpression`).

**Backward Compatibility:**

This improvement is fully backward-compatible with existing constraints and models. It adds considerable flexibility when working with `SetVar`, and I believe it will make modeling with sets much more intuitive.

**Future Improvements:**

I believe that additional operations, such as disjoint, could also be implemented to further enhance set operations in Choco-Solver.

Finally, I've included a comprehensive suite of tests in `SetVarExpressionTest`, which I hope will be useful to validate this enhancement.

I would greatly appreciate any feedback or suggestions for optimizations, as well as any edge cases that could further improve this approach!
