### PR TITLE
Update maven-test.yml

### DIFF
--- a/.github/workflows/maven-test.yml
+++ b/.github/workflows/maven-test.yml
@@ -25,7 +25,12 @@ jobs:
           java-version: '11'
           distribution: 'temurin'
           cache: 'maven'
-
+          
+      - name: Set up Python 3.10 (for Ibex)
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+      
       # Install Ibex
       - name: Install Ibex
         if: matrix.group == 'ibex'


### PR DESCRIPTION
Set up Python version

The runner version was bumped to 2.321 which rely on Ubuntu 24.4 instead of Ubuntu 22.04.  And the default version Python is 3.12 instead of 3.10, which seems to make waf fails