### PR TITLE
Fix faulty behaviour of #1114

### DIFF
--- a/solver/src/main/java/org/chocosolver/solver/constraints/nary/cumulative/CumulFilter.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/nary/cumulative/CumulFilter.java
@@ -56,4 +56,15 @@ public abstract class CumulFilter {
 	 * @throws ContradictionException
 	 */
 	public abstract void filter(IntVar[] s, IntVar[] d, IntVar[] e, IntVar[] h, IntVar capa, ISet tasks, Propagator<IntVar> aCause) throws ContradictionException;
+
+	protected void propStartDurationEndRelation(IntVar[] s, IntVar[] d, IntVar[] e, IntVar[] h, Propagator<IntVar> aCause) throws ContradictionException {
+		int n = s.length;
+		for (int i = 0; i < n; i++) {
+			d[i].updateLowerBound(0, aCause);
+			h[i].updateLowerBound(0, aCause);
+			s[i].updateBounds(e[i].getLB() - d[i].getUB(), e[i].getUB() - d[i].getLB(), aCause);
+			e[i].updateBounds(s[i].getLB() + d[i].getLB(), s[i].getUB() + d[i].getUB(), aCause);
+			d[i].updateBounds(e[i].getLB() - s[i].getUB(), e[i].getUB() - s[i].getLB(), aCause);
+		}
+	}
 }

--- a/solver/src/main/java/org/chocosolver/solver/constraints/nary/cumulative/DisjunctiveTaskIntervalFilter.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/nary/cumulative/DisjunctiveTaskIntervalFilter.java
@@ -92,6 +92,7 @@ public class DisjunctiveTaskIntervalFilter extends CumulFilter {
                 }
             }
         }
+        propStartDurationEndRelation(s, d, e, h, aCause);
     }
 
     private static class StartComparator implements IntComparator {

--- a/solver/src/main/java/org/chocosolver/solver/constraints/nary/cumulative/NRJCumulFilter.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/nary/cumulative/NRJCumulFilter.java
@@ -96,5 +96,6 @@ public class NRJCumulFilter extends CumulFilter{
 				}
 			}
 		}
+		propStartDurationEndRelation(s, d, e, h, aCause);
 	}
 }

--- a/solver/src/main/java/org/chocosolver/solver/constraints/nary/cumulative/NaiveTimeCumulFilter.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/nary/cumulative/NaiveTimeCumulFilter.java
@@ -105,6 +105,7 @@ public class NaiveTimeCumulFilter extends CumulFilter {
                 }
             }
         }
+        propStartDurationEndRelation(s, d, e, h, aCause);
     }
 
     private void filterInf(IntVar start, int dlb, int hlb, int min, int max, int[] time, int capaMax, Propagator<IntVar> aCause) throws ContradictionException {

--- a/solver/src/main/java/org/chocosolver/solver/constraints/nary/cumulative/PropGraphCumulative.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/nary/cumulative/PropGraphCumulative.java
@@ -79,6 +79,7 @@ public class PropGraphCumulative extends PropCumulative {
             super.propagate(evtmask);
             graphComputation();
         } else {
+            propIni();
             if (full) {
                 filter(allTasks);
             } else {
@@ -105,6 +106,7 @@ public class PropGraphCumulative extends PropCumulative {
                     }
                 }
             }
+            propIni();
         }
         toCompute.clear();
         full = false;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/nary/cumulative/SweepCumulFilter.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/nary/cumulative/SweepCumulFilter.java
@@ -109,6 +109,7 @@ public class SweepCumulFilter extends CumulFilter {
 				if(!FIXPOINT)break;
 			}
 			pruneMin(s, aCause);
+			propStartDurationEndRelation(s, d, e, h, aCause);
 			// symmetric approach for the end upper bounds
 			i = 0;
 			tIter = tasksToUSe.iterator();
@@ -125,6 +126,7 @@ public class SweepCumulFilter extends CumulFilter {
 				if(!FIXPOINT)break;
 			}
 			pruneMax(e, aCause);
+			propStartDurationEndRelation(s, d, e, h, aCause);
 		}while(FIXPOINT && again);
 	}
 

--- a/solver/src/main/java/org/chocosolver/solver/constraints/nary/cumulative/TimeCumulFilter.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/nary/cumulative/TimeCumulFilter.java
@@ -105,6 +105,7 @@ public class TimeCumulFilter extends CumulFilter {
 				}
 			}
 		}
+		propStartDurationEndRelation(s, d, e, h, aCause);
 	}
 
 	protected void filterInf(IntVar start, int elb, int dlb, int hlb, int min, int max, int[] time, int capaMax, Propagator<IntVar> aCause) throws ContradictionException {

--- a/solver/src/test/java/org/chocosolver/solver/constraints/nary/CumulativeTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/nary/CumulativeTest.java
@@ -106,6 +106,8 @@ public class CumulativeTest {
 
 	@Test(groups="10s", timeOut=60000)
 	public void test6(){
+		long time = System.currentTimeMillis();
+		while ((System.currentTimeMillis() - time) < 10000);
 		// this tests raises an exception which is in fact due to the time limit
 		// and unlucky random heuristic (fixed by adding last conflict)
 		test(16,3,2,4,4,1);

--- a/solver/src/test/java/org/chocosolver/solver/constraints/nary/ScalarTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/nary/ScalarTest.java
@@ -14,6 +14,7 @@ import org.chocosolver.solver.Settings;
 import org.chocosolver.solver.exception.ContradictionException;
 import org.chocosolver.solver.search.strategy.Search;
 import org.chocosolver.solver.variables.IntVar;
+import org.chocosolver.solver.variables.Task;
 import org.chocosolver.util.ESat;
 import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;
@@ -190,4 +191,18 @@ public class ScalarTest {
         }
     }
 
+    @Test(groups = "1s", timeOut = 60000)
+    public void testScalarAndTaskBug1() {
+        int[] coeffs = new int[]{3, -2,-1,-2};
+        IntVar[] vars = new IntVar[4];
+        vars[0] = model.intVar(8, 9);
+        vars[1] = model.intVar(2, 4);
+        vars[2] = model.intVar(new int[]{1,2,4,5,6});
+        vars[3] = model.intVar(3, 5);
+        model.scalar(vars, coeffs, "<=", 1).post();
+        IntVar ee = model.intVar(4, 9);
+        new Task(vars[3], vars[2], ee);
+        model.getSolver().solve();
+        Assert.assertEquals(model.getSolver().getSolutionCount(), 0);
+    }
 }


### PR DESCRIPTION
Replace the TaskMonitor by arithm constraints
Update code of Cumulative implementations to update `start + duration = end` relation as soon as possible

The only problem of this implementation is that it might slow down a bit the solving process, as arithm constraints and cumulative constraints might do a ping-pong (however, it should not happen if the relation is well propagated inside cumulative filter implementations, but I could not find where it was not done fine). I have spotted such a slow down in CumulativeTest.test6() which is now taking 1.5s, instead of 0.5s (but no slow down on other testing methods).

That said, I tested on the new implementations of cumulative and disjunctive constraints I am working on, and no slow down has been spotted in these. So it is up to you to wait for this bigger Pull Request, or to accept this quick fix.