### PR TITLE
License : move to BSD 3-clause

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -22,7 +22,7 @@ identifiers:
     description: The concept DOI of the software
 repository-code: 'https://github.com/chocoteam/choco-solver'
 url: 'https://choco-solver.org/'
-license: BSD-4-Clause
+license: BSD-3-Clause
 preferred-citation:
   authors:
     - given-names: Charles

--- a/LICENSE
+++ b/LICENSE
@@ -1,29 +1,29 @@
-BSD 4-Clause License
+BSD 3-Clause License
 
-Copyright (c) 2026, IMT Atlantique
+Copyright (c) 2001, IMT Atlantique
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:
-1. Redistributions of source code must retain the above copyright
-   notice, this list of conditions and the following disclaimer.
-2. Redistributions in binary form must reproduce the above copyright
-   notice, this list of conditions and the following disclaimer in the
-   documentation and/or other materials provided with the distribution.
-3. All advertising materials mentioning features or use of this software
-   must display the following acknowledgement:
-   This product includes software developed by the IMT Atlantique.
-4. Neither the name of the IMT Atlantique nor the
-   names of its contributors may be used to endorse or promote products
-   derived from this software without specific prior written permission.
 
-THIS SOFTWARE IS PROVIDED BY IMT Atlantique ''AS IS'' AND ANY
-EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-DISCLAIMED. IN NO EVENT SHALL IMT Atlantique BE LIABLE FOR ANY
-DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of IMT Atlantique nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 2001, IMT Atlantique
+Copyright (c) 1999, IMT Atlantique
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Choco-solver comes with:
 
 But also, facilities to interact with the search loop, factories to help modelling, many samples, etc.
 
-Choco-solver is distributed under BSD 4-Clause License (Copyright (c) 1999-2026, IMT Atlantique).
+Choco-solver is distributed under BSD 3-Clause License (Copyright (c) 1999-2026, IMT Atlantique).
 
 Contact:
 - [Choco-solver on Discord](https://discord.gg/aH6zxa7e64)

--- a/etc/header.txt
+++ b/etc/header.txt
@@ -1,7 +1,4 @@
 This file is part of ${project}, http://choco-solver.org/
-
-Copyright (c) ${year}, ${owner}. All rights reserved.
-
-Licensed under the BSD 4-clause license.
-
+Copyright (c) ${project.inceptionYear}, ${owner}.
+SPDX-License-Identifier: BSD-3-Clause.
 See LICENSE file in the project root for full license information.

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -1,11 +1,8 @@
 <!--
 
     This file is part of examples, http://choco-solver.org/
-
-    Copyright (c) 2026, IMT Atlantique. All rights reserved.
-
-    Licensed under the BSD 4-clause license.
-
+    Copyright (c) 1999, IMT Atlantique.
+    SPDX-License-Identifier: BSD-3-Clause.
     See LICENSE file in the project root for full license information.
 
 -->

--- a/examples/src/main/java/module-info.java
+++ b/examples/src/main/java/module-info.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of examples, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 /**

--- a/examples/src/main/java/org/chocosolver/examples/AbstractProblem.java
+++ b/examples/src/main/java/org/chocosolver/examples/AbstractProblem.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of examples, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.examples;

--- a/examples/src/main/java/org/chocosolver/examples/integer/AirPlaneLanding.java
+++ b/examples/src/main/java/org/chocosolver/examples/integer/AirPlaneLanding.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of examples, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.examples.integer;

--- a/examples/src/main/java/org/chocosolver/examples/integer/AllIntervalSeries.java
+++ b/examples/src/main/java/org/chocosolver/examples/integer/AllIntervalSeries.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of examples, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.examples.integer;

--- a/examples/src/main/java/org/chocosolver/examples/integer/BACP.java
+++ b/examples/src/main/java/org/chocosolver/examples/integer/BACP.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of examples, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.examples.integer;

--- a/examples/src/main/java/org/chocosolver/examples/integer/BIBD.java
+++ b/examples/src/main/java/org/chocosolver/examples/integer/BIBD.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of examples, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.examples.integer;

--- a/examples/src/main/java/org/chocosolver/examples/integer/BinPacking.java
+++ b/examples/src/main/java/org/chocosolver/examples/integer/BinPacking.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of examples, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.examples.integer;

--- a/examples/src/main/java/org/chocosolver/examples/integer/CarSequencing.java
+++ b/examples/src/main/java/org/chocosolver/examples/integer/CarSequencing.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of examples, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.examples.integer;

--- a/examples/src/main/java/org/chocosolver/examples/integer/CostasArrays.java
+++ b/examples/src/main/java/org/chocosolver/examples/integer/CostasArrays.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of examples, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.examples.integer;

--- a/examples/src/main/java/org/chocosolver/examples/integer/CumulativeSample.java
+++ b/examples/src/main/java/org/chocosolver/examples/integer/CumulativeSample.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of examples, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 /**

--- a/examples/src/main/java/org/chocosolver/examples/integer/GolombRuler.java
+++ b/examples/src/main/java/org/chocosolver/examples/integer/GolombRuler.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of examples, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.examples.integer;

--- a/examples/src/main/java/org/chocosolver/examples/integer/Grocery.java
+++ b/examples/src/main/java/org/chocosolver/examples/integer/Grocery.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of examples, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.examples.integer;

--- a/examples/src/main/java/org/chocosolver/examples/integer/Knapsack.java
+++ b/examples/src/main/java/org/chocosolver/examples/integer/Knapsack.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of examples, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.examples.integer;

--- a/examples/src/main/java/org/chocosolver/examples/integer/Langford.java
+++ b/examples/src/main/java/org/chocosolver/examples/integer/Langford.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of examples, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.examples.integer;

--- a/examples/src/main/java/org/chocosolver/examples/integer/LatinSquare.java
+++ b/examples/src/main/java/org/chocosolver/examples/integer/LatinSquare.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of examples, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.examples.integer;

--- a/examples/src/main/java/org/chocosolver/examples/integer/MagicSequence.java
+++ b/examples/src/main/java/org/chocosolver/examples/integer/MagicSequence.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of examples, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.examples.integer;

--- a/examples/src/main/java/org/chocosolver/examples/integer/MagicSquare.java
+++ b/examples/src/main/java/org/chocosolver/examples/integer/MagicSquare.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of examples, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.examples.integer;

--- a/examples/src/main/java/org/chocosolver/examples/integer/MarioKart.java
+++ b/examples/src/main/java/org/chocosolver/examples/integer/MarioKart.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of examples, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.examples.integer;

--- a/examples/src/main/java/org/chocosolver/examples/integer/MeetingScheduling.java
+++ b/examples/src/main/java/org/chocosolver/examples/integer/MeetingScheduling.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of examples, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.examples.integer;

--- a/examples/src/main/java/org/chocosolver/examples/integer/Nonogram.java
+++ b/examples/src/main/java/org/chocosolver/examples/integer/Nonogram.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of examples, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.examples.integer;

--- a/examples/src/main/java/org/chocosolver/examples/integer/OpenStacks.java
+++ b/examples/src/main/java/org/chocosolver/examples/integer/OpenStacks.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of examples, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.examples.integer;

--- a/examples/src/main/java/org/chocosolver/examples/integer/Ordering.java
+++ b/examples/src/main/java/org/chocosolver/examples/integer/Ordering.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of examples, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.examples.integer;

--- a/examples/src/main/java/org/chocosolver/examples/integer/OrthoLatinSquare.java
+++ b/examples/src/main/java/org/chocosolver/examples/integer/OrthoLatinSquare.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of examples, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.examples.integer;

--- a/examples/src/main/java/org/chocosolver/examples/integer/Partition.java
+++ b/examples/src/main/java/org/chocosolver/examples/integer/Partition.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of examples, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.examples.integer;

--- a/examples/src/main/java/org/chocosolver/examples/integer/RLFAP.java
+++ b/examples/src/main/java/org/chocosolver/examples/integer/RLFAP.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of examples, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.examples.integer;

--- a/examples/src/main/java/org/chocosolver/examples/integer/SMPTSP.java
+++ b/examples/src/main/java/org/chocosolver/examples/integer/SMPTSP.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of examples, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.examples.integer;

--- a/examples/src/main/java/org/chocosolver/examples/integer/SchurLemma.java
+++ b/examples/src/main/java/org/chocosolver/examples/integer/SchurLemma.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of examples, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.examples.integer;

--- a/examples/src/main/java/org/chocosolver/examples/integer/Semafor.java
+++ b/examples/src/main/java/org/chocosolver/examples/integer/Semafor.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of examples, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.examples.integer;

--- a/examples/src/main/java/org/chocosolver/examples/integer/SendMoreMoney.java
+++ b/examples/src/main/java/org/chocosolver/examples/integer/SendMoreMoney.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of examples, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.examples.integer; /**

--- a/examples/src/main/java/org/chocosolver/examples/integer/SocialGolfer.java
+++ b/examples/src/main/java/org/chocosolver/examples/integer/SocialGolfer.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of examples, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.examples.integer;

--- a/examples/src/main/java/org/chocosolver/examples/integer/StableMarriage.java
+++ b/examples/src/main/java/org/chocosolver/examples/integer/StableMarriage.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of examples, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.examples.integer; /**

--- a/examples/src/main/java/org/chocosolver/examples/integer/Sudoku.java
+++ b/examples/src/main/java/org/chocosolver/examples/integer/Sudoku.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of examples, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.examples.integer;

--- a/examples/src/main/java/org/chocosolver/examples/integer/TSP.java
+++ b/examples/src/main/java/org/chocosolver/examples/integer/TSP.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of examples, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.examples.integer;

--- a/examples/src/main/java/org/chocosolver/examples/integer/Takuzu.java
+++ b/examples/src/main/java/org/chocosolver/examples/integer/Takuzu.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of examples, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.examples.integer;

--- a/examples/src/main/java/org/chocosolver/examples/integer/WarehouseLocation.java
+++ b/examples/src/main/java/org/chocosolver/examples/integer/WarehouseLocation.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of examples, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.examples.integer;

--- a/examples/src/main/java/org/chocosolver/examples/integer/Zebra.java
+++ b/examples/src/main/java/org/chocosolver/examples/integer/Zebra.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of examples, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.examples.integer;

--- a/examples/src/main/java/org/chocosolver/examples/nqueen/AbstractNQueen.java
+++ b/examples/src/main/java/org/chocosolver/examples/nqueen/AbstractNQueen.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of examples, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.examples.nqueen;

--- a/examples/src/main/java/org/chocosolver/examples/nqueen/NQueenBinary.java
+++ b/examples/src/main/java/org/chocosolver/examples/nqueen/NQueenBinary.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of examples, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.examples.nqueen;

--- a/examples/src/main/java/org/chocosolver/examples/nqueen/NQueenBinaryGlobal.java
+++ b/examples/src/main/java/org/chocosolver/examples/nqueen/NQueenBinaryGlobal.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of examples, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.examples.nqueen;

--- a/examples/src/main/java/org/chocosolver/examples/nqueen/NQueenDualBinary.java
+++ b/examples/src/main/java/org/chocosolver/examples/nqueen/NQueenDualBinary.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of examples, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.examples.nqueen;

--- a/examples/src/main/java/org/chocosolver/examples/nqueen/NQueenDualGlobal.java
+++ b/examples/src/main/java/org/chocosolver/examples/nqueen/NQueenDualGlobal.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of examples, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.examples.nqueen;

--- a/examples/src/main/java/org/chocosolver/examples/nqueen/NQueenGlobal.java
+++ b/examples/src/main/java/org/chocosolver/examples/nqueen/NQueenGlobal.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of examples, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.examples.nqueen;

--- a/examples/src/main/java/org/chocosolver/examples/nqueen/NQueenLinearBinary.java
+++ b/examples/src/main/java/org/chocosolver/examples/nqueen/NQueenLinearBinary.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of examples, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.examples.nqueen;

--- a/examples/src/main/java/org/chocosolver/examples/real/CycloHexan.java
+++ b/examples/src/main/java/org/chocosolver/examples/real/CycloHexan.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of examples, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.examples.real;

--- a/examples/src/main/java/org/chocosolver/examples/real/Grocery.java
+++ b/examples/src/main/java/org/chocosolver/examples/real/Grocery.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of examples, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.examples.real;

--- a/examples/src/main/java/org/chocosolver/examples/real/HybridCycloHexan.java
+++ b/examples/src/main/java/org/chocosolver/examples/real/HybridCycloHexan.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of examples, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.examples.real;

--- a/examples/src/main/java/org/chocosolver/examples/real/SantaClaude.java
+++ b/examples/src/main/java/org/chocosolver/examples/real/SantaClaude.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of examples, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.examples.real;

--- a/examples/src/main/java/org/chocosolver/examples/real/SmallSantaClaude.java
+++ b/examples/src/main/java/org/chocosolver/examples/real/SmallSantaClaude.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of examples, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.examples.real;

--- a/examples/src/main/java/org/chocosolver/examples/set/SetPartition.java
+++ b/examples/src/main/java/org/chocosolver/examples/set/SetPartition.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of examples, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 /**

--- a/examples/src/main/java/org/chocosolver/examples/set/SetUnion.java
+++ b/examples/src/main/java/org/chocosolver/examples/set/SetUnion.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of examples, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 /**

--- a/examples/src/main/java/org/chocosolver/examples/tutorial/AircraftLanding.java
+++ b/examples/src/main/java/org/chocosolver/examples/tutorial/AircraftLanding.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of examples, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.examples.tutorial;

--- a/examples/src/main/java/org/chocosolver/examples/tutorial/GolombRuler.java
+++ b/examples/src/main/java/org/chocosolver/examples/tutorial/GolombRuler.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of examples, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.examples.tutorial;

--- a/examples/src/test/java/org/chocosolver/examples/SamplesTest.java
+++ b/examples/src/test/java/org/chocosolver/examples/SamplesTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of examples, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.examples;

--- a/examples/src/test/java/org/chocosolver/examples/integer/CostasArraysTest.java
+++ b/examples/src/test/java/org/chocosolver/examples/integer/CostasArraysTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of examples, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.examples.integer;

--- a/examples/src/test/java/org/chocosolver/examples/integer/GolombRulerTest.java
+++ b/examples/src/test/java/org/chocosolver/examples/integer/GolombRulerTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of examples, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.examples.integer;

--- a/examples/src/test/java/org/chocosolver/examples/integer/KnapsackTest.java
+++ b/examples/src/test/java/org/chocosolver/examples/integer/KnapsackTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of examples, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.examples.integer;

--- a/examples/src/test/java/org/chocosolver/examples/integer/MagicSquareTest.java
+++ b/examples/src/test/java/org/chocosolver/examples/integer/MagicSquareTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of examples, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.examples.integer;

--- a/examples/src/test/java/org/chocosolver/examples/integer/NQueenTest.java
+++ b/examples/src/test/java/org/chocosolver/examples/integer/NQueenTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of examples, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.examples.integer;

--- a/examples/src/test/java/org/chocosolver/examples/integer/ParetoFront.java
+++ b/examples/src/test/java/org/chocosolver/examples/integer/ParetoFront.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of examples, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 /**

--- a/examples/src/test/java/org/chocosolver/examples/integer/PartitionTest.java
+++ b/examples/src/test/java/org/chocosolver/examples/integer/PartitionTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of examples, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.examples.integer;

--- a/examples/src/test/java/org/chocosolver/examples/set/SetPartitionTest.java
+++ b/examples/src/test/java/org/chocosolver/examples/set/SetPartitionTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of examples, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 /**

--- a/parsers/pom.xml
+++ b/parsers/pom.xml
@@ -1,11 +1,8 @@
 <!--
 
     This file is part of choco-parsers, http://choco-solver.org/
-
-    Copyright (c) 2026, IMT Atlantique. All rights reserved.
-
-    Licensed under the BSD 4-clause license.
-
+    Copyright (c) 1999, IMT Atlantique.
+    SPDX-License-Identifier: BSD-3-Clause.
     See LICENSE file in the project root for full license information.
 
 -->

--- a/parsers/src/main/java/module-info.java
+++ b/parsers/src/main/java/module-info.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-parsers, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 /**

--- a/parsers/src/main/java/org/chocosolver/database/MySQLAccess.java
+++ b/parsers/src/main/java/org/chocosolver/database/MySQLAccess.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-parsers, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.database;

--- a/parsers/src/main/java/org/chocosolver/parser/Exit.java
+++ b/parsers/src/main/java/org/chocosolver/parser/Exit.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-parsers, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.parser;

--- a/parsers/src/main/java/org/chocosolver/parser/IParser.java
+++ b/parsers/src/main/java/org/chocosolver/parser/IParser.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-parsers, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.parser;

--- a/parsers/src/main/java/org/chocosolver/parser/Level.java
+++ b/parsers/src/main/java/org/chocosolver/parser/Level.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-parsers, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.parser;

--- a/parsers/src/main/java/org/chocosolver/parser/Parser.java
+++ b/parsers/src/main/java/org/chocosolver/parser/Parser.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-parsers, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.parser;

--- a/parsers/src/main/java/org/chocosolver/parser/ParserException.java
+++ b/parsers/src/main/java/org/chocosolver/parser/ParserException.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-parsers, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.parser;

--- a/parsers/src/main/java/org/chocosolver/parser/ParserListener.java
+++ b/parsers/src/main/java/org/chocosolver/parser/ParserListener.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-parsers, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.parser;

--- a/parsers/src/main/java/org/chocosolver/parser/RegParser.java
+++ b/parsers/src/main/java/org/chocosolver/parser/RegParser.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-parsers, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.parser;

--- a/parsers/src/main/java/org/chocosolver/parser/SetUpException.java
+++ b/parsers/src/main/java/org/chocosolver/parser/SetUpException.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-parsers, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.parser;

--- a/parsers/src/main/java/org/chocosolver/parser/dimacs/ChocoDIMACS.java
+++ b/parsers/src/main/java/org/chocosolver/parser/dimacs/ChocoDIMACS.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-parsers, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.parser.dimacs;

--- a/parsers/src/main/java/org/chocosolver/parser/dimacs/DIMACS.java
+++ b/parsers/src/main/java/org/chocosolver/parser/dimacs/DIMACS.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-parsers, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.parser.dimacs;

--- a/parsers/src/main/java/org/chocosolver/parser/dimacs/DIMACSParser.java
+++ b/parsers/src/main/java/org/chocosolver/parser/dimacs/DIMACSParser.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-parsers, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.parser.dimacs;

--- a/parsers/src/main/java/org/chocosolver/parser/flatzinc/ChocoFZN.java
+++ b/parsers/src/main/java/org/chocosolver/parser/flatzinc/ChocoFZN.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-parsers, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.parser.flatzinc;

--- a/parsers/src/main/java/org/chocosolver/parser/flatzinc/Flatzinc.java
+++ b/parsers/src/main/java/org/chocosolver/parser/flatzinc/Flatzinc.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-parsers, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.parser.flatzinc;

--- a/parsers/src/main/java/org/chocosolver/parser/flatzinc/Flatzinc4Lexer.java
+++ b/parsers/src/main/java/org/chocosolver/parser/flatzinc/Flatzinc4Lexer.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-parsers, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 // Generated from Flatzinc4Lexer.g4 by ANTLR 4.9.3

--- a/parsers/src/main/java/org/chocosolver/parser/flatzinc/Flatzinc4Parser.java
+++ b/parsers/src/main/java/org/chocosolver/parser/flatzinc/Flatzinc4Parser.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-parsers, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 // Generated from Flatzinc4Parser.g4 by ANTLR 4.9.3

--- a/parsers/src/main/java/org/chocosolver/parser/flatzinc/PreprocessFZN.java
+++ b/parsers/src/main/java/org/chocosolver/parser/flatzinc/PreprocessFZN.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-parsers, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 /**

--- a/parsers/src/main/java/org/chocosolver/parser/flatzinc/ast/Datas.java
+++ b/parsers/src/main/java/org/chocosolver/parser/flatzinc/ast/Datas.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-parsers, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.parser.flatzinc.ast;

--- a/parsers/src/main/java/org/chocosolver/parser/flatzinc/ast/FConstraint.java
+++ b/parsers/src/main/java/org/chocosolver/parser/flatzinc/ast/FConstraint.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-parsers, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.parser.flatzinc.ast;

--- a/parsers/src/main/java/org/chocosolver/parser/flatzinc/ast/FGoal.java
+++ b/parsers/src/main/java/org/chocosolver/parser/flatzinc/ast/FGoal.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-parsers, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.parser.flatzinc.ast;

--- a/parsers/src/main/java/org/chocosolver/parser/flatzinc/ast/FParameter.java
+++ b/parsers/src/main/java/org/chocosolver/parser/flatzinc/ast/FParameter.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-parsers, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.parser.flatzinc.ast;

--- a/parsers/src/main/java/org/chocosolver/parser/flatzinc/ast/FPredParam.java
+++ b/parsers/src/main/java/org/chocosolver/parser/flatzinc/ast/FPredParam.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-parsers, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.parser.flatzinc.ast;

--- a/parsers/src/main/java/org/chocosolver/parser/flatzinc/ast/FPredicate.java
+++ b/parsers/src/main/java/org/chocosolver/parser/flatzinc/ast/FPredicate.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-parsers, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.parser.flatzinc.ast;

--- a/parsers/src/main/java/org/chocosolver/parser/flatzinc/ast/FVariable.java
+++ b/parsers/src/main/java/org/chocosolver/parser/flatzinc/ast/FVariable.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-parsers, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.parser.flatzinc.ast;

--- a/parsers/src/main/java/org/chocosolver/parser/flatzinc/ast/declaration/DArray.java
+++ b/parsers/src/main/java/org/chocosolver/parser/flatzinc/ast/declaration/DArray.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-parsers, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.parser.flatzinc.ast.declaration;

--- a/parsers/src/main/java/org/chocosolver/parser/flatzinc/ast/declaration/DBool.java
+++ b/parsers/src/main/java/org/chocosolver/parser/flatzinc/ast/declaration/DBool.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-parsers, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.parser.flatzinc.ast.declaration;

--- a/parsers/src/main/java/org/chocosolver/parser/flatzinc/ast/declaration/DFloat.java
+++ b/parsers/src/main/java/org/chocosolver/parser/flatzinc/ast/declaration/DFloat.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-parsers, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.parser.flatzinc.ast.declaration;

--- a/parsers/src/main/java/org/chocosolver/parser/flatzinc/ast/declaration/DInt.java
+++ b/parsers/src/main/java/org/chocosolver/parser/flatzinc/ast/declaration/DInt.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-parsers, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.parser.flatzinc.ast.declaration;

--- a/parsers/src/main/java/org/chocosolver/parser/flatzinc/ast/declaration/DInt2.java
+++ b/parsers/src/main/java/org/chocosolver/parser/flatzinc/ast/declaration/DInt2.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-parsers, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.parser.flatzinc.ast.declaration;

--- a/parsers/src/main/java/org/chocosolver/parser/flatzinc/ast/declaration/DManyInt.java
+++ b/parsers/src/main/java/org/chocosolver/parser/flatzinc/ast/declaration/DManyInt.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-parsers, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.parser.flatzinc.ast.declaration;

--- a/parsers/src/main/java/org/chocosolver/parser/flatzinc/ast/declaration/DSet.java
+++ b/parsers/src/main/java/org/chocosolver/parser/flatzinc/ast/declaration/DSet.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-parsers, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.parser.flatzinc.ast.declaration;

--- a/parsers/src/main/java/org/chocosolver/parser/flatzinc/ast/declaration/DSetOfInt.java
+++ b/parsers/src/main/java/org/chocosolver/parser/flatzinc/ast/declaration/DSetOfInt.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-parsers, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.parser.flatzinc.ast.declaration;

--- a/parsers/src/main/java/org/chocosolver/parser/flatzinc/ast/declaration/Declaration.java
+++ b/parsers/src/main/java/org/chocosolver/parser/flatzinc/ast/declaration/Declaration.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-parsers, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.parser.flatzinc.ast.declaration;

--- a/parsers/src/main/java/org/chocosolver/parser/flatzinc/ast/expression/EAnnotation.java
+++ b/parsers/src/main/java/org/chocosolver/parser/flatzinc/ast/expression/EAnnotation.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-parsers, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.parser.flatzinc.ast.expression;

--- a/parsers/src/main/java/org/chocosolver/parser/flatzinc/ast/expression/EArray.java
+++ b/parsers/src/main/java/org/chocosolver/parser/flatzinc/ast/expression/EArray.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-parsers, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.parser.flatzinc.ast.expression;

--- a/parsers/src/main/java/org/chocosolver/parser/flatzinc/ast/expression/EBool.java
+++ b/parsers/src/main/java/org/chocosolver/parser/flatzinc/ast/expression/EBool.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-parsers, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.parser.flatzinc.ast.expression;

--- a/parsers/src/main/java/org/chocosolver/parser/flatzinc/ast/expression/EFloat.java
+++ b/parsers/src/main/java/org/chocosolver/parser/flatzinc/ast/expression/EFloat.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-parsers, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.parser.flatzinc.ast.expression;

--- a/parsers/src/main/java/org/chocosolver/parser/flatzinc/ast/expression/EIdArray.java
+++ b/parsers/src/main/java/org/chocosolver/parser/flatzinc/ast/expression/EIdArray.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-parsers, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.parser.flatzinc.ast.expression;

--- a/parsers/src/main/java/org/chocosolver/parser/flatzinc/ast/expression/EIdentifier.java
+++ b/parsers/src/main/java/org/chocosolver/parser/flatzinc/ast/expression/EIdentifier.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-parsers, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.parser.flatzinc.ast.expression;

--- a/parsers/src/main/java/org/chocosolver/parser/flatzinc/ast/expression/EInt.java
+++ b/parsers/src/main/java/org/chocosolver/parser/flatzinc/ast/expression/EInt.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-parsers, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.parser.flatzinc.ast.expression;

--- a/parsers/src/main/java/org/chocosolver/parser/flatzinc/ast/expression/ESet.java
+++ b/parsers/src/main/java/org/chocosolver/parser/flatzinc/ast/expression/ESet.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-parsers, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.parser.flatzinc.ast.expression;

--- a/parsers/src/main/java/org/chocosolver/parser/flatzinc/ast/expression/ESetBounds.java
+++ b/parsers/src/main/java/org/chocosolver/parser/flatzinc/ast/expression/ESetBounds.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-parsers, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.parser.flatzinc.ast.expression;

--- a/parsers/src/main/java/org/chocosolver/parser/flatzinc/ast/expression/ESetList.java
+++ b/parsers/src/main/java/org/chocosolver/parser/flatzinc/ast/expression/ESetList.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-parsers, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.parser.flatzinc.ast.expression;

--- a/parsers/src/main/java/org/chocosolver/parser/flatzinc/ast/expression/EString.java
+++ b/parsers/src/main/java/org/chocosolver/parser/flatzinc/ast/expression/EString.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-parsers, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.parser.flatzinc.ast.expression;

--- a/parsers/src/main/java/org/chocosolver/parser/flatzinc/ast/expression/Expression.java
+++ b/parsers/src/main/java/org/chocosolver/parser/flatzinc/ast/expression/Expression.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-parsers, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.parser.flatzinc.ast.expression;

--- a/parsers/src/main/java/org/chocosolver/parser/flatzinc/ast/propagators/PropBoolSumEq0Reif.java
+++ b/parsers/src/main/java/org/chocosolver/parser/flatzinc/ast/propagators/PropBoolSumEq0Reif.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-parsers, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.parser.flatzinc.ast.propagators;

--- a/parsers/src/main/java/org/chocosolver/parser/flatzinc/ast/searches/Assignment.java
+++ b/parsers/src/main/java/org/chocosolver/parser/flatzinc/ast/searches/Assignment.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-parsers, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.parser.flatzinc.ast.searches;

--- a/parsers/src/main/java/org/chocosolver/parser/flatzinc/ast/searches/IntSearch.java
+++ b/parsers/src/main/java/org/chocosolver/parser/flatzinc/ast/searches/IntSearch.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-parsers, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.parser.flatzinc.ast.searches;

--- a/parsers/src/main/java/org/chocosolver/parser/flatzinc/ast/searches/SetSearch.java
+++ b/parsers/src/main/java/org/chocosolver/parser/flatzinc/ast/searches/SetSearch.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-parsers, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.parser.flatzinc.ast.searches;

--- a/parsers/src/main/java/org/chocosolver/parser/flatzinc/ast/searches/Strategy.java
+++ b/parsers/src/main/java/org/chocosolver/parser/flatzinc/ast/searches/Strategy.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-parsers, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.parser.flatzinc.ast.searches;

--- a/parsers/src/main/java/org/chocosolver/parser/flatzinc/ast/searches/VarChoice.java
+++ b/parsers/src/main/java/org/chocosolver/parser/flatzinc/ast/searches/VarChoice.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-parsers, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.parser.flatzinc.ast.searches;

--- a/parsers/src/main/java/org/chocosolver/parser/handlers/LimitHandler.java
+++ b/parsers/src/main/java/org/chocosolver/parser/handlers/LimitHandler.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-parsers, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.parser.handlers;

--- a/parsers/src/main/java/org/chocosolver/parser/handlers/RestartHandler.java
+++ b/parsers/src/main/java/org/chocosolver/parser/handlers/RestartHandler.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-parsers, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.parser.handlers;

--- a/parsers/src/main/java/org/chocosolver/parser/handlers/ValSelHandler.java
+++ b/parsers/src/main/java/org/chocosolver/parser/handlers/ValSelHandler.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-parsers, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.parser.handlers;

--- a/parsers/src/main/java/org/chocosolver/parser/handlers/VarSelHandler.java
+++ b/parsers/src/main/java/org/chocosolver/parser/handlers/VarSelHandler.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-parsers, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.parser.handlers;

--- a/parsers/src/main/java/org/chocosolver/parser/mps/ChocoMPS.java
+++ b/parsers/src/main/java/org/chocosolver/parser/mps/ChocoMPS.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-parsers, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.parser.mps;

--- a/parsers/src/main/java/org/chocosolver/parser/mps/MPS.java
+++ b/parsers/src/main/java/org/chocosolver/parser/mps/MPS.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-parsers, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.parser.mps;

--- a/parsers/src/main/java/org/chocosolver/parser/mps/MPSParser.java
+++ b/parsers/src/main/java/org/chocosolver/parser/mps/MPSParser.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-parsers, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.parser.mps;

--- a/parsers/src/main/java/org/chocosolver/parser/xcsp/ChocoXCSP.java
+++ b/parsers/src/main/java/org/chocosolver/parser/xcsp/ChocoXCSP.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-parsers, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.parser.xcsp;

--- a/parsers/src/main/java/org/chocosolver/parser/xcsp/XCSP.java
+++ b/parsers/src/main/java/org/chocosolver/parser/xcsp/XCSP.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-parsers, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.parser.xcsp;

--- a/parsers/src/main/java/org/chocosolver/parser/xcsp/XCSPParser.java
+++ b/parsers/src/main/java/org/chocosolver/parser/xcsp/XCSPParser.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-parsers, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.parser.xcsp;

--- a/parsers/src/test/java/org/chocosolver/dimacs/ParserTest.java
+++ b/parsers/src/test/java/org/chocosolver/dimacs/ParserTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-parsers, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.dimacs;

--- a/parsers/src/test/java/org/chocosolver/flatzinc/PerformanceTest.java
+++ b/parsers/src/test/java/org/chocosolver/flatzinc/PerformanceTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-parsers, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.flatzinc;

--- a/parsers/src/test/java/org/chocosolver/flatzinc/RegressionTest.java
+++ b/parsers/src/test/java/org/chocosolver/flatzinc/RegressionTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-parsers, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.flatzinc;

--- a/parsers/src/test/java/org/chocosolver/mps/ParserTest.java
+++ b/parsers/src/test/java/org/chocosolver/mps/ParserTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-parsers, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.mps;

--- a/parsers/src/test/java/org/chocosolver/parser/PerformanceListener.java
+++ b/parsers/src/test/java/org/chocosolver/parser/PerformanceListener.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-parsers, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.parser;

--- a/parsers/src/test/java/org/chocosolver/parser/PerformanceTest.java
+++ b/parsers/src/test/java/org/chocosolver/parser/PerformanceTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-parsers, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.parser;

--- a/parsers/src/test/java/org/chocosolver/parser/RegParserTest.java
+++ b/parsers/src/test/java/org/chocosolver/parser/RegParserTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-parsers, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.parser;

--- a/parsers/src/test/java/org/chocosolver/parser/flatzinc/FlatzincModelTest.java
+++ b/parsers/src/test/java/org/chocosolver/parser/flatzinc/FlatzincModelTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-parsers, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.parser.flatzinc;

--- a/parsers/src/test/java/org/chocosolver/parser/flatzinc/parser/GrammarTest.java
+++ b/parsers/src/test/java/org/chocosolver/parser/flatzinc/parser/GrammarTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-parsers, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.parser.flatzinc.parser;

--- a/parsers/src/test/java/org/chocosolver/parser/flatzinc/parser/RandomPhrase.java
+++ b/parsers/src/test/java/org/chocosolver/parser/flatzinc/parser/RandomPhrase.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-parsers, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.parser.flatzinc.parser;

--- a/parsers/src/test/java/org/chocosolver/parser/flatzinc/parser/T_annotation.java
+++ b/parsers/src/test/java/org/chocosolver/parser/flatzinc/parser/T_annotation.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-parsers, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.parser.flatzinc.parser;

--- a/parsers/src/test/java/org/chocosolver/parser/flatzinc/parser/T_annotations.java
+++ b/parsers/src/test/java/org/chocosolver/parser/flatzinc/parser/T_annotations.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-parsers, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.parser.flatzinc.parser;

--- a/parsers/src/test/java/org/chocosolver/parser/flatzinc/parser/T_bool_const.java
+++ b/parsers/src/test/java/org/chocosolver/parser/flatzinc/parser/T_bool_const.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-parsers, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.parser.flatzinc.parser;

--- a/parsers/src/test/java/org/chocosolver/parser/flatzinc/parser/T_constraint.java
+++ b/parsers/src/test/java/org/chocosolver/parser/flatzinc/parser/T_constraint.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-parsers, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.parser.flatzinc.parser;

--- a/parsers/src/test/java/org/chocosolver/parser/flatzinc/parser/T_expr.java
+++ b/parsers/src/test/java/org/chocosolver/parser/flatzinc/parser/T_expr.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-parsers, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.parser.flatzinc.parser;

--- a/parsers/src/test/java/org/chocosolver/parser/flatzinc/parser/T_flatzinc_model.java
+++ b/parsers/src/test/java/org/chocosolver/parser/flatzinc/parser/T_flatzinc_model.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-parsers, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.parser.flatzinc.parser;

--- a/parsers/src/test/java/org/chocosolver/parser/flatzinc/parser/T_index_set.java
+++ b/parsers/src/test/java/org/chocosolver/parser/flatzinc/parser/T_index_set.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-parsers, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.parser.flatzinc.parser;

--- a/parsers/src/test/java/org/chocosolver/parser/flatzinc/parser/T_par_type.java
+++ b/parsers/src/test/java/org/chocosolver/parser/flatzinc/parser/T_par_type.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-parsers, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.parser.flatzinc.parser;

--- a/parsers/src/test/java/org/chocosolver/parser/flatzinc/parser/T_par_type_u.java
+++ b/parsers/src/test/java/org/chocosolver/parser/flatzinc/parser/T_par_type_u.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-parsers, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.parser.flatzinc.parser;

--- a/parsers/src/test/java/org/chocosolver/parser/flatzinc/parser/T_param_decl.java
+++ b/parsers/src/test/java/org/chocosolver/parser/flatzinc/parser/T_param_decl.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-parsers, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.parser.flatzinc.parser;

--- a/parsers/src/test/java/org/chocosolver/parser/flatzinc/parser/T_solve_goal.java
+++ b/parsers/src/test/java/org/chocosolver/parser/flatzinc/parser/T_solve_goal.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-parsers, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.parser.flatzinc.parser;

--- a/parsers/src/test/java/org/chocosolver/parser/flatzinc/parser/T_var_decl.java
+++ b/parsers/src/test/java/org/chocosolver/parser/flatzinc/parser/T_var_decl.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-parsers, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.parser.flatzinc.parser;

--- a/parsers/src/test/java/org/chocosolver/parser/flatzinc/parser/T_var_type.java
+++ b/parsers/src/test/java/org/chocosolver/parser/flatzinc/parser/T_var_type.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-parsers, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.parser.flatzinc.parser;

--- a/parsers/src/test/java/org/chocosolver/parser/flatzinc/parser/T_var_type_u.java
+++ b/parsers/src/test/java/org/chocosolver/parser/flatzinc/parser/T_var_type_u.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-parsers, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.parser.flatzinc.parser;

--- a/parsers/src/test/java/org/chocosolver/xscp/PerformanceTest.java
+++ b/parsers/src/test/java/org/chocosolver/xscp/PerformanceTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-parsers, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.xscp;

--- a/pom.xml
+++ b/pom.xml
@@ -2,11 +2,8 @@
 <!--
 
     This file is part of choco, http://choco-solver.org/
-
-    Copyright (c) 2026, IMT Atlantique. All rights reserved.
-
-    Licensed under the BSD 4-clause license.
-
+    Copyright (c) 1999, IMT Atlantique.
+    SPDX-License-Identifier: BSD-3-Clause.
     See LICENSE file in the project root for full license information.
 
 -->
@@ -22,6 +19,13 @@
     <description>
         A Free and Open-Source library dedicated to Constraint Programming.
     </description>
+    <inceptionYear>1999</inceptionYear>
+    <licenses>
+        <license>
+            <name>BSD-3-Clause</name>
+            <url>https://spdx.org/licenses/BSD-3-Clause.html</url>
+        </license>
+    </licenses>
 
     <modules>
         <module>solver</module>
@@ -75,13 +79,6 @@
         <developerConnection>scm:git:git@github.com:chocoteam/choco-solver.git</developerConnection>
         <tag>HEAD</tag>
     </scm>
-
-    <licenses>
-        <license>
-            <name>BSD 4-Clause License</name>
-            <url>https://spdx.org/licenses/BSD-4-Clause.html</url>
-        </license>
-    </licenses>
 
     <developers>
         <developer>
@@ -375,7 +372,7 @@
             <plugin>
                 <groupId>com.mycila</groupId>
                 <artifactId>license-maven-plugin</artifactId>
-                <version>4.1</version>
+                <version>4.3</version>
                 <configuration>
                     <header>${main_dir}/etc/header.txt</header>
                     <!--<header>LICENSE</header>-->

--- a/scripts/set_version.sh
+++ b/scripts/set_version.sh
@@ -36,7 +36,7 @@ then
 
     sedInPlace "s%Current stable version is .*.%Current stable version is $VERSION ($d).%"  README.md
     sedInPlace "s%<version>.*</version>%<version>$VERSION</version>%"  README.md
-    sedInPlace "s%Choco-solver is distributed.*.%Choco-solver is distributed under BSD 4-Clause License \(Copyright \(c\) 1999-$YEAR, IMT Atlantique).%"  README.md
+    sedInPlace "s%Choco-solver is distributed.*.%Choco-solver is distributed under BSD 3-Clause License \(Copyright \(c\) 1999-$YEAR, IMT Atlantique).%"  README.md
 
     ## The LICENSE
     sedInPlace "s%Copyright.*.%Copyright (c) $YEAR, IMT Atlantique%"  LICENSE

--- a/solver/pom.xml
+++ b/solver/pom.xml
@@ -2,11 +2,8 @@
 <!--
 
     This file is part of choco-solver, http://choco-solver.org/
-
-    Copyright (c) 2026, IMT Atlantique. All rights reserved.
-
-    Licensed under the BSD 4-clause license.
-
+    Copyright (c) 1999, IMT Atlantique.
+    SPDX-License-Identifier: BSD-3-Clause.
     See LICENSE file in the project root for full license information.
 
 -->

--- a/solver/src/main/java/module-info.java
+++ b/solver/src/main/java/module-info.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 /**

--- a/solver/src/main/java/org/chocosolver/lp/LinearProgram.java
+++ b/solver/src/main/java/org/chocosolver/lp/LinearProgram.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.lp;

--- a/solver/src/main/java/org/chocosolver/lp/MILP.java
+++ b/solver/src/main/java/org/chocosolver/lp/MILP.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.lp;

--- a/solver/src/main/java/org/chocosolver/memory/AbstractEnvironment.java
+++ b/solver/src/main/java/org/chocosolver/memory/AbstractEnvironment.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.memory;

--- a/solver/src/main/java/org/chocosolver/memory/EnvironmentBuilder.java
+++ b/solver/src/main/java/org/chocosolver/memory/EnvironmentBuilder.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.memory;

--- a/solver/src/main/java/org/chocosolver/memory/IEnvironment.java
+++ b/solver/src/main/java/org/chocosolver/memory/IEnvironment.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.memory;

--- a/solver/src/main/java/org/chocosolver/memory/IStateBitSet.java
+++ b/solver/src/main/java/org/chocosolver/memory/IStateBitSet.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.memory;

--- a/solver/src/main/java/org/chocosolver/memory/IStateBool.java
+++ b/solver/src/main/java/org/chocosolver/memory/IStateBool.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.memory;

--- a/solver/src/main/java/org/chocosolver/memory/IStateDouble.java
+++ b/solver/src/main/java/org/chocosolver/memory/IStateDouble.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.memory;

--- a/solver/src/main/java/org/chocosolver/memory/IStateDoubleVector.java
+++ b/solver/src/main/java/org/chocosolver/memory/IStateDoubleVector.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.memory;

--- a/solver/src/main/java/org/chocosolver/memory/IStateInt.java
+++ b/solver/src/main/java/org/chocosolver/memory/IStateInt.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.memory;

--- a/solver/src/main/java/org/chocosolver/memory/IStateIntVector.java
+++ b/solver/src/main/java/org/chocosolver/memory/IStateIntVector.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.memory;

--- a/solver/src/main/java/org/chocosolver/memory/IStateLong.java
+++ b/solver/src/main/java/org/chocosolver/memory/IStateLong.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.memory;

--- a/solver/src/main/java/org/chocosolver/memory/IStorage.java
+++ b/solver/src/main/java/org/chocosolver/memory/IStorage.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.memory;

--- a/solver/src/main/java/org/chocosolver/memory/structure/BasicIndexedBipartiteSet.java
+++ b/solver/src/main/java/org/chocosolver/memory/structure/BasicIndexedBipartiteSet.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.memory.structure;

--- a/solver/src/main/java/org/chocosolver/memory/structure/IOperation.java
+++ b/solver/src/main/java/org/chocosolver/memory/structure/IOperation.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.memory.structure;

--- a/solver/src/main/java/org/chocosolver/memory/structure/IndexedObject.java
+++ b/solver/src/main/java/org/chocosolver/memory/structure/IndexedObject.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.memory.structure;

--- a/solver/src/main/java/org/chocosolver/memory/structure/OneWordS32BitSet.java
+++ b/solver/src/main/java/org/chocosolver/memory/structure/OneWordS32BitSet.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.memory.structure;

--- a/solver/src/main/java/org/chocosolver/memory/structure/OneWordS64BitSet.java
+++ b/solver/src/main/java/org/chocosolver/memory/structure/OneWordS64BitSet.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.memory.structure;

--- a/solver/src/main/java/org/chocosolver/memory/structure/S64BitSet.java
+++ b/solver/src/main/java/org/chocosolver/memory/structure/S64BitSet.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.memory.structure;

--- a/solver/src/main/java/org/chocosolver/memory/structure/SparseBitSet.java
+++ b/solver/src/main/java/org/chocosolver/memory/structure/SparseBitSet.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.memory.structure;

--- a/solver/src/main/java/org/chocosolver/memory/trailing/EnvironmentTrailing.java
+++ b/solver/src/main/java/org/chocosolver/memory/trailing/EnvironmentTrailing.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.memory.trailing;

--- a/solver/src/main/java/org/chocosolver/memory/trailing/StoredBool.java
+++ b/solver/src/main/java/org/chocosolver/memory/trailing/StoredBool.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.memory.trailing;

--- a/solver/src/main/java/org/chocosolver/memory/trailing/StoredDouble.java
+++ b/solver/src/main/java/org/chocosolver/memory/trailing/StoredDouble.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.memory.trailing;

--- a/solver/src/main/java/org/chocosolver/memory/trailing/StoredDoubleVector.java
+++ b/solver/src/main/java/org/chocosolver/memory/trailing/StoredDoubleVector.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.memory.trailing;

--- a/solver/src/main/java/org/chocosolver/memory/trailing/StoredInt.java
+++ b/solver/src/main/java/org/chocosolver/memory/trailing/StoredInt.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.memory.trailing;

--- a/solver/src/main/java/org/chocosolver/memory/trailing/StoredIntVector.java
+++ b/solver/src/main/java/org/chocosolver/memory/trailing/StoredIntVector.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.memory.trailing;

--- a/solver/src/main/java/org/chocosolver/memory/trailing/StoredLong.java
+++ b/solver/src/main/java/org/chocosolver/memory/trailing/StoredLong.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.memory.trailing;

--- a/solver/src/main/java/org/chocosolver/memory/trailing/trail/IOperationTrail.java
+++ b/solver/src/main/java/org/chocosolver/memory/trailing/trail/IOperationTrail.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.memory.trailing.trail;

--- a/solver/src/main/java/org/chocosolver/memory/trailing/trail/IStoredBoolTrail.java
+++ b/solver/src/main/java/org/chocosolver/memory/trailing/trail/IStoredBoolTrail.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.memory.trailing.trail;

--- a/solver/src/main/java/org/chocosolver/memory/trailing/trail/IStoredDoubleTrail.java
+++ b/solver/src/main/java/org/chocosolver/memory/trailing/trail/IStoredDoubleTrail.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.memory.trailing.trail;

--- a/solver/src/main/java/org/chocosolver/memory/trailing/trail/IStoredIntTrail.java
+++ b/solver/src/main/java/org/chocosolver/memory/trailing/trail/IStoredIntTrail.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.memory.trailing.trail;

--- a/solver/src/main/java/org/chocosolver/memory/trailing/trail/IStoredLongTrail.java
+++ b/solver/src/main/java/org/chocosolver/memory/trailing/trail/IStoredLongTrail.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.memory.trailing.trail;

--- a/solver/src/main/java/org/chocosolver/memory/trailing/trail/StoredDoubleVectorTrail.java
+++ b/solver/src/main/java/org/chocosolver/memory/trailing/trail/StoredDoubleVectorTrail.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.memory.trailing.trail;

--- a/solver/src/main/java/org/chocosolver/memory/trailing/trail/StoredIntVectorTrail.java
+++ b/solver/src/main/java/org/chocosolver/memory/trailing/trail/StoredIntVectorTrail.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.memory.trailing.trail;

--- a/solver/src/main/java/org/chocosolver/memory/trailing/trail/chunck/BoolWorld.java
+++ b/solver/src/main/java/org/chocosolver/memory/trailing/trail/chunck/BoolWorld.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.memory.trailing.trail.chunck;

--- a/solver/src/main/java/org/chocosolver/memory/trailing/trail/chunck/ChunckedBoolTrail.java
+++ b/solver/src/main/java/org/chocosolver/memory/trailing/trail/chunck/ChunckedBoolTrail.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.memory.trailing.trail.chunck;

--- a/solver/src/main/java/org/chocosolver/memory/trailing/trail/chunck/ChunckedDoubleTrail.java
+++ b/solver/src/main/java/org/chocosolver/memory/trailing/trail/chunck/ChunckedDoubleTrail.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.memory.trailing.trail.chunck;

--- a/solver/src/main/java/org/chocosolver/memory/trailing/trail/chunck/ChunckedIntTrail.java
+++ b/solver/src/main/java/org/chocosolver/memory/trailing/trail/chunck/ChunckedIntTrail.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.memory.trailing.trail.chunck;

--- a/solver/src/main/java/org/chocosolver/memory/trailing/trail/chunck/ChunckedLongTrail.java
+++ b/solver/src/main/java/org/chocosolver/memory/trailing/trail/chunck/ChunckedLongTrail.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.memory.trailing.trail.chunck;

--- a/solver/src/main/java/org/chocosolver/memory/trailing/trail/chunck/ChunckedOperationTrail.java
+++ b/solver/src/main/java/org/chocosolver/memory/trailing/trail/chunck/ChunckedOperationTrail.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.memory.trailing.trail.chunck;

--- a/solver/src/main/java/org/chocosolver/memory/trailing/trail/chunck/ChunckedTrail.java
+++ b/solver/src/main/java/org/chocosolver/memory/trailing/trail/chunck/ChunckedTrail.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.memory.trailing.trail.chunck;

--- a/solver/src/main/java/org/chocosolver/memory/trailing/trail/chunck/DoubleWorld.java
+++ b/solver/src/main/java/org/chocosolver/memory/trailing/trail/chunck/DoubleWorld.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.memory.trailing.trail.chunck;

--- a/solver/src/main/java/org/chocosolver/memory/trailing/trail/chunck/IntWorld.java
+++ b/solver/src/main/java/org/chocosolver/memory/trailing/trail/chunck/IntWorld.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.memory.trailing.trail.chunck;

--- a/solver/src/main/java/org/chocosolver/memory/trailing/trail/chunck/LongWorld.java
+++ b/solver/src/main/java/org/chocosolver/memory/trailing/trail/chunck/LongWorld.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.memory.trailing.trail.chunck;

--- a/solver/src/main/java/org/chocosolver/memory/trailing/trail/chunck/OperationWorld.java
+++ b/solver/src/main/java/org/chocosolver/memory/trailing/trail/chunck/OperationWorld.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.memory.trailing.trail.chunck;

--- a/solver/src/main/java/org/chocosolver/memory/trailing/trail/chunck/World.java
+++ b/solver/src/main/java/org/chocosolver/memory/trailing/trail/chunck/World.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.memory.trailing.trail.chunck;

--- a/solver/src/main/java/org/chocosolver/memory/trailing/trail/flatten/OperationTrail.java
+++ b/solver/src/main/java/org/chocosolver/memory/trailing/trail/flatten/OperationTrail.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.memory.trailing.trail.flatten;

--- a/solver/src/main/java/org/chocosolver/memory/trailing/trail/flatten/StoredBoolTrail.java
+++ b/solver/src/main/java/org/chocosolver/memory/trailing/trail/flatten/StoredBoolTrail.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.memory.trailing.trail.flatten;

--- a/solver/src/main/java/org/chocosolver/memory/trailing/trail/flatten/StoredDoubleTrail.java
+++ b/solver/src/main/java/org/chocosolver/memory/trailing/trail/flatten/StoredDoubleTrail.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.memory.trailing.trail.flatten;

--- a/solver/src/main/java/org/chocosolver/memory/trailing/trail/flatten/StoredIntTrail.java
+++ b/solver/src/main/java/org/chocosolver/memory/trailing/trail/flatten/StoredIntTrail.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.memory.trailing.trail.flatten;

--- a/solver/src/main/java/org/chocosolver/memory/trailing/trail/flatten/StoredLongTrail.java
+++ b/solver/src/main/java/org/chocosolver/memory/trailing/trail/flatten/StoredLongTrail.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.memory.trailing.trail.flatten;

--- a/solver/src/main/java/org/chocosolver/sat/ArrayClause.java
+++ b/solver/src/main/java/org/chocosolver/sat/ArrayClause.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.sat;

--- a/solver/src/main/java/org/chocosolver/sat/Clause.java
+++ b/solver/src/main/java/org/chocosolver/sat/Clause.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.sat;

--- a/solver/src/main/java/org/chocosolver/sat/Dimacs.java
+++ b/solver/src/main/java/org/chocosolver/sat/Dimacs.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.sat;

--- a/solver/src/main/java/org/chocosolver/sat/IReasonManager.java
+++ b/solver/src/main/java/org/chocosolver/sat/IReasonManager.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.sat;

--- a/solver/src/main/java/org/chocosolver/sat/IndexBasedReason.java
+++ b/solver/src/main/java/org/chocosolver/sat/IndexBasedReason.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.sat;

--- a/solver/src/main/java/org/chocosolver/sat/Literalizer.java
+++ b/solver/src/main/java/org/chocosolver/sat/Literalizer.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.sat;

--- a/solver/src/main/java/org/chocosolver/sat/MiniSat.java
+++ b/solver/src/main/java/org/chocosolver/sat/MiniSat.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.sat;

--- a/solver/src/main/java/org/chocosolver/sat/MiniSatSolver.java
+++ b/solver/src/main/java/org/chocosolver/sat/MiniSatSolver.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.sat;

--- a/solver/src/main/java/org/chocosolver/sat/Reason.java
+++ b/solver/src/main/java/org/chocosolver/sat/Reason.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.sat;

--- a/solver/src/main/java/org/chocosolver/sat/SatDecorator.java
+++ b/solver/src/main/java/org/chocosolver/sat/SatDecorator.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.sat;

--- a/solver/src/main/java/org/chocosolver/sat/SatFactory.java
+++ b/solver/src/main/java/org/chocosolver/sat/SatFactory.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.sat;

--- a/solver/src/main/java/org/chocosolver/solver/Cause.java
+++ b/solver/src/main/java/org/chocosolver/solver/Cause.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver;

--- a/solver/src/main/java/org/chocosolver/solver/ICause.java
+++ b/solver/src/main/java/org/chocosolver/solver/ICause.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver;

--- a/solver/src/main/java/org/chocosolver/solver/IModel.java
+++ b/solver/src/main/java/org/chocosolver/solver/IModel.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver;

--- a/solver/src/main/java/org/chocosolver/solver/ISelf.java
+++ b/solver/src/main/java/org/chocosolver/solver/ISelf.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver;

--- a/solver/src/main/java/org/chocosolver/solver/ISolver.java
+++ b/solver/src/main/java/org/chocosolver/solver/ISolver.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver;

--- a/solver/src/main/java/org/chocosolver/solver/Identity.java
+++ b/solver/src/main/java/org/chocosolver/solver/Identity.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver;

--- a/solver/src/main/java/org/chocosolver/solver/Model.java
+++ b/solver/src/main/java/org/chocosolver/solver/Model.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver;

--- a/solver/src/main/java/org/chocosolver/solver/ModelAnalyser.java
+++ b/solver/src/main/java/org/chocosolver/solver/ModelAnalyser.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver;

--- a/solver/src/main/java/org/chocosolver/solver/ParallelPortfolio.java
+++ b/solver/src/main/java/org/chocosolver/solver/ParallelPortfolio.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver;

--- a/solver/src/main/java/org/chocosolver/solver/Priority.java
+++ b/solver/src/main/java/org/chocosolver/solver/Priority.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver;

--- a/solver/src/main/java/org/chocosolver/solver/QuickXPlain.java
+++ b/solver/src/main/java/org/chocosolver/solver/QuickXPlain.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver;

--- a/solver/src/main/java/org/chocosolver/solver/ResolutionPolicy.java
+++ b/solver/src/main/java/org/chocosolver/solver/ResolutionPolicy.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver;

--- a/solver/src/main/java/org/chocosolver/solver/Settings.java
+++ b/solver/src/main/java/org/chocosolver/solver/Settings.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver;

--- a/solver/src/main/java/org/chocosolver/solver/SettingsBuilder.java
+++ b/solver/src/main/java/org/chocosolver/solver/SettingsBuilder.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver;

--- a/solver/src/main/java/org/chocosolver/solver/Solution.java
+++ b/solver/src/main/java/org/chocosolver/solver/Solution.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver;

--- a/solver/src/main/java/org/chocosolver/solver/Solver.java
+++ b/solver/src/main/java/org/chocosolver/solver/Solver.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/Arithmetic.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/Arithmetic.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/Constraint.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/Constraint.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/ConstraintsName.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/ConstraintsName.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/Explained.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/Explained.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/IConstraintFactory.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/IConstraintFactory.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/IDecompositionFactory.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/IDecompositionFactory.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/IGraphConstraintFactory.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/IGraphConstraintFactory.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/IIntConstraintFactory.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/IIntConstraintFactory.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/IRealConstraintFactory.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/IRealConstraintFactory.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/IReificationFactory.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/IReificationFactory.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/ISatFactory.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/ISatFactory.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/ISchedulingFactory.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/ISchedulingFactory.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/ISetConstraintFactory.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/ISetConstraintFactory.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/ImpliedConstraint.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/ImpliedConstraint.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/Operator.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/Operator.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/Propagator.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/Propagator.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/PropagatorPriority.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/PropagatorPriority.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/ReificationConstraint.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/ReificationConstraint.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/UpdatablePropagator.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/UpdatablePropagator.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/binary/PropAbsolute.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/binary/PropAbsolute.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.binary;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/binary/PropAbsoluteLight.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/binary/PropAbsoluteLight.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.binary;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/binary/PropDistanceXYC.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/binary/PropDistanceXYC.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.binary;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/binary/PropEqualXY_C.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/binary/PropEqualXY_C.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.binary;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/binary/PropEqualX_Y.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/binary/PropEqualX_Y.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.binary;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/binary/PropEqualX_YC.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/binary/PropEqualX_YC.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.binary;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/binary/PropGreaterOrEqualXY_C.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/binary/PropGreaterOrEqualXY_C.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.binary;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/binary/PropGreaterOrEqualX_Y.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/binary/PropGreaterOrEqualX_Y.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.binary;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/binary/PropGreaterOrEqualX_YC.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/binary/PropGreaterOrEqualX_YC.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.binary;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/binary/PropLessOrEqualXY_C.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/binary/PropLessOrEqualXY_C.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.binary;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/binary/PropModXY.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/binary/PropModXY.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.binary;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/binary/PropNotEqualXY_C.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/binary/PropNotEqualXY_C.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.binary;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/binary/PropNotEqualX_Y.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/binary/PropNotEqualX_Y.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.binary;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/binary/PropNotEqualX_YC.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/binary/PropNotEqualX_YC.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.binary;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/binary/PropPowEven.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/binary/PropPowEven.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.binary;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/binary/PropPowOdd.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/binary/PropPowOdd.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.binary;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/binary/PropScale.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/binary/PropScale.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.binary;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/binary/element/ElementFactory.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/binary/element/ElementFactory.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.binary.element;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/binary/element/PropElement.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/binary/element/PropElement.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.binary.element;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/extension/TupleEvaluator.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/extension/TupleEvaluator.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.extension;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/extension/TupleValidator.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/extension/TupleValidator.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.extension;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/extension/Tuples.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/extension/Tuples.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.extension;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/extension/TuplesFactory.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/extension/TuplesFactory.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.extension;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/extension/binary/BinRelation.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/extension/binary/BinRelation.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.extension.binary;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/extension/binary/CouplesBitSetTable.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/extension/binary/CouplesBitSetTable.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.extension.binary;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/extension/binary/CouplesTable.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/extension/binary/CouplesTable.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.extension.binary;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/extension/binary/PropBinAC2001.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/extension/binary/PropBinAC2001.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.extension.binary;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/extension/binary/PropBinAC3.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/extension/binary/PropBinAC3.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.extension.binary;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/extension/binary/PropBinAC3bitrm.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/extension/binary/PropBinAC3bitrm.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.extension.binary;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/extension/binary/PropBinAC3rm.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/extension/binary/PropBinAC3rm.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.extension.binary;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/extension/binary/PropBinCSP.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/extension/binary/PropBinCSP.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.extension.binary;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/extension/binary/PropBinFC.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/extension/binary/PropBinFC.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.extension.binary;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/extension/hybrid/ASupport.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/extension/hybrid/ASupport.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.extension.hybrid;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/extension/hybrid/HybridTuples.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/extension/hybrid/HybridTuples.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.extension.hybrid;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/extension/hybrid/ISupportable.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/extension/hybrid/ISupportable.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.extension.hybrid;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/extension/hybrid/PropHybridTable.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/extension/hybrid/PropHybridTable.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.extension.hybrid;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/extension/nary/FastBooleanValidityChecker.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/extension/nary/FastBooleanValidityChecker.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.extension.nary;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/extension/nary/IterTuplesTable.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/extension/nary/IterTuplesTable.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.extension.nary;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/extension/nary/LargeRelation.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/extension/nary/LargeRelation.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.extension.nary;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/extension/nary/PropCompactTable.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/extension/nary/PropCompactTable.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.extension.nary;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/extension/nary/PropCompactTableNeg.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/extension/nary/PropCompactTableNeg.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.extension.nary;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/extension/nary/PropCompactTableStar.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/extension/nary/PropCompactTableStar.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.extension.nary;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/extension/nary/PropLargeCSP.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/extension/nary/PropLargeCSP.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.extension.nary;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/extension/nary/PropLargeFC.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/extension/nary/PropLargeFC.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.extension.nary;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/extension/nary/PropLargeGAC2001.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/extension/nary/PropLargeGAC2001.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.extension.nary;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/extension/nary/PropLargeGAC2001Positive.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/extension/nary/PropLargeGAC2001Positive.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.extension.nary;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/extension/nary/PropLargeGAC3rm.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/extension/nary/PropLargeGAC3rm.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.extension.nary;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/extension/nary/PropLargeGAC3rmPositive.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/extension/nary/PropLargeGAC3rmPositive.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.extension.nary;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/extension/nary/PropLargeGACSTRPos.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/extension/nary/PropLargeGACSTRPos.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.extension.nary;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/extension/nary/PropLargeMDDC.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/extension/nary/PropLargeMDDC.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.extension.nary;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/extension/nary/PropTableStr2.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/extension/nary/PropTableStr2.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.extension.nary;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/extension/nary/RelationFactory.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/extension/nary/RelationFactory.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.extension.nary;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/extension/nary/TuplesLargeTable.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/extension/nary/TuplesLargeTable.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.extension.nary;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/extension/nary/TuplesList.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/extension/nary/TuplesList.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.extension.nary;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/extension/nary/TuplesTable.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/extension/nary/TuplesTable.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.extension.nary;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/extension/nary/TuplesVeryLargeTable.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/extension/nary/TuplesVeryLargeTable.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.extension.nary;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/extension/nary/ValidityChecker.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/extension/nary/ValidityChecker.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.extension.nary;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/graph/basic/PropAntiSymmetric.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/graph/basic/PropAntiSymmetric.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.graph.basic;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/graph/basic/PropDiameter.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/graph/basic/PropDiameter.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.graph.basic;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/graph/basic/PropLoopSet.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/graph/basic/PropLoopSet.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.graph.basic;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/graph/basic/PropNbCliques.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/graph/basic/PropNbCliques.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.graph.basic;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/graph/basic/PropNbEdges.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/graph/basic/PropNbEdges.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.graph.basic;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/graph/basic/PropNbLoops.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/graph/basic/PropNbLoops.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.graph.basic;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/graph/basic/PropNbNodes.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/graph/basic/PropNbNodes.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.graph.basic;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/graph/basic/PropSymmetric.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/graph/basic/PropSymmetric.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.graph.basic;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/graph/basic/PropTransitivity.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/graph/basic/PropTransitivity.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.graph.basic;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/graph/channeling/edges/PropEdgeBoolChannel.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/graph/channeling/edges/PropEdgeBoolChannel.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.graph.channeling.edges;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/graph/channeling/edges/PropNeighBoolChannel.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/graph/channeling/edges/PropNeighBoolChannel.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.graph.channeling.edges;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/graph/channeling/edges/PropNeighBoolsChannel1.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/graph/channeling/edges/PropNeighBoolsChannel1.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.graph.channeling.edges;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/graph/channeling/edges/PropNeighBoolsChannel2.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/graph/channeling/edges/PropNeighBoolsChannel2.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.graph.channeling.edges;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/graph/channeling/edges/PropNeighSetChannel.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/graph/channeling/edges/PropNeighSetChannel.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.graph.channeling.edges;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/graph/channeling/edges/PropNeighSetsChannel1.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/graph/channeling/edges/PropNeighSetsChannel1.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.graph.channeling.edges;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/graph/channeling/edges/PropNeighSetsChannel2.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/graph/channeling/edges/PropNeighSetsChannel2.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.graph.channeling.edges;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/graph/channeling/nodes/PropNodeBoolChannel.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/graph/channeling/nodes/PropNodeBoolChannel.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.graph.channeling.nodes;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/graph/channeling/nodes/PropNodeBoolsChannel.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/graph/channeling/nodes/PropNodeBoolsChannel.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.graph.channeling.nodes;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/graph/channeling/nodes/PropNodeSetChannel.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/graph/channeling/nodes/PropNodeSetChannel.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.graph.channeling.nodes;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/graph/connectivity/PropBiconnected.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/graph/connectivity/PropBiconnected.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.graph.connectivity;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/graph/connectivity/PropConnected.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/graph/connectivity/PropConnected.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.graph.connectivity;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/graph/connectivity/PropNbCC.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/graph/connectivity/PropNbCC.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.graph.connectivity;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/graph/connectivity/PropNbSCC.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/graph/connectivity/PropNbSCC.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.graph.connectivity;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/graph/connectivity/PropSizeMaxCC.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/graph/connectivity/PropSizeMaxCC.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.graph.connectivity;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/graph/connectivity/PropSizeMinCC.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/graph/connectivity/PropSizeMinCC.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.graph.connectivity;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/graph/cost/GraphLagrangianRelaxation.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/graph/cost/GraphLagrangianRelaxation.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 /**

--- a/solver/src/main/java/org/chocosolver/solver/constraints/graph/cost/IGraphRelaxation.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/graph/cost/IGraphRelaxation.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 /**

--- a/solver/src/main/java/org/chocosolver/solver/constraints/graph/cost/trees/PropMaxDegTree.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/graph/cost/trees/PropMaxDegTree.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.graph.cost.trees;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/graph/cost/trees/PropMaxDegVarTree.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/graph/cost/trees/PropMaxDegVarTree.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.graph.cost.trees;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/graph/cost/trees/PropTreeCostSimple.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/graph/cost/trees/PropTreeCostSimple.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.graph.cost.trees;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/graph/cost/trees/lagrangian/AbstractTreeFinder.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/graph/cost/trees/lagrangian/AbstractTreeFinder.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.graph.cost.trees.lagrangian;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/graph/cost/trees/lagrangian/KruskalMSTFinder.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/graph/cost/trees/lagrangian/KruskalMSTFinder.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.graph.cost.trees.lagrangian;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/graph/cost/trees/lagrangian/KruskalMSTGAC.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/graph/cost/trees/lagrangian/KruskalMSTGAC.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.graph.cost.trees.lagrangian;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/graph/cost/trees/lagrangian/PrimMSTFinder.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/graph/cost/trees/lagrangian/PrimMSTFinder.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.graph.cost.trees.lagrangian;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/graph/cost/trees/lagrangian/PropGenericLagrDCMST.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/graph/cost/trees/lagrangian/PropGenericLagrDCMST.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.graph.cost.trees.lagrangian;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/graph/cost/tsp/PropCycleCostSimple.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/graph/cost/tsp/PropCycleCostSimple.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.graph.cost.tsp;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/graph/cost/tsp/heap/BinarySimpleHeap.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/graph/cost/tsp/heap/BinarySimpleHeap.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 /**

--- a/solver/src/main/java/org/chocosolver/solver/constraints/graph/cost/tsp/heap/FastSimpleHeap.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/graph/cost/tsp/heap/FastSimpleHeap.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.graph.cost.tsp.heap;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/graph/cost/tsp/heap/ISimpleHeap.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/graph/cost/tsp/heap/ISimpleHeap.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.graph.cost.tsp.heap;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/graph/cost/tsp/lagrangian/KruskalOneTreeGAC.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/graph/cost/tsp/lagrangian/KruskalOneTreeGAC.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.graph.cost.tsp.lagrangian;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/graph/cost/tsp/lagrangian/PrimOneTreeFinder.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/graph/cost/tsp/lagrangian/PrimOneTreeFinder.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.graph.cost.tsp.lagrangian;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/graph/cost/tsp/lagrangian/PropLagrOneTree.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/graph/cost/tsp/lagrangian/PropLagrOneTree.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.graph.cost.tsp.lagrangian;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/graph/cycles/PropAcyclic.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/graph/cycles/PropAcyclic.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.graph.cycles;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/graph/cycles/PropCycle.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/graph/cycles/PropCycle.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.graph.cycles;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/graph/degree/PropNodeDegreeAtLeastIncr.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/graph/degree/PropNodeDegreeAtLeastIncr.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.graph.degree;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/graph/degree/PropNodeDegreeAtMostIncr.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/graph/degree/PropNodeDegreeAtMostIncr.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.graph.degree;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/graph/degree/PropNodeDegreeVar.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/graph/degree/PropNodeDegreeVar.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.graph.degree;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/graph/inclusion/PropInclusion.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/graph/inclusion/PropInclusion.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.graph.inclusion;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/graph/symmbreaking/Pair.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/graph/symmbreaking/Pair.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.graph.symmbreaking;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/graph/symmbreaking/PropGirth.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/graph/symmbreaking/PropGirth.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.graph.symmbreaking;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/graph/symmbreaking/PropIncrementalAdjacencyMatrix.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/graph/symmbreaking/PropIncrementalAdjacencyMatrix.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.graph.symmbreaking;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/graph/symmbreaking/PropIncrementalAdjacencyUndirectedMatrix.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/graph/symmbreaking/PropIncrementalAdjacencyUndirectedMatrix.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.graph.symmbreaking;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/graph/symmbreaking/PropSymmetryBreaking.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/graph/symmbreaking/PropSymmetryBreaking.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.graph.symmbreaking;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/graph/symmbreaking/PropSymmetryBreakingEx.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/graph/symmbreaking/PropSymmetryBreakingEx.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.graph.symmbreaking;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/graph/tree/PropArborescence.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/graph/tree/PropArborescence.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.graph.tree;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/graph/tree/PropArborescences.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/graph/tree/PropArborescences.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.graph.tree;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/graph/tree/PropReachability.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/graph/tree/PropReachability.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.graph.tree;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/nary/PropDiffN.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/nary/PropDiffN.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.nary;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/nary/PropIntValuePrecedeChain.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/nary/PropIntValuePrecedeChain.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.nary;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/nary/PropKLoops.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/nary/PropKLoops.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.nary;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/nary/PropSweepBasedDiffN.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/nary/PropSweepBasedDiffN.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.nary;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/nary/alldifferent/AllDifferent.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/nary/alldifferent/AllDifferent.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.nary.alldifferent;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/nary/alldifferent/PropAllDiffAC.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/nary/alldifferent/PropAllDiffAC.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.nary.alldifferent;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/nary/alldifferent/PropAllDiffAdaptative.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/nary/alldifferent/PropAllDiffAdaptative.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.nary.alldifferent;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/nary/alldifferent/PropAllDiffBC.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/nary/alldifferent/PropAllDiffBC.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.nary.alldifferent;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/nary/alldifferent/PropAllDiffInst.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/nary/alldifferent/PropAllDiffInst.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.nary.alldifferent;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/nary/alldifferent/algo/AlgoAllDiffAC.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/nary/alldifferent/algo/AlgoAllDiffAC.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.nary.alldifferent.algo;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/nary/alldifferent/algo/AlgoAllDiffACFast.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/nary/alldifferent/algo/AlgoAllDiffACFast.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.nary.alldifferent.algo;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/nary/alldifferent/algo/AlgoAllDiffBC.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/nary/alldifferent/algo/AlgoAllDiffBC.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.nary.alldifferent.algo;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/nary/alldifferent/algo/AlgoAllDiffBimodal.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/nary/alldifferent/algo/AlgoAllDiffBimodal.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.nary.alldifferent.algo;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/nary/alldifferent/algo/IAlldifferentAlgorithm.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/nary/alldifferent/algo/IAlldifferentAlgorithm.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.nary.alldifferent.algo;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/nary/alldifferent/conditions/CondAllDifferent.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/nary/alldifferent/conditions/CondAllDifferent.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.nary.alldifferent.conditions;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/nary/alldifferent/conditions/Condition.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/nary/alldifferent/conditions/Condition.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 /**

--- a/solver/src/main/java/org/chocosolver/solver/constraints/nary/alldifferent/conditions/PropCondAllDiffAC.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/nary/alldifferent/conditions/PropCondAllDiffAC.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.nary.alldifferent.conditions;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/nary/alldifferent/conditions/PropCondAllDiffAdaptative.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/nary/alldifferent/conditions/PropCondAllDiffAdaptative.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.nary.alldifferent.conditions;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/nary/alldifferent/conditions/PropCondAllDiffBC.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/nary/alldifferent/conditions/PropCondAllDiffBC.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.nary.alldifferent.conditions;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/nary/alldifferent/conditions/PropCondAllDiffBase.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/nary/alldifferent/conditions/PropCondAllDiffBase.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.nary.alldifferent.conditions;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/nary/alldifferent/conditions/PropCondAllDiffInst.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/nary/alldifferent/conditions/PropCondAllDiffInst.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.nary.alldifferent.conditions;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/nary/alldifferentprec/AllDiffPrec.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/nary/alldifferentprec/AllDiffPrec.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 /*

--- a/solver/src/main/java/org/chocosolver/solver/constraints/nary/alldifferentprec/AllDiffPrecMoreThanBc.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/nary/alldifferentprec/AllDiffPrecMoreThanBc.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 /*

--- a/solver/src/main/java/org/chocosolver/solver/constraints/nary/alldifferentprec/FilterAllDiffPrec.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/nary/alldifferentprec/FilterAllDiffPrec.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 /*

--- a/solver/src/main/java/org/chocosolver/solver/constraints/nary/alldifferentprec/GreedyBoundSupport.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/nary/alldifferentprec/GreedyBoundSupport.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 /*

--- a/solver/src/main/java/org/chocosolver/solver/constraints/nary/alldifferentprec/IntUnionFind.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/nary/alldifferentprec/IntUnionFind.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 /*

--- a/solver/src/main/java/org/chocosolver/solver/constraints/nary/alldifferentprec/PropAllDiffPrec.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/nary/alldifferentprec/PropAllDiffPrec.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 /*

--- a/solver/src/main/java/org/chocosolver/solver/constraints/nary/among/PropAmongGAC.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/nary/among/PropAmongGAC.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.nary.among;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/nary/automata/CostRegular.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/nary/automata/CostRegular.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.nary.automata;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/nary/automata/FA/CostAutomaton.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/nary/automata/FA/CostAutomaton.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.nary.automata.FA;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/nary/automata/FA/FiniteAutomaton.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/nary/automata/FA/FiniteAutomaton.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.nary.automata.FA;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/nary/automata/FA/IAutomaton.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/nary/automata/FA/IAutomaton.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.nary.automata.FA;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/nary/automata/FA/ICostAutomaton.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/nary/automata/FA/ICostAutomaton.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.nary.automata.FA;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/nary/automata/FA/utils/Bounds.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/nary/automata/FA/utils/Bounds.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.nary.automata.FA.utils;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/nary/automata/FA/utils/Counter.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/nary/automata/FA/utils/Counter.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.nary.automata.FA.utils;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/nary/automata/FA/utils/CounterState.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/nary/automata/FA/utils/CounterState.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.nary.automata.FA.utils;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/nary/automata/FA/utils/ICounter.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/nary/automata/FA/utils/ICounter.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.nary.automata.FA.utils;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/nary/automata/PropCostRegular.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/nary/automata/PropCostRegular.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.nary.automata;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/nary/automata/PropMultiCostRegular.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/nary/automata/PropMultiCostRegular.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.nary.automata;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/nary/automata/PropRegular.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/nary/automata/PropRegular.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.nary.automata;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/nary/automata/structure/Node.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/nary/automata/structure/Node.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.nary.automata.structure;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/nary/automata/structure/costregular/Arc.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/nary/automata/structure/costregular/Arc.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.nary.automata.structure.costregular;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/nary/automata/structure/costregular/StoredValuedDirectedMultiGraph.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/nary/automata/structure/costregular/StoredValuedDirectedMultiGraph.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.nary.automata.structure.costregular;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/nary/automata/structure/multicostregular/FastPathFinder.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/nary/automata/structure/multicostregular/FastPathFinder.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.nary.automata.structure.multicostregular;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/nary/automata/structure/multicostregular/StoredDirectedMultiGraph.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/nary/automata/structure/multicostregular/StoredDirectedMultiGraph.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.nary.automata.structure.multicostregular;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/nary/automata/structure/regular/Arc.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/nary/automata/structure/regular/Arc.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.nary.automata.structure.regular;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/nary/automata/structure/regular/StoredDirectedMultiGraph.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/nary/automata/structure/regular/StoredDirectedMultiGraph.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.nary.automata.structure.regular;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/nary/binPacking/PropBinPacking.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/nary/binPacking/PropBinPacking.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.nary.binPacking;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/nary/channeling/PropClauseChanneling.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/nary/channeling/PropClauseChanneling.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.nary.channeling;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/nary/channeling/PropEnumDomainChanneling.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/nary/channeling/PropEnumDomainChanneling.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.nary.channeling;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/nary/channeling/PropInverseChannelAC.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/nary/channeling/PropInverseChannelAC.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.nary.channeling;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/nary/channeling/PropInverseChannelBC.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/nary/channeling/PropInverseChannelBC.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.nary.channeling;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/nary/circuit/CircuitConf.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/nary/circuit/CircuitConf.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 /**

--- a/solver/src/main/java/org/chocosolver/solver/constraints/nary/circuit/PropCircuitSCC.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/nary/circuit/PropCircuitSCC.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.nary.circuit;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/nary/circuit/PropCircuit_AntiArboFiltering.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/nary/circuit/PropCircuit_AntiArboFiltering.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.nary.circuit;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/nary/circuit/PropCircuit_ArboFiltering.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/nary/circuit/PropCircuit_ArboFiltering.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.nary.circuit;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/nary/circuit/PropNoSubtour.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/nary/circuit/PropNoSubtour.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 /**

--- a/solver/src/main/java/org/chocosolver/solver/constraints/nary/circuit/PropSubcircuit.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/nary/circuit/PropSubcircuit.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 /**

--- a/solver/src/main/java/org/chocosolver/solver/constraints/nary/circuit/PropSubcircuitDominatorFilter.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/nary/circuit/PropSubcircuitDominatorFilter.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.nary.circuit;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/nary/cnf/ILogical.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/nary/cnf/ILogical.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.nary.cnf;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/nary/cnf/LogOp.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/nary/cnf/LogOp.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.nary.cnf;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/nary/cnf/LogicTreeToolBox.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/nary/cnf/LogicTreeToolBox.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.nary.cnf;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/nary/cnf/SatConstraint.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/nary/cnf/SatConstraint.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.nary.cnf;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/nary/count/PropCountVar.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/nary/count/PropCountVar.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.nary.count;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/nary/count/PropCount_AC.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/nary/count/PropCount_AC.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.nary.count;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/nary/cumulative/Event.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/nary/cumulative/Event.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.nary.cumulative;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/nary/cumulative/EventPointSeries.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/nary/cumulative/EventPointSeries.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 /*

--- a/solver/src/main/java/org/chocosolver/solver/constraints/nary/cumulative/Profile.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/nary/cumulative/Profile.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.nary.cumulative;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/nary/cumulative/PropagatorCumulative.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/nary/cumulative/PropagatorCumulative.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.nary.cumulative;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/nary/cumulative/SchedulingUtils.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/nary/cumulative/SchedulingUtils.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.nary.cumulative;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/nary/element/PropElementV_fast.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/nary/element/PropElementV_fast.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.nary.element;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/nary/flow/PropMinCostMaxFlow.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/nary/flow/PropMinCostMaxFlow.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.nary.flow;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/nary/globalcardinality/GlobalCardinality.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/nary/globalcardinality/GlobalCardinality.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.nary.globalcardinality;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/nary/globalcardinality/PropFastGCC.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/nary/globalcardinality/PropFastGCC.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.nary.globalcardinality;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/nary/knapsack/PropKnapsack.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/nary/knapsack/PropKnapsack.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.nary.knapsack;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/nary/knapsack/PropKnapsackKatriel01.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/nary/knapsack/PropKnapsackKatriel01.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.nary.knapsack;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/nary/knapsack/structure/BinarySearchFingerTree.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/nary/knapsack/structure/BinarySearchFingerTree.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.nary.knapsack.structure;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/nary/knapsack/structure/ComputingLossWeightTree.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/nary/knapsack/structure/ComputingLossWeightTree.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.nary.knapsack.structure;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/nary/knapsack/structure/FingerTree.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/nary/knapsack/structure/FingerTree.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.nary.knapsack.structure;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/nary/knapsack/structure/Info.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/nary/knapsack/structure/Info.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.nary.knapsack.structure;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/nary/knapsack/structure/InnerNode.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/nary/knapsack/structure/InnerNode.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.nary.knapsack.structure;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/nary/knapsack/structure/InnerNodeMaxWeight.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/nary/knapsack/structure/InnerNodeMaxWeight.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.nary.knapsack.structure;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/nary/knapsack/structure/InnerNodeSum.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/nary/knapsack/structure/InnerNodeSum.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.nary.knapsack.structure;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/nary/knapsack/structure/ItemFindingSearchTree.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/nary/knapsack/structure/ItemFindingSearchTree.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.nary.knapsack.structure;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/nary/knapsack/structure/KPItem.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/nary/knapsack/structure/KPItem.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.nary.knapsack.structure;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/nary/knapsack/structure/ProfitInterface.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/nary/knapsack/structure/ProfitInterface.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.nary.knapsack.structure;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/nary/knapsack/structure/SearchInfos.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/nary/knapsack/structure/SearchInfos.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.nary.knapsack.structure;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/nary/knapsack/structure/WeightInterface.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/nary/knapsack/structure/WeightInterface.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.nary.knapsack.structure;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/nary/lex/PropIncreasing.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/nary/lex/PropIncreasing.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.nary.lex;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/nary/lex/PropLex.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/nary/lex/PropLex.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.nary.lex;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/nary/lex/PropLexChain.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/nary/lex/PropLexChain.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.nary.lex;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/nary/lex/PropLexInt.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/nary/lex/PropLexInt.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.nary.lex;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/nary/min_max/PropArgmax.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/nary/min_max/PropArgmax.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.nary.min_max;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/nary/min_max/PropBoolMax.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/nary/min_max/PropBoolMax.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.nary.min_max;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/nary/min_max/PropBoolMin.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/nary/min_max/PropBoolMin.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.nary.min_max;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/nary/min_max/PropMax.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/nary/min_max/PropMax.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.nary.min_max;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/nary/min_max/PropMin.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/nary/min_max/PropMin.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.nary.min_max;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/nary/nvalue/PropAMNV.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/nary/nvalue/PropAMNV.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.nary.nvalue;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/nary/nvalue/PropAtLeastNValues.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/nary/nvalue/PropAtLeastNValues.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.nary.nvalue;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/nary/nvalue/PropAtLeastNValues_AC.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/nary/nvalue/PropAtLeastNValues_AC.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.nary.nvalue;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/nary/nvalue/PropAtMostNValues.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/nary/nvalue/PropAtMostNValues.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.nary.nvalue;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/nary/nvalue/PropAtMostNValues_BC.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/nary/nvalue/PropAtMostNValues_BC.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.nary.nvalue;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/nary/nvalue/PropNValue.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/nary/nvalue/PropNValue.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.nary.nvalue;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/nary/nvalue/amnv/differences/AutoDiffDetection.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/nary/nvalue/amnv/differences/AutoDiffDetection.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.nary.nvalue.amnv.differences;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/nary/nvalue/amnv/differences/D.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/nary/nvalue/amnv/differences/D.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.nary.nvalue.amnv.differences;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/nary/nvalue/amnv/graph/G.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/nary/nvalue/amnv/graph/G.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.nary.nvalue.amnv.graph;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/nary/nvalue/amnv/graph/Gci.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/nary/nvalue/amnv/graph/Gci.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.nary.nvalue.amnv.graph;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/nary/nvalue/amnv/graph/Gi.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/nary/nvalue/amnv/graph/Gi.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.nary.nvalue.amnv.graph;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/nary/nvalue/amnv/mis/F.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/nary/nvalue/amnv/mis/F.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.nary.nvalue.amnv.mis;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/nary/nvalue/amnv/mis/MD.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/nary/nvalue/amnv/mis/MD.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.nary.nvalue.amnv.mis;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/nary/nvalue/amnv/mis/MDRk.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/nary/nvalue/amnv/mis/MDRk.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.nary.nvalue.amnv.mis;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/nary/nvalue/amnv/mis/Rk.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/nary/nvalue/amnv/mis/Rk.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.nary.nvalue.amnv.mis;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/nary/nvalue/amnv/rules/R.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/nary/nvalue/amnv/rules/R.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.nary.nvalue.amnv.rules;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/nary/nvalue/amnv/rules/R1.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/nary/nvalue/amnv/rules/R1.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.nary.nvalue.amnv.rules;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/nary/nvalue/amnv/rules/R2.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/nary/nvalue/amnv/rules/R2.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.nary.nvalue.amnv.rules;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/nary/nvalue/amnv/rules/R3.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/nary/nvalue/amnv/rules/R3.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.nary.nvalue.amnv.rules;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/nary/nvalue/amnv/rules/R4.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/nary/nvalue/amnv/rules/R4.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.nary.nvalue.amnv.rules;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/nary/sat/NogoodStealer.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/nary/sat/NogoodStealer.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.nary.sat;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/nary/sat/PropSat.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/nary/sat/PropSat.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.nary.sat;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/nary/sort/PropKeysorting.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/nary/sort/PropKeysorting.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.nary.sort;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/nary/sort/PropSort.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/nary/sort/PropSort.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.nary.sort;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/nary/sum/IntLinCombFactory.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/nary/sum/IntLinCombFactory.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.nary.sum;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/nary/sum/PropScalar.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/nary/sum/PropScalar.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.nary.sum;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/nary/sum/PropScalarWithLong.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/nary/sum/PropScalarWithLong.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.nary.sum;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/nary/sum/PropSum.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/nary/sum/PropSum.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.nary.sum;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/nary/sum/PropSumBool.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/nary/sum/PropSumBool.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.nary.sum;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/nary/sum/PropSumBoolIncr.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/nary/sum/PropSumBoolIncr.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.nary.sum;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/nary/sum/PropSumFullBool.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/nary/sum/PropSumFullBool.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.nary.sum;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/nary/sum/PropSumFullBoolIncr.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/nary/sum/PropSumFullBoolIncr.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.nary.sum;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/nary/sum/PropSumWithLong.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/nary/sum/PropSumWithLong.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.nary.sum;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/nary/sum/SumConstraint.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/nary/sum/SumConstraint.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.nary.sum;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/nary/sum/SumWithLongConstraint.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/nary/sum/SumWithLongConstraint.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.nary.sum;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/nary/tree/PropAntiArborescences.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/nary/tree/PropAntiArborescences.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.nary.tree;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/real/Ibex.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/real/Ibex.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.real;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/real/IbexHandler.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/real/IbexHandler.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.real;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/real/PropMixed.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/real/PropMixed.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.real;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/real/PropMixedElement.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/real/PropMixedElement.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.real;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/real/PropScalarMixed.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/real/PropScalarMixed.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.real;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/real/RealConstraint.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/real/RealConstraint.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.real;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/real/RealPropagator.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/real/RealPropagator.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.real;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/reification/LocalConstructiveDisjunction.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/reification/LocalConstructiveDisjunction.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.reification;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/reification/Opposite.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/reification/Opposite.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.reification;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/reification/PropConditional.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/reification/PropConditional.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.reification;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/reification/PropImplied.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/reification/PropImplied.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.reification;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/reification/PropLocalConDis.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/reification/PropLocalConDis.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.reification;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/reification/PropOpposite.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/reification/PropOpposite.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.reification;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/reification/PropReif.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/reification/PropReif.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.reification;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/reification/PropXeqCHalfReif.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/reification/PropXeqCHalfReif.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.reification;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/reification/PropXeqYHalfReif.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/reification/PropXeqYHalfReif.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.reification;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/reification/PropXgeCHalfReif.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/reification/PropXgeCHalfReif.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.reification;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/reification/PropXinSHalfReif.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/reification/PropXinSHalfReif.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.reification;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/reification/PropXleCHalfReif.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/reification/PropXleCHalfReif.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.reification;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/reification/PropXleYHalfReif.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/reification/PropXleYHalfReif.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.reification;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/reification/PropXneCHalfReif.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/reification/PropXneCHalfReif.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.reification;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/reification/PropXneYHalfReif.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/reification/PropXneYHalfReif.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.reification;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/set/PropAllDiff.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/set/PropAllDiff.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 /**

--- a/solver/src/main/java/org/chocosolver/solver/constraints/set/PropAllDisjoint.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/set/PropAllDisjoint.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.set;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/set/PropAllEqual.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/set/PropAllEqual.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.set;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/set/PropAtMost1Empty.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/set/PropAtMost1Empty.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 /**

--- a/solver/src/main/java/org/chocosolver/solver/constraints/set/PropBoolChannel.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/set/PropBoolChannel.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.set;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/set/PropCardinality.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/set/PropCardinality.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 /**

--- a/solver/src/main/java/org/chocosolver/solver/constraints/set/PropElement.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/set/PropElement.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 /**

--- a/solver/src/main/java/org/chocosolver/solver/constraints/set/PropIntBoundedMemberSet.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/set/PropIntBoundedMemberSet.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 /**

--- a/solver/src/main/java/org/chocosolver/solver/constraints/set/PropIntChannel.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/set/PropIntChannel.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.set;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/set/PropIntCstMemberSet.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/set/PropIntCstMemberSet.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 /**

--- a/solver/src/main/java/org/chocosolver/solver/constraints/set/PropIntCstNotMemberSet.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/set/PropIntCstNotMemberSet.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 /**

--- a/solver/src/main/java/org/chocosolver/solver/constraints/set/PropIntEnumMemberSet.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/set/PropIntEnumMemberSet.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.set;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/set/PropIntersection.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/set/PropIntersection.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.set;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/set/PropIntersectionFilterSets.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/set/PropIntersectionFilterSets.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.set;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/set/PropInverse.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/set/PropInverse.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.set;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/set/PropMaxElement.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/set/PropMaxElement.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 /**

--- a/solver/src/main/java/org/chocosolver/solver/constraints/set/PropMinElement.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/set/PropMinElement.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 /**

--- a/solver/src/main/java/org/chocosolver/solver/constraints/set/PropNbEmpty.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/set/PropNbEmpty.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.set;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/set/PropNotEmpty.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/set/PropNotEmpty.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.set;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/set/PropNotMemberIntSet.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/set/PropNotMemberIntSet.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.set;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/set/PropNotMemberSetInt.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/set/PropNotMemberSetInt.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.set;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/set/PropOffSet.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/set/PropOffSet.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.set;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/set/PropSetIntValuesUnion.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/set/PropSetIntValuesUnion.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.set;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/set/PropSortedIntChannel.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/set/PropSortedIntChannel.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.set;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/set/PropSubsetEq.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/set/PropSubsetEq.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.set;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/set/PropSumOfElements.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/set/PropSumOfElements.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 /**

--- a/solver/src/main/java/org/chocosolver/solver/constraints/set/PropSymmetric.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/set/PropSymmetric.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.set;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/set/PropUnion.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/set/PropUnion.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.set;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/set/PropUnionVar.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/set/PropUnionVar.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.set;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/ternary/AbstractPropDistanceXYZ.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/ternary/AbstractPropDistanceXYZ.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.ternary;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/ternary/PropDivXYZ.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/ternary/PropDivXYZ.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.ternary;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/ternary/PropDivXYZLight.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/ternary/PropDivXYZLight.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.ternary;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/ternary/PropEQDistanceXYZ.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/ternary/PropEQDistanceXYZ.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.ternary;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/ternary/PropGEDistanceXYZ.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/ternary/PropGEDistanceXYZ.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.ternary;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/ternary/PropGTDistanceXYZ.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/ternary/PropGTDistanceXYZ.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.ternary;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/ternary/PropLEDistanceXYZ.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/ternary/PropLEDistanceXYZ.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.ternary;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/ternary/PropLTDistanceXYZ.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/ternary/PropLTDistanceXYZ.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.ternary;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/ternary/PropMaxBC.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/ternary/PropMaxBC.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.ternary;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/ternary/PropMinBC.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/ternary/PropMinBC.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.ternary;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/ternary/PropModXYZ.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/ternary/PropModXYZ.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.ternary;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/ternary/PropTimesNaive.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/ternary/PropTimesNaive.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.ternary;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/ternary/PropTimesNaiveWithLong.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/ternary/PropTimesNaiveWithLong.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.ternary;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/ternary/PropXplusYeqZ.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/ternary/PropXplusYeqZ.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.ternary;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/unary/BooleanConstraint.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/unary/BooleanConstraint.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.unary;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/unary/Member.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/unary/Member.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.unary;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/unary/NotMember.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/unary/NotMember.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.unary;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/unary/PropEqualXC.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/unary/PropEqualXC.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.unary;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/unary/PropGreaterOrEqualXC.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/unary/PropGreaterOrEqualXC.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.unary;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/unary/PropLessOrEqualXC.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/unary/PropLessOrEqualXC.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.unary;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/unary/PropMember.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/unary/PropMember.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.unary;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/unary/PropNotEqualXC.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/unary/PropNotEqualXC.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.unary;

--- a/solver/src/main/java/org/chocosolver/solver/constraints/unary/PropNotMember.java
+++ b/solver/src/main/java/org/chocosolver/solver/constraints/unary/PropNotMember.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.unary;

--- a/solver/src/main/java/org/chocosolver/solver/exception/ContradictionException.java
+++ b/solver/src/main/java/org/chocosolver/solver/exception/ContradictionException.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.exception;

--- a/solver/src/main/java/org/chocosolver/solver/exception/InvalidSolutionException.java
+++ b/solver/src/main/java/org/chocosolver/solver/exception/InvalidSolutionException.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.exception;

--- a/solver/src/main/java/org/chocosolver/solver/exception/SolverException.java
+++ b/solver/src/main/java/org/chocosolver/solver/exception/SolverException.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.exception;

--- a/solver/src/main/java/org/chocosolver/solver/expression/continuous/arithmetic/BiCArExpression.java
+++ b/solver/src/main/java/org/chocosolver/solver/expression/continuous/arithmetic/BiCArExpression.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.expression.continuous.arithmetic;

--- a/solver/src/main/java/org/chocosolver/solver/expression/continuous/arithmetic/CArExpression.java
+++ b/solver/src/main/java/org/chocosolver/solver/expression/continuous/arithmetic/CArExpression.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.expression.continuous.arithmetic;

--- a/solver/src/main/java/org/chocosolver/solver/expression/continuous/arithmetic/RealIntervalConstant.java
+++ b/solver/src/main/java/org/chocosolver/solver/expression/continuous/arithmetic/RealIntervalConstant.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.expression.continuous.arithmetic;

--- a/solver/src/main/java/org/chocosolver/solver/expression/continuous/arithmetic/UnCArExpression.java
+++ b/solver/src/main/java/org/chocosolver/solver/expression/continuous/arithmetic/UnCArExpression.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.expression.continuous.arithmetic;

--- a/solver/src/main/java/org/chocosolver/solver/expression/continuous/relational/BiCReExpression.java
+++ b/solver/src/main/java/org/chocosolver/solver/expression/continuous/relational/BiCReExpression.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.expression.continuous.relational;

--- a/solver/src/main/java/org/chocosolver/solver/expression/continuous/relational/CReExpression.java
+++ b/solver/src/main/java/org/chocosolver/solver/expression/continuous/relational/CReExpression.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.expression.continuous.relational;

--- a/solver/src/main/java/org/chocosolver/solver/expression/continuous/relational/PropEquation.java
+++ b/solver/src/main/java/org/chocosolver/solver/expression/continuous/relational/PropEquation.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.expression.continuous.relational;

--- a/solver/src/main/java/org/chocosolver/solver/expression/discrete/arithmetic/ArExpression.java
+++ b/solver/src/main/java/org/chocosolver/solver/expression/discrete/arithmetic/ArExpression.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.expression.discrete.arithmetic;

--- a/solver/src/main/java/org/chocosolver/solver/expression/discrete/arithmetic/BiArExpression.java
+++ b/solver/src/main/java/org/chocosolver/solver/expression/discrete/arithmetic/BiArExpression.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.expression.discrete.arithmetic;

--- a/solver/src/main/java/org/chocosolver/solver/expression/discrete/arithmetic/IfArExpression.java
+++ b/solver/src/main/java/org/chocosolver/solver/expression/discrete/arithmetic/IfArExpression.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.expression.discrete.arithmetic;

--- a/solver/src/main/java/org/chocosolver/solver/expression/discrete/arithmetic/NaArExpression.java
+++ b/solver/src/main/java/org/chocosolver/solver/expression/discrete/arithmetic/NaArExpression.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.expression.discrete.arithmetic;

--- a/solver/src/main/java/org/chocosolver/solver/expression/discrete/arithmetic/UnArExpression.java
+++ b/solver/src/main/java/org/chocosolver/solver/expression/discrete/arithmetic/UnArExpression.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.expression.discrete.arithmetic;

--- a/solver/src/main/java/org/chocosolver/solver/expression/discrete/arithmetic/UnCArExpression.java
+++ b/solver/src/main/java/org/chocosolver/solver/expression/discrete/arithmetic/UnCArExpression.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.expression.discrete.arithmetic;

--- a/solver/src/main/java/org/chocosolver/solver/expression/discrete/logical/BiLoExpression.java
+++ b/solver/src/main/java/org/chocosolver/solver/expression/discrete/logical/BiLoExpression.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.expression.discrete.logical;

--- a/solver/src/main/java/org/chocosolver/solver/expression/discrete/logical/LoExpression.java
+++ b/solver/src/main/java/org/chocosolver/solver/expression/discrete/logical/LoExpression.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.expression.discrete.logical;

--- a/solver/src/main/java/org/chocosolver/solver/expression/discrete/logical/NaLoExpression.java
+++ b/solver/src/main/java/org/chocosolver/solver/expression/discrete/logical/NaLoExpression.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.expression.discrete.logical;

--- a/solver/src/main/java/org/chocosolver/solver/expression/discrete/logical/UnLoExpression.java
+++ b/solver/src/main/java/org/chocosolver/solver/expression/discrete/logical/UnLoExpression.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.expression.discrete.logical;

--- a/solver/src/main/java/org/chocosolver/solver/expression/discrete/relational/BiReExpression.java
+++ b/solver/src/main/java/org/chocosolver/solver/expression/discrete/relational/BiReExpression.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.expression.discrete.relational;

--- a/solver/src/main/java/org/chocosolver/solver/expression/discrete/relational/NaReExpression.java
+++ b/solver/src/main/java/org/chocosolver/solver/expression/discrete/relational/NaReExpression.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.expression.discrete.relational;

--- a/solver/src/main/java/org/chocosolver/solver/expression/discrete/relational/ReExpression.java
+++ b/solver/src/main/java/org/chocosolver/solver/expression/discrete/relational/ReExpression.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.expression.discrete.relational;

--- a/solver/src/main/java/org/chocosolver/solver/expression/discrete/relational/UnCReExpression.java
+++ b/solver/src/main/java/org/chocosolver/solver/expression/discrete/relational/UnCReExpression.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.expression.discrete.relational;

--- a/solver/src/main/java/org/chocosolver/solver/objective/AbstractIntObjManager.java
+++ b/solver/src/main/java/org/chocosolver/solver/objective/AbstractIntObjManager.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.objective;

--- a/solver/src/main/java/org/chocosolver/solver/objective/AbstractRealObjManager.java
+++ b/solver/src/main/java/org/chocosolver/solver/objective/AbstractRealObjManager.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.objective;

--- a/solver/src/main/java/org/chocosolver/solver/objective/IBoundsManager.java
+++ b/solver/src/main/java/org/chocosolver/solver/objective/IBoundsManager.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.objective;

--- a/solver/src/main/java/org/chocosolver/solver/objective/IObjectiveManager.java
+++ b/solver/src/main/java/org/chocosolver/solver/objective/IObjectiveManager.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.objective;

--- a/solver/src/main/java/org/chocosolver/solver/objective/ObjectiveFactory.java
+++ b/solver/src/main/java/org/chocosolver/solver/objective/ObjectiveFactory.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.objective;

--- a/solver/src/main/java/org/chocosolver/solver/objective/ObjectiveStrategy.java
+++ b/solver/src/main/java/org/chocosolver/solver/objective/ObjectiveStrategy.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 /**

--- a/solver/src/main/java/org/chocosolver/solver/objective/OptimizationPolicy.java
+++ b/solver/src/main/java/org/chocosolver/solver/objective/OptimizationPolicy.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 /**

--- a/solver/src/main/java/org/chocosolver/solver/objective/ParetoMaximizer.java
+++ b/solver/src/main/java/org/chocosolver/solver/objective/ParetoMaximizer.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.objective;

--- a/solver/src/main/java/org/chocosolver/solver/propagation/PropagationEngine.java
+++ b/solver/src/main/java/org/chocosolver/solver/propagation/PropagationEngine.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.propagation;

--- a/solver/src/main/java/org/chocosolver/solver/propagation/PropagationEngineObserver.java
+++ b/solver/src/main/java/org/chocosolver/solver/propagation/PropagationEngineObserver.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.propagation;

--- a/solver/src/main/java/org/chocosolver/solver/propagation/PropagationObserver.java
+++ b/solver/src/main/java/org/chocosolver/solver/propagation/PropagationObserver.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.propagation;

--- a/solver/src/main/java/org/chocosolver/solver/propagation/PropagationProfiler.java
+++ b/solver/src/main/java/org/chocosolver/solver/propagation/PropagationProfiler.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.propagation;

--- a/solver/src/main/java/org/chocosolver/solver/search/IResolutionHelper.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/IResolutionHelper.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.search;

--- a/solver/src/main/java/org/chocosolver/solver/search/SearchState.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/SearchState.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.search;

--- a/solver/src/main/java/org/chocosolver/solver/search/limits/ACounter.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/limits/ACounter.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.search.limits;

--- a/solver/src/main/java/org/chocosolver/solver/search/limits/BacktrackCounter.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/limits/BacktrackCounter.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.search.limits;

--- a/solver/src/main/java/org/chocosolver/solver/search/limits/FailCounter.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/limits/FailCounter.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.search.limits;

--- a/solver/src/main/java/org/chocosolver/solver/search/limits/ICounter.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/limits/ICounter.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.search.limits;

--- a/solver/src/main/java/org/chocosolver/solver/search/limits/NodeCounter.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/limits/NodeCounter.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.search.limits;

--- a/solver/src/main/java/org/chocosolver/solver/search/limits/RestartCounter.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/limits/RestartCounter.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.search.limits;

--- a/solver/src/main/java/org/chocosolver/solver/search/limits/SolutionCounter.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/limits/SolutionCounter.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.search.limits;

--- a/solver/src/main/java/org/chocosolver/solver/search/limits/TimeCounter.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/limits/TimeCounter.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.search.limits;

--- a/solver/src/main/java/org/chocosolver/solver/search/loop/RecursiveSearchLoop.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/loop/RecursiveSearchLoop.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.search.loop;

--- a/solver/src/main/java/org/chocosolver/solver/search/loop/Reporting.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/loop/Reporting.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.search.loop;

--- a/solver/src/main/java/org/chocosolver/solver/search/loop/TimeStampedObject.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/loop/TimeStampedObject.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.search.loop;

--- a/solver/src/main/java/org/chocosolver/solver/search/loop/learn/ILearnFactory.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/loop/learn/ILearnFactory.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.search.loop.learn;

--- a/solver/src/main/java/org/chocosolver/solver/search/loop/learn/LazyClauseGeneration.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/loop/learn/LazyClauseGeneration.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.search.loop.learn;

--- a/solver/src/main/java/org/chocosolver/solver/search/loop/learn/Learn.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/loop/learn/Learn.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.search.loop.learn;

--- a/solver/src/main/java/org/chocosolver/solver/search/loop/learn/LearnNothing.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/loop/learn/LearnNothing.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.search.loop.learn;

--- a/solver/src/main/java/org/chocosolver/solver/search/loop/lns/INeighborFactory.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/loop/lns/INeighborFactory.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.search.loop.lns;

--- a/solver/src/main/java/org/chocosolver/solver/search/loop/lns/neighbors/AdaptiveNeighborhood.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/loop/lns/neighbors/AdaptiveNeighborhood.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.search.loop.lns.neighbors;

--- a/solver/src/main/java/org/chocosolver/solver/search/loop/lns/neighbors/INeighbor.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/loop/lns/neighbors/INeighbor.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.search.loop.lns.neighbors;

--- a/solver/src/main/java/org/chocosolver/solver/search/loop/lns/neighbors/IntNeighbor.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/loop/lns/neighbors/IntNeighbor.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.search.loop.lns.neighbors;

--- a/solver/src/main/java/org/chocosolver/solver/search/loop/lns/neighbors/PropagationGuidedNeighborhood.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/loop/lns/neighbors/PropagationGuidedNeighborhood.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.search.loop.lns.neighbors;

--- a/solver/src/main/java/org/chocosolver/solver/search/loop/lns/neighbors/RandomNeighborhood.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/loop/lns/neighbors/RandomNeighborhood.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.search.loop.lns.neighbors;

--- a/solver/src/main/java/org/chocosolver/solver/search/loop/lns/neighbors/ReversePropagationGuidedNeighborhood.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/loop/lns/neighbors/ReversePropagationGuidedNeighborhood.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.search.loop.lns.neighbors;

--- a/solver/src/main/java/org/chocosolver/solver/search/loop/lns/neighbors/SequenceNeighborhood.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/loop/lns/neighbors/SequenceNeighborhood.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.search.loop.lns.neighbors;

--- a/solver/src/main/java/org/chocosolver/solver/search/loop/lns/neighbors/SetRandomNeighbor.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/loop/lns/neighbors/SetRandomNeighbor.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.search.loop.lns.neighbors;

--- a/solver/src/main/java/org/chocosolver/solver/search/loop/monitors/IMonitorClose.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/loop/monitors/IMonitorClose.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.search.loop.monitors;

--- a/solver/src/main/java/org/chocosolver/solver/search/loop/monitors/IMonitorContradiction.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/loop/monitors/IMonitorContradiction.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.search.loop.monitors;

--- a/solver/src/main/java/org/chocosolver/solver/search/loop/monitors/IMonitorDownBranch.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/loop/monitors/IMonitorDownBranch.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.search.loop.monitors;

--- a/solver/src/main/java/org/chocosolver/solver/search/loop/monitors/IMonitorInitialize.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/loop/monitors/IMonitorInitialize.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.search.loop.monitors;

--- a/solver/src/main/java/org/chocosolver/solver/search/loop/monitors/IMonitorOpenNode.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/loop/monitors/IMonitorOpenNode.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.search.loop.monitors;

--- a/solver/src/main/java/org/chocosolver/solver/search/loop/monitors/IMonitorRestart.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/loop/monitors/IMonitorRestart.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.search.loop.monitors;

--- a/solver/src/main/java/org/chocosolver/solver/search/loop/monitors/IMonitorSolution.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/loop/monitors/IMonitorSolution.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.search.loop.monitors;

--- a/solver/src/main/java/org/chocosolver/solver/search/loop/monitors/IMonitorUpBranch.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/loop/monitors/IMonitorUpBranch.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.search.loop.monitors;

--- a/solver/src/main/java/org/chocosolver/solver/search/loop/monitors/ISearchMonitor.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/loop/monitors/ISearchMonitor.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.search.loop.monitors;

--- a/solver/src/main/java/org/chocosolver/solver/search/loop/monitors/ISearchMonitorFactory.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/loop/monitors/ISearchMonitorFactory.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.search.loop.monitors;

--- a/solver/src/main/java/org/chocosolver/solver/search/loop/monitors/NogoodFromRestarts.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/loop/monitors/NogoodFromRestarts.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.search.loop.monitors;

--- a/solver/src/main/java/org/chocosolver/solver/search/loop/monitors/NogoodFromSolutions.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/loop/monitors/NogoodFromSolutions.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.search.loop.monitors;

--- a/solver/src/main/java/org/chocosolver/solver/search/loop/monitors/SearchMonitorList.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/loop/monitors/SearchMonitorList.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.search.loop.monitors;

--- a/solver/src/main/java/org/chocosolver/solver/search/loop/monitors/SolvingStatisticsFlow.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/loop/monitors/SolvingStatisticsFlow.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.search.loop.monitors;

--- a/solver/src/main/java/org/chocosolver/solver/search/loop/move/IMoveFactory.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/loop/move/IMoveFactory.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.search.loop.move;

--- a/solver/src/main/java/org/chocosolver/solver/search/loop/move/Move.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/loop/move/Move.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.search.loop.move;

--- a/solver/src/main/java/org/chocosolver/solver/search/loop/move/MoveBinaryDDS.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/loop/move/MoveBinaryDDS.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.search.loop.move;

--- a/solver/src/main/java/org/chocosolver/solver/search/loop/move/MoveBinaryDFS.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/loop/move/MoveBinaryDFS.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.search.loop.move;

--- a/solver/src/main/java/org/chocosolver/solver/search/loop/move/MoveBinaryHBFS.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/loop/move/MoveBinaryHBFS.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.search.loop.move;

--- a/solver/src/main/java/org/chocosolver/solver/search/loop/move/MoveBinaryLDS.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/loop/move/MoveBinaryLDS.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.search.loop.move;

--- a/solver/src/main/java/org/chocosolver/solver/search/loop/move/MoveLNS.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/loop/move/MoveLNS.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.search.loop.move;

--- a/solver/src/main/java/org/chocosolver/solver/search/loop/move/MoveSeq.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/loop/move/MoveSeq.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.search.loop.move;

--- a/solver/src/main/java/org/chocosolver/solver/search/loop/propagate/Propagate.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/loop/propagate/Propagate.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.search.loop.propagate;

--- a/solver/src/main/java/org/chocosolver/solver/search/measure/IMeasures.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/measure/IMeasures.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.search.measure;

--- a/solver/src/main/java/org/chocosolver/solver/search/measure/Measures.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/measure/Measures.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.search.measure;

--- a/solver/src/main/java/org/chocosolver/solver/search/measure/MeasuresRecorder.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/measure/MeasuresRecorder.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.search.measure;

--- a/solver/src/main/java/org/chocosolver/solver/search/restart/AbstractCutoff.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/restart/AbstractCutoff.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.search.restart;

--- a/solver/src/main/java/org/chocosolver/solver/search/restart/AbstractRestart.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/restart/AbstractRestart.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.search.restart;

--- a/solver/src/main/java/org/chocosolver/solver/search/restart/ForceRestartBeforeCut.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/restart/ForceRestartBeforeCut.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.search.restart;

--- a/solver/src/main/java/org/chocosolver/solver/search/restart/GeometricalCutoff.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/restart/GeometricalCutoff.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.search.restart;

--- a/solver/src/main/java/org/chocosolver/solver/search/restart/ICutoff.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/restart/ICutoff.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.search.restart;

--- a/solver/src/main/java/org/chocosolver/solver/search/restart/InnerOuterCutoff.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/restart/InnerOuterCutoff.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.search.restart;

--- a/solver/src/main/java/org/chocosolver/solver/search/restart/LinearCutoff.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/restart/LinearCutoff.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.search.restart;

--- a/solver/src/main/java/org/chocosolver/solver/search/restart/LubyCutoff.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/restart/LubyCutoff.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.search.restart;

--- a/solver/src/main/java/org/chocosolver/solver/search/restart/MonotonicCutoff.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/restart/MonotonicCutoff.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.search.restart;

--- a/solver/src/main/java/org/chocosolver/solver/search/restart/Restarter.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/restart/Restarter.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.search.restart;

--- a/solver/src/main/java/org/chocosolver/solver/search/strategy/BlackBoxConfigurator.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/strategy/BlackBoxConfigurator.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.search.strategy;

--- a/solver/src/main/java/org/chocosolver/solver/search/strategy/BoundSearch.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/strategy/BoundSearch.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.search.strategy;

--- a/solver/src/main/java/org/chocosolver/solver/search/strategy/Search.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/strategy/Search.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.search.strategy;

--- a/solver/src/main/java/org/chocosolver/solver/search/strategy/SearchParams.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/strategy/SearchParams.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.search.strategy;

--- a/solver/src/main/java/org/chocosolver/solver/search/strategy/assignments/DecisionOperator.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/strategy/assignments/DecisionOperator.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.search.strategy.assignments;

--- a/solver/src/main/java/org/chocosolver/solver/search/strategy/assignments/DecisionOperatorFactory.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/strategy/assignments/DecisionOperatorFactory.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.search.strategy.assignments;

--- a/solver/src/main/java/org/chocosolver/solver/search/strategy/assignments/GraphDecisionOperator.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/strategy/assignments/GraphDecisionOperator.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.search.strategy.assignments;

--- a/solver/src/main/java/org/chocosolver/solver/search/strategy/decision/Decision.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/strategy/decision/Decision.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.search.strategy.decision;

--- a/solver/src/main/java/org/chocosolver/solver/search/strategy/decision/DecisionMaker.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/strategy/decision/DecisionMaker.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.search.strategy.decision;

--- a/solver/src/main/java/org/chocosolver/solver/search/strategy/decision/DecisionPath.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/strategy/decision/DecisionPath.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.search.strategy.decision;

--- a/solver/src/main/java/org/chocosolver/solver/search/strategy/decision/GraphDecision.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/strategy/decision/GraphDecision.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.search.strategy.decision;

--- a/solver/src/main/java/org/chocosolver/solver/search/strategy/decision/IbexDecision.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/strategy/decision/IbexDecision.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.search.strategy.decision;

--- a/solver/src/main/java/org/chocosolver/solver/search/strategy/decision/IntDecision.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/strategy/decision/IntDecision.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.search.strategy.decision;

--- a/solver/src/main/java/org/chocosolver/solver/search/strategy/decision/RealDecision.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/strategy/decision/RealDecision.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.search.strategy.decision;

--- a/solver/src/main/java/org/chocosolver/solver/search/strategy/decision/RootDecision.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/strategy/decision/RootDecision.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.search.strategy.decision;

--- a/solver/src/main/java/org/chocosolver/solver/search/strategy/decision/SetDecision.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/strategy/decision/SetDecision.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.search.strategy.decision;

--- a/solver/src/main/java/org/chocosolver/solver/search/strategy/selectors/values/IntDomainBest.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/strategy/selectors/values/IntDomainBest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.search.strategy.selectors.values;

--- a/solver/src/main/java/org/chocosolver/solver/search/strategy/selectors/values/IntDomainClosest.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/strategy/selectors/values/IntDomainClosest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.search.strategy.selectors.values;

--- a/solver/src/main/java/org/chocosolver/solver/search/strategy/selectors/values/IntDomainImpact.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/strategy/selectors/values/IntDomainImpact.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.search.strategy.selectors.values;

--- a/solver/src/main/java/org/chocosolver/solver/search/strategy/selectors/values/IntDomainLast.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/strategy/selectors/values/IntDomainLast.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.search.strategy.selectors.values;

--- a/solver/src/main/java/org/chocosolver/solver/search/strategy/selectors/values/IntDomainMax.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/strategy/selectors/values/IntDomainMax.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.search.strategy.selectors.values;

--- a/solver/src/main/java/org/chocosolver/solver/search/strategy/selectors/values/IntDomainMedian.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/strategy/selectors/values/IntDomainMedian.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.search.strategy.selectors.values;

--- a/solver/src/main/java/org/chocosolver/solver/search/strategy/selectors/values/IntDomainMiddle.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/strategy/selectors/values/IntDomainMiddle.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.search.strategy.selectors.values;

--- a/solver/src/main/java/org/chocosolver/solver/search/strategy/selectors/values/IntDomainMin.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/strategy/selectors/values/IntDomainMin.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.search.strategy.selectors.values;

--- a/solver/src/main/java/org/chocosolver/solver/search/strategy/selectors/values/IntDomainRandom.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/strategy/selectors/values/IntDomainRandom.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.search.strategy.selectors.values;

--- a/solver/src/main/java/org/chocosolver/solver/search/strategy/selectors/values/IntDomainSticky.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/strategy/selectors/values/IntDomainSticky.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.search.strategy.selectors.values;

--- a/solver/src/main/java/org/chocosolver/solver/search/strategy/selectors/values/IntValueSelector.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/strategy/selectors/values/IntValueSelector.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.search.strategy.selectors.values;

--- a/solver/src/main/java/org/chocosolver/solver/search/strategy/selectors/values/RealDomainMax.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/strategy/selectors/values/RealDomainMax.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.search.strategy.selectors.values;

--- a/solver/src/main/java/org/chocosolver/solver/search/strategy/selectors/values/RealDomainMiddle.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/strategy/selectors/values/RealDomainMiddle.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.search.strategy.selectors.values;

--- a/solver/src/main/java/org/chocosolver/solver/search/strategy/selectors/values/RealDomainMin.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/strategy/selectors/values/RealDomainMin.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.search.strategy.selectors.values;

--- a/solver/src/main/java/org/chocosolver/solver/search/strategy/selectors/values/RealValueSelector.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/strategy/selectors/values/RealValueSelector.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.search.strategy.selectors.values;

--- a/solver/src/main/java/org/chocosolver/solver/search/strategy/selectors/values/SetDomainMax.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/strategy/selectors/values/SetDomainMax.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.search.strategy.selectors.values;

--- a/solver/src/main/java/org/chocosolver/solver/search/strategy/selectors/values/SetDomainMin.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/strategy/selectors/values/SetDomainMin.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.search.strategy.selectors.values;

--- a/solver/src/main/java/org/chocosolver/solver/search/strategy/selectors/values/SetValueSelector.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/strategy/selectors/values/SetValueSelector.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.search.strategy.selectors.values;

--- a/solver/src/main/java/org/chocosolver/solver/search/strategy/selectors/values/graph/edge/GraphEdgeSelector.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/strategy/selectors/values/graph/edge/GraphEdgeSelector.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.search.strategy.selectors.values.graph.edge;

--- a/solver/src/main/java/org/chocosolver/solver/search/strategy/selectors/values/graph/edge/GraphLexEdge.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/strategy/selectors/values/graph/edge/GraphLexEdge.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.search.strategy.selectors.values.graph.edge;

--- a/solver/src/main/java/org/chocosolver/solver/search/strategy/selectors/values/graph/edge/GraphRandomEdge.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/strategy/selectors/values/graph/edge/GraphRandomEdge.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.search.strategy.selectors.values.graph.edge;

--- a/solver/src/main/java/org/chocosolver/solver/search/strategy/selectors/values/graph/node/GraphLexNode.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/strategy/selectors/values/graph/node/GraphLexNode.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2021, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 2001, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.search.strategy.selectors.values.graph.node;

--- a/solver/src/main/java/org/chocosolver/solver/search/strategy/selectors/values/graph/node/GraphNodeSelector.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/strategy/selectors/values/graph/node/GraphNodeSelector.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2021, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 2001, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.search.strategy.selectors.values.graph.node;

--- a/solver/src/main/java/org/chocosolver/solver/search/strategy/selectors/values/graph/node/GraphRandomNode.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/strategy/selectors/values/graph/node/GraphRandomNode.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2021, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 2001, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.search.strategy.selectors.values.graph.node;

--- a/solver/src/main/java/org/chocosolver/solver/search/strategy/selectors/values/graph/priority/GraphEdgesOnly.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/strategy/selectors/values/graph/priority/GraphEdgesOnly.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.search.strategy.selectors.values.graph.priority;

--- a/solver/src/main/java/org/chocosolver/solver/search/strategy/selectors/values/graph/priority/GraphNodeOrEdgeSelector.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/strategy/selectors/values/graph/priority/GraphNodeOrEdgeSelector.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.search.strategy.selectors.values.graph.priority;

--- a/solver/src/main/java/org/chocosolver/solver/search/strategy/selectors/values/graph/priority/GraphNodeThenEdges.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/strategy/selectors/values/graph/priority/GraphNodeThenEdges.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.search.strategy.selectors.values.graph.priority;

--- a/solver/src/main/java/org/chocosolver/solver/search/strategy/selectors/values/graph/priority/GraphNodeThenNeighbors.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/strategy/selectors/values/graph/priority/GraphNodeThenNeighbors.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.search.strategy.selectors.values.graph.priority;

--- a/solver/src/main/java/org/chocosolver/solver/search/strategy/selectors/variables/AbstractCriterionBasedVariableSelector.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/strategy/selectors/variables/AbstractCriterionBasedVariableSelector.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.search.strategy.selectors.variables;

--- a/solver/src/main/java/org/chocosolver/solver/search/strategy/selectors/variables/ActivityBased.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/strategy/selectors/variables/ActivityBased.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.search.strategy.selectors.variables;

--- a/solver/src/main/java/org/chocosolver/solver/search/strategy/selectors/variables/AntiFirstFail.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/strategy/selectors/variables/AntiFirstFail.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.search.strategy.selectors.variables;

--- a/solver/src/main/java/org/chocosolver/solver/search/strategy/selectors/variables/ConflictHistorySearch.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/strategy/selectors/variables/ConflictHistorySearch.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.search.strategy.selectors.variables;

--- a/solver/src/main/java/org/chocosolver/solver/search/strategy/selectors/variables/Cyclic.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/strategy/selectors/variables/Cyclic.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.search.strategy.selectors.variables;

--- a/solver/src/main/java/org/chocosolver/solver/search/strategy/selectors/variables/DomOverWDeg.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/strategy/selectors/variables/DomOverWDeg.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.search.strategy.selectors.variables;

--- a/solver/src/main/java/org/chocosolver/solver/search/strategy/selectors/variables/DomOverWDegRef.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/strategy/selectors/variables/DomOverWDegRef.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.search.strategy.selectors.variables;

--- a/solver/src/main/java/org/chocosolver/solver/search/strategy/selectors/variables/FailureBased.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/strategy/selectors/variables/FailureBased.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.search.strategy.selectors.variables;

--- a/solver/src/main/java/org/chocosolver/solver/search/strategy/selectors/variables/FirstFail.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/strategy/selectors/variables/FirstFail.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.search.strategy.selectors.variables;

--- a/solver/src/main/java/org/chocosolver/solver/search/strategy/selectors/variables/GeneralizedMinDomVarSelector.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/strategy/selectors/variables/GeneralizedMinDomVarSelector.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.search.strategy.selectors.variables;

--- a/solver/src/main/java/org/chocosolver/solver/search/strategy/selectors/variables/ImpactBased.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/strategy/selectors/variables/ImpactBased.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.search.strategy.selectors.variables;

--- a/solver/src/main/java/org/chocosolver/solver/search/strategy/selectors/variables/InputOrder.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/strategy/selectors/variables/InputOrder.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.search.strategy.selectors.variables;

--- a/solver/src/main/java/org/chocosolver/solver/search/strategy/selectors/variables/Largest.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/strategy/selectors/variables/Largest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.search.strategy.selectors.variables;

--- a/solver/src/main/java/org/chocosolver/solver/search/strategy/selectors/variables/MaxDelta.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/strategy/selectors/variables/MaxDelta.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.search.strategy.selectors.variables;

--- a/solver/src/main/java/org/chocosolver/solver/search/strategy/selectors/variables/MaxRegret.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/strategy/selectors/variables/MaxRegret.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.search.strategy.selectors.variables;

--- a/solver/src/main/java/org/chocosolver/solver/search/strategy/selectors/variables/MinDelta.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/strategy/selectors/variables/MinDelta.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.search.strategy.selectors.variables;

--- a/solver/src/main/java/org/chocosolver/solver/search/strategy/selectors/variables/Occurrence.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/strategy/selectors/variables/Occurrence.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.search.strategy.selectors.variables;

--- a/solver/src/main/java/org/chocosolver/solver/search/strategy/selectors/variables/PickOnDom.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/strategy/selectors/variables/PickOnDom.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.search.strategy.selectors.variables;

--- a/solver/src/main/java/org/chocosolver/solver/search/strategy/selectors/variables/Random.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/strategy/selectors/variables/Random.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.search.strategy.selectors.variables;

--- a/solver/src/main/java/org/chocosolver/solver/search/strategy/selectors/variables/RandomVar.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/strategy/selectors/variables/RandomVar.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.search.strategy.selectors.variables;

--- a/solver/src/main/java/org/chocosolver/solver/search/strategy/selectors/variables/RoundRobinGroup.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/strategy/selectors/variables/RoundRobinGroup.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.search.strategy.selectors.variables;

--- a/solver/src/main/java/org/chocosolver/solver/search/strategy/selectors/variables/Smallest.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/strategy/selectors/variables/Smallest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.search.strategy.selectors.variables;

--- a/solver/src/main/java/org/chocosolver/solver/search/strategy/selectors/variables/VariableEvaluator.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/strategy/selectors/variables/VariableEvaluator.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.search.strategy.selectors.variables;

--- a/solver/src/main/java/org/chocosolver/solver/search/strategy/selectors/variables/VariableSelector.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/strategy/selectors/variables/VariableSelector.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.search.strategy.selectors.variables;

--- a/solver/src/main/java/org/chocosolver/solver/search/strategy/selectors/variables/VariableSelectorWithTies.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/strategy/selectors/variables/VariableSelectorWithTies.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.search.strategy.selectors.variables;

--- a/solver/src/main/java/org/chocosolver/solver/search/strategy/strategy/AbstractStrategy.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/strategy/strategy/AbstractStrategy.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.search.strategy.strategy;

--- a/solver/src/main/java/org/chocosolver/solver/search/strategy/strategy/AntiLastConflict.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/strategy/strategy/AntiLastConflict.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.search.strategy.strategy;

--- a/solver/src/main/java/org/chocosolver/solver/search/strategy/strategy/ConflictOrderingSearch.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/strategy/strategy/ConflictOrderingSearch.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.search.strategy.strategy;

--- a/solver/src/main/java/org/chocosolver/solver/search/strategy/strategy/FindAndProve.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/strategy/strategy/FindAndProve.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.search.strategy.strategy;

--- a/solver/src/main/java/org/chocosolver/solver/search/strategy/strategy/FullyRandom.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/strategy/strategy/FullyRandom.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.search.strategy.strategy;

--- a/solver/src/main/java/org/chocosolver/solver/search/strategy/strategy/GraphCostBasedSearch.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/strategy/strategy/GraphCostBasedSearch.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 /**

--- a/solver/src/main/java/org/chocosolver/solver/search/strategy/strategy/GraphStrategy.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/strategy/strategy/GraphStrategy.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.search.strategy.strategy;

--- a/solver/src/main/java/org/chocosolver/solver/search/strategy/strategy/GreedyBranching.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/strategy/strategy/GreedyBranching.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.search.strategy.strategy;

--- a/solver/src/main/java/org/chocosolver/solver/search/strategy/strategy/IntStrategy.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/strategy/strategy/IntStrategy.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.search.strategy.strategy;

--- a/solver/src/main/java/org/chocosolver/solver/search/strategy/strategy/LastConflict.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/strategy/strategy/LastConflict.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.search.strategy.strategy;

--- a/solver/src/main/java/org/chocosolver/solver/search/strategy/strategy/MetaStrategy.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/strategy/strategy/MetaStrategy.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.search.strategy.strategy;

--- a/solver/src/main/java/org/chocosolver/solver/search/strategy/strategy/MultiArmedBanditSequencer.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/strategy/strategy/MultiArmedBanditSequencer.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.search.strategy.strategy;

--- a/solver/src/main/java/org/chocosolver/solver/search/strategy/strategy/PartialAssignmentGenerator.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/strategy/strategy/PartialAssignmentGenerator.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.search.strategy.strategy;

--- a/solver/src/main/java/org/chocosolver/solver/search/strategy/strategy/RealStrategy.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/strategy/strategy/RealStrategy.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.search.strategy.strategy;

--- a/solver/src/main/java/org/chocosolver/solver/search/strategy/strategy/RoundRobin.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/strategy/strategy/RoundRobin.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.search.strategy.strategy;

--- a/solver/src/main/java/org/chocosolver/solver/search/strategy/strategy/SetStrategy.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/strategy/strategy/SetStrategy.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.search.strategy.strategy;

--- a/solver/src/main/java/org/chocosolver/solver/search/strategy/strategy/SetTimes.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/strategy/strategy/SetTimes.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 /*

--- a/solver/src/main/java/org/chocosolver/solver/search/strategy/strategy/StrategiesSequencer.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/strategy/strategy/StrategiesSequencer.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.search.strategy.strategy;

--- a/solver/src/main/java/org/chocosolver/solver/search/strategy/strategy/WarmStart.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/strategy/strategy/WarmStart.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.search.strategy.strategy;

--- a/solver/src/main/java/org/chocosolver/solver/trace/CPProfiler.java
+++ b/solver/src/main/java/org/chocosolver/solver/trace/CPProfiler.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.trace;

--- a/solver/src/main/java/org/chocosolver/solver/trace/GephiConstants.java
+++ b/solver/src/main/java/org/chocosolver/solver/trace/GephiConstants.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.trace;

--- a/solver/src/main/java/org/chocosolver/solver/trace/GephiGenerator.java
+++ b/solver/src/main/java/org/chocosolver/solver/trace/GephiGenerator.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.trace;

--- a/solver/src/main/java/org/chocosolver/solver/trace/GephiNetwork.java
+++ b/solver/src/main/java/org/chocosolver/solver/trace/GephiNetwork.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.trace;

--- a/solver/src/main/java/org/chocosolver/solver/trace/GraphvizGenerator.java
+++ b/solver/src/main/java/org/chocosolver/solver/trace/GraphvizGenerator.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.trace;

--- a/solver/src/main/java/org/chocosolver/solver/trace/IMessage.java
+++ b/solver/src/main/java/org/chocosolver/solver/trace/IMessage.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.trace;

--- a/solver/src/main/java/org/chocosolver/solver/trace/IOutputFactory.java
+++ b/solver/src/main/java/org/chocosolver/solver/trace/IOutputFactory.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.trace;

--- a/solver/src/main/java/org/chocosolver/solver/trace/LogStatEveryXXms.java
+++ b/solver/src/main/java/org/chocosolver/solver/trace/LogStatEveryXXms.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.trace;

--- a/solver/src/main/java/org/chocosolver/solver/trace/SearchViz.java
+++ b/solver/src/main/java/org/chocosolver/solver/trace/SearchViz.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.trace;

--- a/solver/src/main/java/org/chocosolver/solver/trace/VerboseSolving.java
+++ b/solver/src/main/java/org/chocosolver/solver/trace/VerboseSolving.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.trace;

--- a/solver/src/main/java/org/chocosolver/solver/variables/BoolVar.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/BoolVar.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.variables;

--- a/solver/src/main/java/org/chocosolver/solver/variables/DirectedGraphVar.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/DirectedGraphVar.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.variables;

--- a/solver/src/main/java/org/chocosolver/solver/variables/GraphVar.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/GraphVar.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.variables;

--- a/solver/src/main/java/org/chocosolver/solver/variables/Group.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/Group.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.variables;

--- a/solver/src/main/java/org/chocosolver/solver/variables/IResultVariableFactory.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/IResultVariableFactory.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.variables;

--- a/solver/src/main/java/org/chocosolver/solver/variables/IVariableFactory.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/IVariableFactory.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.variables;

--- a/solver/src/main/java/org/chocosolver/solver/variables/IVariableMonitor.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/IVariableMonitor.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.variables;

--- a/solver/src/main/java/org/chocosolver/solver/variables/IViewFactory.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/IViewFactory.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.variables;

--- a/solver/src/main/java/org/chocosolver/solver/variables/IncidentSet.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/IncidentSet.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.variables;

--- a/solver/src/main/java/org/chocosolver/solver/variables/IntVar.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/IntVar.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.variables;

--- a/solver/src/main/java/org/chocosolver/solver/variables/OptionalTask.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/OptionalTask.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.variables;

--- a/solver/src/main/java/org/chocosolver/solver/variables/RealVar.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/RealVar.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.variables;

--- a/solver/src/main/java/org/chocosolver/solver/variables/SetVar.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/SetVar.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.variables;

--- a/solver/src/main/java/org/chocosolver/solver/variables/Task.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/Task.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.variables;

--- a/solver/src/main/java/org/chocosolver/solver/variables/UndirectedGraphVar.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/UndirectedGraphVar.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.variables;

--- a/solver/src/main/java/org/chocosolver/solver/variables/Variable.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/Variable.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.variables;

--- a/solver/src/main/java/org/chocosolver/solver/variables/delta/EnumDelta.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/delta/EnumDelta.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.variables.delta;

--- a/solver/src/main/java/org/chocosolver/solver/variables/delta/GraphDelta.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/delta/GraphDelta.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.variables.delta;

--- a/solver/src/main/java/org/chocosolver/solver/variables/delta/IDelta.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/delta/IDelta.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.variables.delta;

--- a/solver/src/main/java/org/chocosolver/solver/variables/delta/IDeltaMonitor.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/delta/IDeltaMonitor.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.variables.delta;

--- a/solver/src/main/java/org/chocosolver/solver/variables/delta/IEnumDelta.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/delta/IEnumDelta.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.variables.delta;

--- a/solver/src/main/java/org/chocosolver/solver/variables/delta/IGraphDelta.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/delta/IGraphDelta.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.variables.delta;

--- a/solver/src/main/java/org/chocosolver/solver/variables/delta/IGraphDeltaMonitor.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/delta/IGraphDeltaMonitor.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.variables.delta;

--- a/solver/src/main/java/org/chocosolver/solver/variables/delta/IIntDeltaMonitor.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/delta/IIntDeltaMonitor.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.variables.delta;

--- a/solver/src/main/java/org/chocosolver/solver/variables/delta/IIntervalDelta.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/delta/IIntervalDelta.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.variables.delta;

--- a/solver/src/main/java/org/chocosolver/solver/variables/delta/ISetDelta.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/delta/ISetDelta.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.variables.delta;

--- a/solver/src/main/java/org/chocosolver/solver/variables/delta/ISetDeltaMonitor.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/delta/ISetDeltaMonitor.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.variables.delta;

--- a/solver/src/main/java/org/chocosolver/solver/variables/delta/IntDelta.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/delta/IntDelta.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.variables.delta;

--- a/solver/src/main/java/org/chocosolver/solver/variables/delta/IntervalDelta.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/delta/IntervalDelta.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.variables.delta;

--- a/solver/src/main/java/org/chocosolver/solver/variables/delta/NoDelta.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/delta/NoDelta.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.variables.delta;

--- a/solver/src/main/java/org/chocosolver/solver/variables/delta/OneValueDelta.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/delta/OneValueDelta.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.variables.delta;

--- a/solver/src/main/java/org/chocosolver/solver/variables/delta/SetDelta.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/delta/SetDelta.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.variables.delta;

--- a/solver/src/main/java/org/chocosolver/solver/variables/delta/monitor/EnumDeltaMonitor.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/delta/monitor/EnumDeltaMonitor.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.variables.delta.monitor;

--- a/solver/src/main/java/org/chocosolver/solver/variables/delta/monitor/GraphDeltaMonitor.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/delta/monitor/GraphDeltaMonitor.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.variables.delta.monitor;

--- a/solver/src/main/java/org/chocosolver/solver/variables/delta/monitor/IntervalDeltaMonitor.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/delta/monitor/IntervalDeltaMonitor.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.variables.delta.monitor;

--- a/solver/src/main/java/org/chocosolver/solver/variables/delta/monitor/OneValueDeltaMonitor.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/delta/monitor/OneValueDeltaMonitor.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.variables.delta.monitor;

--- a/solver/src/main/java/org/chocosolver/solver/variables/delta/monitor/SetDeltaMonitor.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/delta/monitor/SetDeltaMonitor.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.variables.delta.monitor;

--- a/solver/src/main/java/org/chocosolver/solver/variables/events/GraphEventType.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/events/GraphEventType.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.variables.events;

--- a/solver/src/main/java/org/chocosolver/solver/variables/events/IEventType.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/events/IEventType.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.variables.events;

--- a/solver/src/main/java/org/chocosolver/solver/variables/events/IntEventType.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/events/IntEventType.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.variables.events;

--- a/solver/src/main/java/org/chocosolver/solver/variables/events/PropagatorEventType.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/events/PropagatorEventType.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.variables.events;

--- a/solver/src/main/java/org/chocosolver/solver/variables/events/RealEventType.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/events/RealEventType.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.variables.events;

--- a/solver/src/main/java/org/chocosolver/solver/variables/events/SetEventType.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/events/SetEventType.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.variables.events;

--- a/solver/src/main/java/org/chocosolver/solver/variables/impl/AbstractGraphVar.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/impl/AbstractGraphVar.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.variables.impl;

--- a/solver/src/main/java/org/chocosolver/solver/variables/impl/AbstractVariable.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/impl/AbstractVariable.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.variables.impl;

--- a/solver/src/main/java/org/chocosolver/solver/variables/impl/BipartiteList.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/impl/BipartiteList.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.variables.impl;

--- a/solver/src/main/java/org/chocosolver/solver/variables/impl/BitsetIntVarImpl.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/impl/BitsetIntVarImpl.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.variables.impl;

--- a/solver/src/main/java/org/chocosolver/solver/variables/impl/BoolVarEagerLit.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/impl/BoolVarEagerLit.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.variables.impl;

--- a/solver/src/main/java/org/chocosolver/solver/variables/impl/BoolVarImpl.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/impl/BoolVarImpl.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.variables.impl;

--- a/solver/src/main/java/org/chocosolver/solver/variables/impl/DirectedGraphVarImpl.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/impl/DirectedGraphVarImpl.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.variables.impl;

--- a/solver/src/main/java/org/chocosolver/solver/variables/impl/DirectedNodeInducedGraphVarImpl.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/impl/DirectedNodeInducedGraphVarImpl.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.variables.impl;

--- a/solver/src/main/java/org/chocosolver/solver/variables/impl/FixedBoolVarImpl.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/impl/FixedBoolVarImpl.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.variables.impl;

--- a/solver/src/main/java/org/chocosolver/solver/variables/impl/FixedIntVarImpl.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/impl/FixedIntVarImpl.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.variables.impl;

--- a/solver/src/main/java/org/chocosolver/solver/variables/impl/FixedRealVarImpl.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/impl/FixedRealVarImpl.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.variables.impl;

--- a/solver/src/main/java/org/chocosolver/solver/variables/impl/IBipartiteList.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/impl/IBipartiteList.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.variables.impl;

--- a/solver/src/main/java/org/chocosolver/solver/variables/impl/IntVarEagerLit.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/impl/IntVarEagerLit.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.variables.impl;

--- a/solver/src/main/java/org/chocosolver/solver/variables/impl/IntVarLazyLit.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/impl/IntVarLazyLit.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.variables.impl;

--- a/solver/src/main/java/org/chocosolver/solver/variables/impl/IntervalIntVarImpl.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/impl/IntervalIntVarImpl.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.variables.impl;

--- a/solver/src/main/java/org/chocosolver/solver/variables/impl/LitVar.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/impl/LitVar.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.variables.impl;

--- a/solver/src/main/java/org/chocosolver/solver/variables/impl/RealVarImpl.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/impl/RealVarImpl.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.variables.impl;

--- a/solver/src/main/java/org/chocosolver/solver/variables/impl/SetVarImpl.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/impl/SetVarImpl.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.variables.impl;

--- a/solver/src/main/java/org/chocosolver/solver/variables/impl/UndirectedGraphVarImpl.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/impl/UndirectedGraphVarImpl.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.variables.impl;

--- a/solver/src/main/java/org/chocosolver/solver/variables/impl/UndirectedNodeInducedGraphVarImpl.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/impl/UndirectedNodeInducedGraphVarImpl.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.variables.impl;

--- a/solver/src/main/java/org/chocosolver/solver/variables/impl/lazyness/ILazyBound.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/impl/lazyness/ILazyBound.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.variables.impl.lazyness;

--- a/solver/src/main/java/org/chocosolver/solver/variables/impl/lazyness/StrongBound.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/impl/lazyness/StrongBound.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.variables.impl.lazyness;

--- a/solver/src/main/java/org/chocosolver/solver/variables/impl/lazyness/WeakBound.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/impl/lazyness/WeakBound.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.variables.impl.lazyness;

--- a/solver/src/main/java/org/chocosolver/solver/variables/impl/scheduler/BoolEvtScheduler.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/impl/scheduler/BoolEvtScheduler.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.variables.impl.scheduler;

--- a/solver/src/main/java/org/chocosolver/solver/variables/impl/scheduler/GraphEvtScheduler.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/impl/scheduler/GraphEvtScheduler.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.variables.impl.scheduler;

--- a/solver/src/main/java/org/chocosolver/solver/variables/impl/scheduler/IntEvtScheduler.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/impl/scheduler/IntEvtScheduler.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.variables.impl.scheduler;

--- a/solver/src/main/java/org/chocosolver/solver/variables/impl/scheduler/RealEvtScheduler.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/impl/scheduler/RealEvtScheduler.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.variables.impl.scheduler;

--- a/solver/src/main/java/org/chocosolver/solver/variables/impl/scheduler/SetEvtScheduler.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/impl/scheduler/SetEvtScheduler.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.variables.impl.scheduler;

--- a/solver/src/main/java/org/chocosolver/solver/variables/view/AbstractView.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/view/AbstractView.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.variables.view;

--- a/solver/src/main/java/org/chocosolver/solver/variables/view/BoolIntView.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/view/BoolIntView.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.variables.view;

--- a/solver/src/main/java/org/chocosolver/solver/variables/view/GraphView.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/view/GraphView.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.variables.view;

--- a/solver/src/main/java/org/chocosolver/solver/variables/view/IView.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/view/IView.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.variables.view;

--- a/solver/src/main/java/org/chocosolver/solver/variables/view/IntView.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/view/IntView.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.variables.view;

--- a/solver/src/main/java/org/chocosolver/solver/variables/view/RealView.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/view/RealView.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.variables.view;

--- a/solver/src/main/java/org/chocosolver/solver/variables/view/SetView.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/view/SetView.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.variables.view;

--- a/solver/src/main/java/org/chocosolver/solver/variables/view/ViewDeltaMonitor.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/view/ViewDeltaMonitor.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.variables.view;

--- a/solver/src/main/java/org/chocosolver/solver/variables/view/bool/BoolEqView.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/view/bool/BoolEqView.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.variables.view.bool;

--- a/solver/src/main/java/org/chocosolver/solver/variables/view/bool/BoolGeqView.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/view/bool/BoolGeqView.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.variables.view.bool;

--- a/solver/src/main/java/org/chocosolver/solver/variables/view/bool/BoolNotView.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/view/bool/BoolNotView.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.variables.view.bool;

--- a/solver/src/main/java/org/chocosolver/solver/variables/view/bool/BoolSetView.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/view/bool/BoolSetView.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.variables.view.bool;

--- a/solver/src/main/java/org/chocosolver/solver/variables/view/delta/GraphUnionViewDeltaMonitor.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/view/delta/GraphUnionViewDeltaMonitor.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.variables.view.delta;

--- a/solver/src/main/java/org/chocosolver/solver/variables/view/delta/GraphViewDeltaMonitor.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/view/delta/GraphViewDeltaMonitor.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.variables.view.delta;

--- a/solver/src/main/java/org/chocosolver/solver/variables/view/delta/SetGraphViewDeltaMonitor.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/view/delta/SetGraphViewDeltaMonitor.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.variables.view.delta;

--- a/solver/src/main/java/org/chocosolver/solver/variables/view/delta/SetViewOnSetsDeltaMonitor.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/view/delta/SetViewOnSetsDeltaMonitor.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.variables.view.delta;

--- a/solver/src/main/java/org/chocosolver/solver/variables/view/graph/DirectedGraphView.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/view/graph/DirectedGraphView.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.variables.view.graph;

--- a/solver/src/main/java/org/chocosolver/solver/variables/view/graph/UndirectedGraphView.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/view/graph/UndirectedGraphView.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.variables.view.graph;

--- a/solver/src/main/java/org/chocosolver/solver/variables/view/graph/directed/DirectedEdgeInducedSubgraphView.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/view/graph/directed/DirectedEdgeInducedSubgraphView.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.variables.view.graph.directed;

--- a/solver/src/main/java/org/chocosolver/solver/variables/view/graph/directed/DirectedGraphUnionView.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/view/graph/directed/DirectedGraphUnionView.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.variables.view.graph.directed;

--- a/solver/src/main/java/org/chocosolver/solver/variables/view/graph/directed/DirectedNodeInducedSubgraphView.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/view/graph/directed/DirectedNodeInducedSubgraphView.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.variables.view.graph.directed;

--- a/solver/src/main/java/org/chocosolver/solver/variables/view/graph/undirected/EdgeInducedSubgraphView.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/view/graph/undirected/EdgeInducedSubgraphView.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.variables.view.graph.undirected;

--- a/solver/src/main/java/org/chocosolver/solver/variables/view/graph/undirected/NodeInducedSubgraphView.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/view/graph/undirected/NodeInducedSubgraphView.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.variables.view.graph.undirected;

--- a/solver/src/main/java/org/chocosolver/solver/variables/view/graph/undirected/UndirectedGraphUnionView.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/view/graph/undirected/UndirectedGraphUnionView.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.variables.view.graph.undirected;

--- a/solver/src/main/java/org/chocosolver/solver/variables/view/integer/IntAffineView.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/view/integer/IntAffineView.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.variables.view.integer;

--- a/solver/src/main/java/org/chocosolver/solver/variables/view/set/SetBoolsView.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/view/set/SetBoolsView.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.variables.view.set;

--- a/solver/src/main/java/org/chocosolver/solver/variables/view/set/SetDifferenceView.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/view/set/SetDifferenceView.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.variables.view.set;

--- a/solver/src/main/java/org/chocosolver/solver/variables/view/set/SetGraphView.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/view/set/SetGraphView.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.variables.view.set;

--- a/solver/src/main/java/org/chocosolver/solver/variables/view/set/SetIntersectionView.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/view/set/SetIntersectionView.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.variables.view.set;

--- a/solver/src/main/java/org/chocosolver/solver/variables/view/set/SetIntsView.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/view/set/SetIntsView.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.variables.view.set;

--- a/solver/src/main/java/org/chocosolver/solver/variables/view/set/SetNodeGraphView.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/view/set/SetNodeGraphView.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.variables.view.set;

--- a/solver/src/main/java/org/chocosolver/solver/variables/view/set/SetPredecessorsGraphView.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/view/set/SetPredecessorsGraphView.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.variables.view.set;

--- a/solver/src/main/java/org/chocosolver/solver/variables/view/set/SetSuccessorsGraphView.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/view/set/SetSuccessorsGraphView.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.variables.view.set;

--- a/solver/src/main/java/org/chocosolver/solver/variables/view/set/SetUnionView.java
+++ b/solver/src/main/java/org/chocosolver/solver/variables/view/set/SetUnionView.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.variables.view.set;

--- a/solver/src/main/java/org/chocosolver/util/ESat.java
+++ b/solver/src/main/java/org/chocosolver/util/ESat.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.util;

--- a/solver/src/main/java/org/chocosolver/util/Indexable.java
+++ b/solver/src/main/java/org/chocosolver/util/Indexable.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.util;

--- a/solver/src/main/java/org/chocosolver/util/PoolManager.java
+++ b/solver/src/main/java/org/chocosolver/util/PoolManager.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.util;

--- a/solver/src/main/java/org/chocosolver/util/bandit/MOSS.java
+++ b/solver/src/main/java/org/chocosolver/util/bandit/MOSS.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.util.bandit;

--- a/solver/src/main/java/org/chocosolver/util/bandit/Policy.java
+++ b/solver/src/main/java/org/chocosolver/util/bandit/Policy.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.util.bandit;

--- a/solver/src/main/java/org/chocosolver/util/bandit/Static.java
+++ b/solver/src/main/java/org/chocosolver/util/bandit/Static.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.util.bandit;

--- a/solver/src/main/java/org/chocosolver/util/bandit/UCB1.java
+++ b/solver/src/main/java/org/chocosolver/util/bandit/UCB1.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.util.bandit;

--- a/solver/src/main/java/org/chocosolver/util/criteria/Criterion.java
+++ b/solver/src/main/java/org/chocosolver/util/criteria/Criterion.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.util.criteria;

--- a/solver/src/main/java/org/chocosolver/util/criteria/LongCriterion.java
+++ b/solver/src/main/java/org/chocosolver/util/criteria/LongCriterion.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.util.criteria;

--- a/solver/src/main/java/org/chocosolver/util/graphOperations/BitOperations.java
+++ b/solver/src/main/java/org/chocosolver/util/graphOperations/BitOperations.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.util.graphOperations;

--- a/solver/src/main/java/org/chocosolver/util/graphOperations/LCAGraphManager.java
+++ b/solver/src/main/java/org/chocosolver/util/graphOperations/LCAGraphManager.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.util.graphOperations;

--- a/solver/src/main/java/org/chocosolver/util/graphOperations/connectivity/ConnectivityFinder.java
+++ b/solver/src/main/java/org/chocosolver/util/graphOperations/connectivity/ConnectivityFinder.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.util.graphOperations.connectivity;

--- a/solver/src/main/java/org/chocosolver/util/graphOperations/connectivity/StrongConnectivityFinder.java
+++ b/solver/src/main/java/org/chocosolver/util/graphOperations/connectivity/StrongConnectivityFinder.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.util.graphOperations.connectivity;

--- a/solver/src/main/java/org/chocosolver/util/graphOperations/connectivity/UGVarConnectivityHelper.java
+++ b/solver/src/main/java/org/chocosolver/util/graphOperations/connectivity/UGVarConnectivityHelper.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.util.graphOperations.connectivity;

--- a/solver/src/main/java/org/chocosolver/util/graphOperations/dominance/AbstractLengauerTarjanDominatorsFinder.java
+++ b/solver/src/main/java/org/chocosolver/util/graphOperations/dominance/AbstractLengauerTarjanDominatorsFinder.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.util.graphOperations.dominance;

--- a/solver/src/main/java/org/chocosolver/util/graphOperations/dominance/AlphaDominatorsFinder.java
+++ b/solver/src/main/java/org/chocosolver/util/graphOperations/dominance/AlphaDominatorsFinder.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.util.graphOperations.dominance;

--- a/solver/src/main/java/org/chocosolver/util/graphOperations/dominance/SimpleDominatorsFinder.java
+++ b/solver/src/main/java/org/chocosolver/util/graphOperations/dominance/SimpleDominatorsFinder.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.util.graphOperations.dominance;

--- a/solver/src/main/java/org/chocosolver/util/iterators/Disposable.java
+++ b/solver/src/main/java/org/chocosolver/util/iterators/Disposable.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.util.iterators;

--- a/solver/src/main/java/org/chocosolver/util/iterators/DisposableIntIterator.java
+++ b/solver/src/main/java/org/chocosolver/util/iterators/DisposableIntIterator.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.util.iterators;

--- a/solver/src/main/java/org/chocosolver/util/iterators/DisposableRangeBoundIterator.java
+++ b/solver/src/main/java/org/chocosolver/util/iterators/DisposableRangeBoundIterator.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.util.iterators;

--- a/solver/src/main/java/org/chocosolver/util/iterators/DisposableRangeIterator.java
+++ b/solver/src/main/java/org/chocosolver/util/iterators/DisposableRangeIterator.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.util.iterators;

--- a/solver/src/main/java/org/chocosolver/util/iterators/DisposableValueBoundIterator.java
+++ b/solver/src/main/java/org/chocosolver/util/iterators/DisposableValueBoundIterator.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.util.iterators;

--- a/solver/src/main/java/org/chocosolver/util/iterators/DisposableValueIterator.java
+++ b/solver/src/main/java/org/chocosolver/util/iterators/DisposableValueIterator.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.util.iterators;

--- a/solver/src/main/java/org/chocosolver/util/iterators/EvtScheduler.java
+++ b/solver/src/main/java/org/chocosolver/util/iterators/EvtScheduler.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.util.iterators;

--- a/solver/src/main/java/org/chocosolver/util/iterators/IntIterator.java
+++ b/solver/src/main/java/org/chocosolver/util/iterators/IntIterator.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.util.iterators;

--- a/solver/src/main/java/org/chocosolver/util/iterators/IntVarValueIterator.java
+++ b/solver/src/main/java/org/chocosolver/util/iterators/IntVarValueIterator.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.util.iterators;

--- a/solver/src/main/java/org/chocosolver/util/iterators/RangeIterator.java
+++ b/solver/src/main/java/org/chocosolver/util/iterators/RangeIterator.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.util.iterators;

--- a/solver/src/main/java/org/chocosolver/util/iterators/ValueIterator.java
+++ b/solver/src/main/java/org/chocosolver/util/iterators/ValueIterator.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.util.iterators;

--- a/solver/src/main/java/org/chocosolver/util/logger/ANSILogger.java
+++ b/solver/src/main/java/org/chocosolver/util/logger/ANSILogger.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.util.logger;

--- a/solver/src/main/java/org/chocosolver/util/logger/Logger.java
+++ b/solver/src/main/java/org/chocosolver/util/logger/Logger.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.util.logger;

--- a/solver/src/main/java/org/chocosolver/util/objects/BipartiteMatching.java
+++ b/solver/src/main/java/org/chocosolver/util/objects/BipartiteMatching.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.util.objects;

--- a/solver/src/main/java/org/chocosolver/util/objects/IdentityToDouble.java
+++ b/solver/src/main/java/org/chocosolver/util/objects/IdentityToDouble.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.util.objects;

--- a/solver/src/main/java/org/chocosolver/util/objects/IntCircularQueue.java
+++ b/solver/src/main/java/org/chocosolver/util/objects/IntCircularQueue.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.util.objects;

--- a/solver/src/main/java/org/chocosolver/util/objects/IntHeap.java
+++ b/solver/src/main/java/org/chocosolver/util/objects/IntHeap.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.util.objects;

--- a/solver/src/main/java/org/chocosolver/util/objects/IntList.java
+++ b/solver/src/main/java/org/chocosolver/util/objects/IntList.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.util.objects;

--- a/solver/src/main/java/org/chocosolver/util/objects/IntMap.java
+++ b/solver/src/main/java/org/chocosolver/util/objects/IntMap.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.util.objects;

--- a/solver/src/main/java/org/chocosolver/util/objects/PriorityQueue.java
+++ b/solver/src/main/java/org/chocosolver/util/objects/PriorityQueue.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.util.objects;

--- a/solver/src/main/java/org/chocosolver/util/objects/RealInterval.java
+++ b/solver/src/main/java/org/chocosolver/util/objects/RealInterval.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.util.objects;

--- a/solver/src/main/java/org/chocosolver/util/objects/StoredIndexedBipartiteSet.java
+++ b/solver/src/main/java/org/chocosolver/util/objects/StoredIndexedBipartiteSet.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.util.objects;

--- a/solver/src/main/java/org/chocosolver/util/objects/StoredIndexedBipartiteSetWithOffset.java
+++ b/solver/src/main/java/org/chocosolver/util/objects/StoredIndexedBipartiteSetWithOffset.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.util.objects;

--- a/solver/src/main/java/org/chocosolver/util/objects/StoredSparseSet.java
+++ b/solver/src/main/java/org/chocosolver/util/objects/StoredSparseSet.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.util.objects;

--- a/solver/src/main/java/org/chocosolver/util/objects/TrackingList.java
+++ b/solver/src/main/java/org/chocosolver/util/objects/TrackingList.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.util.objects;

--- a/solver/src/main/java/org/chocosolver/util/objects/graphs/DirectedGraph.java
+++ b/solver/src/main/java/org/chocosolver/util/objects/graphs/DirectedGraph.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.util.objects.graphs;

--- a/solver/src/main/java/org/chocosolver/util/objects/graphs/GraphFactory.java
+++ b/solver/src/main/java/org/chocosolver/util/objects/graphs/GraphFactory.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.util.objects.graphs;

--- a/solver/src/main/java/org/chocosolver/util/objects/graphs/IGraph.java
+++ b/solver/src/main/java/org/chocosolver/util/objects/graphs/IGraph.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.util.objects.graphs;

--- a/solver/src/main/java/org/chocosolver/util/objects/graphs/MultivaluedDecisionDiagram.java
+++ b/solver/src/main/java/org/chocosolver/util/objects/graphs/MultivaluedDecisionDiagram.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.util.objects.graphs;

--- a/solver/src/main/java/org/chocosolver/util/objects/graphs/Orientation.java
+++ b/solver/src/main/java/org/chocosolver/util/objects/graphs/Orientation.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 /**

--- a/solver/src/main/java/org/chocosolver/util/objects/graphs/UndirectedGraph.java
+++ b/solver/src/main/java/org/chocosolver/util/objects/graphs/UndirectedGraph.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.util.objects.graphs;

--- a/solver/src/main/java/org/chocosolver/util/objects/queues/CircularQueue.java
+++ b/solver/src/main/java/org/chocosolver/util/objects/queues/CircularQueue.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.util.objects.queues;

--- a/solver/src/main/java/org/chocosolver/util/objects/setDataStructures/AbstractSet.java
+++ b/solver/src/main/java/org/chocosolver/util/objects/setDataStructures/AbstractSet.java
@@ -1,19 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
- * See LICENSE file in the project root for full license information.
- */
-/*
- * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2021, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.util.objects.setDataStructures;

--- a/solver/src/main/java/org/chocosolver/util/objects/setDataStructures/FixedIntArrayIterator.java
+++ b/solver/src/main/java/org/chocosolver/util/objects/setDataStructures/FixedIntArrayIterator.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.util.objects.setDataStructures;

--- a/solver/src/main/java/org/chocosolver/util/objects/setDataStructures/ISet.java
+++ b/solver/src/main/java/org/chocosolver/util/objects/setDataStructures/ISet.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.util.objects.setDataStructures;

--- a/solver/src/main/java/org/chocosolver/util/objects/setDataStructures/ISetIterator.java
+++ b/solver/src/main/java/org/chocosolver/util/objects/setDataStructures/ISetIterator.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.util.objects.setDataStructures;

--- a/solver/src/main/java/org/chocosolver/util/objects/setDataStructures/SetFactory.java
+++ b/solver/src/main/java/org/chocosolver/util/objects/setDataStructures/SetFactory.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 /**

--- a/solver/src/main/java/org/chocosolver/util/objects/setDataStructures/SetType.java
+++ b/solver/src/main/java/org/chocosolver/util/objects/setDataStructures/SetType.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.util.objects.setDataStructures;

--- a/solver/src/main/java/org/chocosolver/util/objects/setDataStructures/Set_ReadOnly.java
+++ b/solver/src/main/java/org/chocosolver/util/objects/setDataStructures/Set_ReadOnly.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.util.objects.setDataStructures;

--- a/solver/src/main/java/org/chocosolver/util/objects/setDataStructures/StdSet.java
+++ b/solver/src/main/java/org/chocosolver/util/objects/setDataStructures/StdSet.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.util.objects.setDataStructures;

--- a/solver/src/main/java/org/chocosolver/util/objects/setDataStructures/bitset/Set_BitSet.java
+++ b/solver/src/main/java/org/chocosolver/util/objects/setDataStructures/bitset/Set_BitSet.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.util.objects.setDataStructures.bitset;

--- a/solver/src/main/java/org/chocosolver/util/objects/setDataStructures/bitset/Set_Std_BitSet.java
+++ b/solver/src/main/java/org/chocosolver/util/objects/setDataStructures/bitset/Set_Std_BitSet.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.util.objects.setDataStructures.bitset;

--- a/solver/src/main/java/org/chocosolver/util/objects/setDataStructures/constant/Set_CstInterval.java
+++ b/solver/src/main/java/org/chocosolver/util/objects/setDataStructures/constant/Set_CstInterval.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.util.objects.setDataStructures.constant;

--- a/solver/src/main/java/org/chocosolver/util/objects/setDataStructures/constant/Set_FixedArray.java
+++ b/solver/src/main/java/org/chocosolver/util/objects/setDataStructures/constant/Set_FixedArray.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.util.objects.setDataStructures.constant;

--- a/solver/src/main/java/org/chocosolver/util/objects/setDataStructures/dynamic/SetDifference.java
+++ b/solver/src/main/java/org/chocosolver/util/objects/setDataStructures/dynamic/SetDifference.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.util.objects.setDataStructures.dynamic;

--- a/solver/src/main/java/org/chocosolver/util/objects/setDataStructures/dynamic/SetDynamicFilter.java
+++ b/solver/src/main/java/org/chocosolver/util/objects/setDataStructures/dynamic/SetDynamicFilter.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.util.objects.setDataStructures.dynamic;

--- a/solver/src/main/java/org/chocosolver/util/objects/setDataStructures/dynamic/SetDynamicFilterOnSet.java
+++ b/solver/src/main/java/org/chocosolver/util/objects/setDataStructures/dynamic/SetDynamicFilterOnSet.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.util.objects.setDataStructures.dynamic;

--- a/solver/src/main/java/org/chocosolver/util/objects/setDataStructures/dynamic/SetIntersection.java
+++ b/solver/src/main/java/org/chocosolver/util/objects/setDataStructures/dynamic/SetIntersection.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.util.objects.setDataStructures.dynamic;

--- a/solver/src/main/java/org/chocosolver/util/objects/setDataStructures/dynamic/SetUnion.java
+++ b/solver/src/main/java/org/chocosolver/util/objects/setDataStructures/dynamic/SetUnion.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.util.objects.setDataStructures.dynamic;

--- a/solver/src/main/java/org/chocosolver/util/objects/setDataStructures/iterable/IntIterableBitSet.java
+++ b/solver/src/main/java/org/chocosolver/util/objects/setDataStructures/iterable/IntIterableBitSet.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.util.objects.setDataStructures.iterable;

--- a/solver/src/main/java/org/chocosolver/util/objects/setDataStructures/iterable/IntIterableRangeSet.java
+++ b/solver/src/main/java/org/chocosolver/util/objects/setDataStructures/iterable/IntIterableRangeSet.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.util.objects.setDataStructures.iterable;

--- a/solver/src/main/java/org/chocosolver/util/objects/setDataStructures/iterable/IntIterableSet.java
+++ b/solver/src/main/java/org/chocosolver/util/objects/setDataStructures/iterable/IntIterableSet.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.util.objects.setDataStructures.iterable;

--- a/solver/src/main/java/org/chocosolver/util/objects/setDataStructures/iterable/IntIterableSetUtils.java
+++ b/solver/src/main/java/org/chocosolver/util/objects/setDataStructures/iterable/IntIterableSetUtils.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.util.objects.setDataStructures.iterable;

--- a/solver/src/main/java/org/chocosolver/util/objects/setDataStructures/linkedlist/Set_LinkedList.java
+++ b/solver/src/main/java/org/chocosolver/util/objects/setDataStructures/linkedlist/Set_LinkedList.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.util.objects.setDataStructures.linkedlist;

--- a/solver/src/main/java/org/chocosolver/util/objects/setDataStructures/swapList/Set_Std_Swap.java
+++ b/solver/src/main/java/org/chocosolver/util/objects/setDataStructures/swapList/Set_Std_Swap.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.util.objects.setDataStructures.swapList;

--- a/solver/src/main/java/org/chocosolver/util/objects/setDataStructures/swapList/Set_Std_Swap2.java
+++ b/solver/src/main/java/org/chocosolver/util/objects/setDataStructures/swapList/Set_Std_Swap2.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.util.objects.setDataStructures.swapList;

--- a/solver/src/main/java/org/chocosolver/util/objects/setDataStructures/swapList/Set_Swap.java
+++ b/solver/src/main/java/org/chocosolver/util/objects/setDataStructures/swapList/Set_Swap.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.util.objects.setDataStructures.swapList;

--- a/solver/src/main/java/org/chocosolver/util/objects/setDataStructures/swapList/Set_Swap2.java
+++ b/solver/src/main/java/org/chocosolver/util/objects/setDataStructures/swapList/Set_Swap2.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.util.objects.setDataStructures.swapList;

--- a/solver/src/main/java/org/chocosolver/util/objects/tree/Interval.java
+++ b/solver/src/main/java/org/chocosolver/util/objects/tree/Interval.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.util.objects.tree;

--- a/solver/src/main/java/org/chocosolver/util/objects/tree/IntervalTree.java
+++ b/solver/src/main/java/org/chocosolver/util/objects/tree/IntervalTree.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.util.objects.tree;

--- a/solver/src/main/java/org/chocosolver/util/procedure/BinaryIntProcedure.java
+++ b/solver/src/main/java/org/chocosolver/util/procedure/BinaryIntProcedure.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.util.procedure;

--- a/solver/src/main/java/org/chocosolver/util/procedure/BinaryProcedure.java
+++ b/solver/src/main/java/org/chocosolver/util/procedure/BinaryProcedure.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.util.procedure;

--- a/solver/src/main/java/org/chocosolver/util/procedure/IntProcedure.java
+++ b/solver/src/main/java/org/chocosolver/util/procedure/IntProcedure.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.util.procedure;

--- a/solver/src/main/java/org/chocosolver/util/procedure/PairProcedure.java
+++ b/solver/src/main/java/org/chocosolver/util/procedure/PairProcedure.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.util.procedure;

--- a/solver/src/main/java/org/chocosolver/util/procedure/Procedure.java
+++ b/solver/src/main/java/org/chocosolver/util/procedure/Procedure.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.util.procedure;

--- a/solver/src/main/java/org/chocosolver/util/procedure/SafeIntProcedure.java
+++ b/solver/src/main/java/org/chocosolver/util/procedure/SafeIntProcedure.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.util.procedure;

--- a/solver/src/main/java/org/chocosolver/util/procedure/TernaryIntProcedure.java
+++ b/solver/src/main/java/org/chocosolver/util/procedure/TernaryIntProcedure.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.util.procedure;

--- a/solver/src/main/java/org/chocosolver/util/procedure/TernaryProcedure.java
+++ b/solver/src/main/java/org/chocosolver/util/procedure/TernaryProcedure.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.util.procedure;

--- a/solver/src/main/java/org/chocosolver/util/procedure/UnaryIntProcedure.java
+++ b/solver/src/main/java/org/chocosolver/util/procedure/UnaryIntProcedure.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.util.procedure;

--- a/solver/src/main/java/org/chocosolver/util/procedure/UnaryProcedure.java
+++ b/solver/src/main/java/org/chocosolver/util/procedure/UnaryProcedure.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.util.procedure;

--- a/solver/src/main/java/org/chocosolver/util/procedure/UnarySafeIntProcedure.java
+++ b/solver/src/main/java/org/chocosolver/util/procedure/UnarySafeIntProcedure.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.util.procedure;

--- a/solver/src/main/java/org/chocosolver/util/sort/ArraySort.java
+++ b/solver/src/main/java/org/chocosolver/util/sort/ArraySort.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 /**

--- a/solver/src/main/java/org/chocosolver/util/sort/IntComparator.java
+++ b/solver/src/main/java/org/chocosolver/util/sort/IntComparator.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.util.sort;

--- a/solver/src/main/java/org/chocosolver/util/tools/ArrayUtils.java
+++ b/solver/src/main/java/org/chocosolver/util/tools/ArrayUtils.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.util.tools;

--- a/solver/src/main/java/org/chocosolver/util/tools/MathUtils.java
+++ b/solver/src/main/java/org/chocosolver/util/tools/MathUtils.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.util.tools;

--- a/solver/src/main/java/org/chocosolver/util/tools/PreProcessing.java
+++ b/solver/src/main/java/org/chocosolver/util/tools/PreProcessing.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.util.tools;

--- a/solver/src/main/java/org/chocosolver/util/tools/RealUtils.java
+++ b/solver/src/main/java/org/chocosolver/util/tools/RealUtils.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.util.tools;

--- a/solver/src/main/java/org/chocosolver/util/tools/StatisticUtils.java
+++ b/solver/src/main/java/org/chocosolver/util/tools/StatisticUtils.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.util.tools;

--- a/solver/src/main/java/org/chocosolver/util/tools/StringUtils.java
+++ b/solver/src/main/java/org/chocosolver/util/tools/StringUtils.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.util.tools;

--- a/solver/src/main/java/org/chocosolver/util/tools/TimeUtils.java
+++ b/solver/src/main/java/org/chocosolver/util/tools/TimeUtils.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.util.tools;

--- a/solver/src/main/java/org/chocosolver/util/tools/VariableUtils.java
+++ b/solver/src/main/java/org/chocosolver/util/tools/VariableUtils.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.util.tools;

--- a/solver/src/main/resources/org/chocosolver/memory/IState_E_.template
+++ b/solver/src/main/resources/org/chocosolver/memory/IState_E_.template
@@ -1,10 +1,7 @@
 /**
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.memory;

--- a/solver/src/main/resources/org/chocosolver/memory/trailing/Stored_E_.template
+++ b/solver/src/main/resources/org/chocosolver/memory/trailing/Stored_E_.template
@@ -1,10 +1,7 @@
 /**
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.memory.trailing;

--- a/solver/src/main/resources/org/chocosolver/memory/trailing/trail/IStored_E_Trail.template
+++ b/solver/src/main/resources/org/chocosolver/memory/trailing/trail/IStored_E_Trail.template
@@ -1,10 +1,7 @@
 /**
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.memory.trailing.trail;

--- a/solver/src/main/resources/org/chocosolver/memory/trailing/trail/chunck/Chuncked_E_Trail.template
+++ b/solver/src/main/resources/org/chocosolver/memory/trailing/trail/chunck/Chuncked_E_Trail.template
@@ -1,10 +1,7 @@
 /**
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.memory.trailing.trail.chunck;

--- a/solver/src/main/resources/org/chocosolver/memory/trailing/trail/chunck/_E_World.template
+++ b/solver/src/main/resources/org/chocosolver/memory/trailing/trail/chunck/_E_World.template
@@ -1,10 +1,7 @@
 /**
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.memory.trailing.trail.chunck;

--- a/solver/src/main/resources/org/chocosolver/memory/trailing/trail/flatten/Stored_E_Trail.template
+++ b/solver/src/main/resources/org/chocosolver/memory/trailing/trail/flatten/Stored_E_Trail.template
@@ -1,10 +1,7 @@
 /**
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.memory.trailing.trail.flatten;

--- a/solver/src/main/resources/org/chocosolver/memory/trailing/trail/unsafe/Unsafe_E_Trail.template
+++ b/solver/src/main/resources/org/chocosolver/memory/trailing/trail/unsafe/Unsafe_E_Trail.template
@@ -1,10 +1,7 @@
 /**
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.memory.trailing.trail.unsafe;

--- a/solver/src/test/java/org/chocosolver/SuspiciousTest.java
+++ b/solver/src/test/java/org/chocosolver/SuspiciousTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver;

--- a/solver/src/test/java/org/chocosolver/cutoffseq/RestartTest.java
+++ b/solver/src/test/java/org/chocosolver/cutoffseq/RestartTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.cutoffseq;

--- a/solver/src/test/java/org/chocosolver/lp/LinearProgramTest.java
+++ b/solver/src/test/java/org/chocosolver/lp/LinearProgramTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.lp;

--- a/solver/src/test/java/org/chocosolver/lp/MILPTest.java
+++ b/solver/src/test/java/org/chocosolver/lp/MILPTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.lp;

--- a/solver/src/test/java/org/chocosolver/lp/TwoPhaseSimplex.java
+++ b/solver/src/test/java/org/chocosolver/lp/TwoPhaseSimplex.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.lp;

--- a/solver/src/test/java/org/chocosolver/memory/BasicIndexBipartiteSetTest.java
+++ b/solver/src/test/java/org/chocosolver/memory/BasicIndexBipartiteSetTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.memory;

--- a/solver/src/test/java/org/chocosolver/memory/DynamicAdditionTest.java
+++ b/solver/src/test/java/org/chocosolver/memory/DynamicAdditionTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.memory;

--- a/solver/src/test/java/org/chocosolver/memory/EnvironmentTest.java
+++ b/solver/src/test/java/org/chocosolver/memory/EnvironmentTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.memory;

--- a/solver/src/test/java/org/chocosolver/memory/PopTest.java
+++ b/solver/src/test/java/org/chocosolver/memory/PopTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.memory;

--- a/solver/src/test/java/org/chocosolver/memory/structure/SparseBitSetTest.java
+++ b/solver/src/test/java/org/chocosolver/memory/structure/SparseBitSetTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.memory.structure;

--- a/solver/src/test/java/org/chocosolver/sat/IReasonManagerTest.java
+++ b/solver/src/test/java/org/chocosolver/sat/IReasonManagerTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.sat;

--- a/solver/src/test/java/org/chocosolver/sat/SatDecoratoTest.java
+++ b/solver/src/test/java/org/chocosolver/sat/SatDecoratoTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.sat;

--- a/solver/src/test/java/org/chocosolver/sat/SatSolverTest.java
+++ b/solver/src/test/java/org/chocosolver/sat/SatSolverTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.sat;

--- a/solver/src/test/java/org/chocosolver/sat/SatTest.java
+++ b/solver/src/test/java/org/chocosolver/sat/SatTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.sat;

--- a/solver/src/test/java/org/chocosolver/solver/EnvironmentTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/EnvironmentTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 /**

--- a/solver/src/test/java/org/chocosolver/solver/LimitsTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/LimitsTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver;

--- a/solver/src/test/java/org/chocosolver/solver/ModelTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/ModelTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver;

--- a/solver/src/test/java/org/chocosolver/solver/PortFolioTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/PortFolioTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver;

--- a/solver/src/test/java/org/chocosolver/solver/Providers.java
+++ b/solver/src/test/java/org/chocosolver/solver/Providers.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver;

--- a/solver/src/test/java/org/chocosolver/solver/SolutionTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/SolutionTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver;

--- a/solver/src/test/java/org/chocosolver/solver/TestSolveur.java
+++ b/solver/src/test/java/org/chocosolver/solver/TestSolveur.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver;

--- a/solver/src/test/java/org/chocosolver/solver/constraints/ClauseTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/ClauseTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints;

--- a/solver/src/test/java/org/chocosolver/solver/constraints/ConstraintTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/ConstraintTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints;

--- a/solver/src/test/java/org/chocosolver/solver/constraints/DynamicPostTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/DynamicPostTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints;

--- a/solver/src/test/java/org/chocosolver/solver/constraints/IReificationFactoryTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/IReificationFactoryTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints;

--- a/solver/src/test/java/org/chocosolver/solver/constraints/LogicTreeTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/LogicTreeTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints;

--- a/solver/src/test/java/org/chocosolver/solver/constraints/SetIntUnion.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/SetIntUnion.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 /**

--- a/solver/src/test/java/org/chocosolver/solver/constraints/binary/AbstractBinaryTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/binary/AbstractBinaryTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.binary;

--- a/solver/src/test/java/org/chocosolver/solver/constraints/binary/BinTableTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/binary/BinTableTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.binary;

--- a/solver/src/test/java/org/chocosolver/solver/constraints/binary/DistanceEQTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/binary/DistanceEQTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.binary;

--- a/solver/src/test/java/org/chocosolver/solver/constraints/binary/DistanceGTTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/binary/DistanceGTTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.binary;

--- a/solver/src/test/java/org/chocosolver/solver/constraints/binary/DistanceLTTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/binary/DistanceLTTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.binary;

--- a/solver/src/test/java/org/chocosolver/solver/constraints/binary/DistanceNQTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/binary/DistanceNQTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.binary;

--- a/solver/src/test/java/org/chocosolver/solver/constraints/binary/DistanceTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/binary/DistanceTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.binary;

--- a/solver/src/test/java/org/chocosolver/solver/constraints/binary/ElementTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/binary/ElementTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.binary;

--- a/solver/src/test/java/org/chocosolver/solver/constraints/binary/EqTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/binary/EqTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.binary;

--- a/solver/src/test/java/org/chocosolver/solver/constraints/binary/ModXYTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/binary/ModXYTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.binary;

--- a/solver/src/test/java/org/chocosolver/solver/constraints/binary/NotEqualX_YCTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/binary/NotEqualX_YCTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.binary;

--- a/solver/src/test/java/org/chocosolver/solver/constraints/binary/PowTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/binary/PowTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.binary;

--- a/solver/src/test/java/org/chocosolver/solver/constraints/binary/SquareTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/binary/SquareTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.binary;

--- a/solver/src/test/java/org/chocosolver/solver/constraints/checker/DomainBuilder.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/checker/DomainBuilder.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.checker;

--- a/solver/src/test/java/org/chocosolver/solver/constraints/checker/Modeler.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/checker/Modeler.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.checker;

--- a/solver/src/test/java/org/chocosolver/solver/constraints/checker/QuickXPlainTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/checker/QuickXPlainTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.checker;

--- a/solver/src/test/java/org/chocosolver/solver/constraints/checker/consistency/ConsistencyChecker.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/checker/consistency/ConsistencyChecker.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.checker.consistency;

--- a/solver/src/test/java/org/chocosolver/solver/constraints/checker/consistency/TestConsistency.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/checker/consistency/TestConsistency.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.checker.consistency;

--- a/solver/src/test/java/org/chocosolver/solver/constraints/checker/consistency/TestConsistencyFactory.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/checker/consistency/TestConsistencyFactory.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.checker.consistency;

--- a/solver/src/test/java/org/chocosolver/solver/constraints/checker/correctness/CorrectnessChecker.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/checker/correctness/CorrectnessChecker.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.checker.correctness;

--- a/solver/src/test/java/org/chocosolver/solver/constraints/checker/correctness/TestCorrectness.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/checker/correctness/TestCorrectness.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.checker.correctness;

--- a/solver/src/test/java/org/chocosolver/solver/constraints/checker/explanation/TestExplanation.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/checker/explanation/TestExplanation.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.checker.explanation;

--- a/solver/src/test/java/org/chocosolver/solver/constraints/checker/fmk/Correctness.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/checker/fmk/Correctness.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.checker.fmk;

--- a/solver/src/test/java/org/chocosolver/solver/constraints/checker/fmk/Domain.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/checker/fmk/Domain.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 /**

--- a/solver/src/test/java/org/chocosolver/solver/constraints/checker/fmk/SetTestModel.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/checker/fmk/SetTestModel.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.checker.fmk;

--- a/solver/src/test/java/org/chocosolver/solver/constraints/checker/fmk/Test_Bools_Sets.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/checker/fmk/Test_Bools_Sets.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.checker.fmk;

--- a/solver/src/test/java/org/chocosolver/solver/constraints/extension/hybrid/HybridTableTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/extension/hybrid/HybridTableTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.extension.hybrid;

--- a/solver/src/test/java/org/chocosolver/solver/constraints/graph/basic/AntiSymmetricTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/graph/basic/AntiSymmetricTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.graph.basic;

--- a/solver/src/test/java/org/chocosolver/solver/constraints/graph/basic/DiameterTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/graph/basic/DiameterTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.graph.basic;

--- a/solver/src/test/java/org/chocosolver/solver/constraints/graph/basic/LoopSetTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/graph/basic/LoopSetTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.graph.basic;

--- a/solver/src/test/java/org/chocosolver/solver/constraints/graph/basic/NbCliquesTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/graph/basic/NbCliquesTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.graph.basic;

--- a/solver/src/test/java/org/chocosolver/solver/constraints/graph/basic/NbEdgesTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/graph/basic/NbEdgesTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.graph.basic;

--- a/solver/src/test/java/org/chocosolver/solver/constraints/graph/basic/NbLoopsTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/graph/basic/NbLoopsTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.graph.basic;

--- a/solver/src/test/java/org/chocosolver/solver/constraints/graph/basic/NbNodesTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/graph/basic/NbNodesTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.graph.basic;

--- a/solver/src/test/java/org/chocosolver/solver/constraints/graph/basic/SymmetricTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/graph/basic/SymmetricTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.graph.basic;

--- a/solver/src/test/java/org/chocosolver/solver/constraints/graph/basic/TransitivityTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/graph/basic/TransitivityTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.graph.basic;

--- a/solver/src/test/java/org/chocosolver/solver/constraints/graph/channeling/edges/EdgeChannelingTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/graph/channeling/edges/EdgeChannelingTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.graph.channeling.edges;

--- a/solver/src/test/java/org/chocosolver/solver/constraints/graph/channeling/edges/NeighborsChannelingTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/graph/channeling/edges/NeighborsChannelingTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.graph.channeling.edges;

--- a/solver/src/test/java/org/chocosolver/solver/constraints/graph/channeling/edges/PredecessorsChannelingTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/graph/channeling/edges/PredecessorsChannelingTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.graph.channeling.edges;

--- a/solver/src/test/java/org/chocosolver/solver/constraints/graph/channeling/edges/SuccessorsChannelingTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/graph/channeling/edges/SuccessorsChannelingTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.graph.channeling.edges;

--- a/solver/src/test/java/org/chocosolver/solver/constraints/graph/channeling/nodes/NodesChannelingTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/graph/channeling/nodes/NodesChannelingTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.graph.channeling.nodes;

--- a/solver/src/test/java/org/chocosolver/solver/constraints/graph/connectivity/BiconnectedTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/graph/connectivity/BiconnectedTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.graph.connectivity;

--- a/solver/src/test/java/org/chocosolver/solver/constraints/graph/connectivity/ConnectedTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/graph/connectivity/ConnectedTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.graph.connectivity;

--- a/solver/src/test/java/org/chocosolver/solver/constraints/graph/connectivity/NbConnectedComponentsTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/graph/connectivity/NbConnectedComponentsTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.graph.connectivity;

--- a/solver/src/test/java/org/chocosolver/solver/constraints/graph/connectivity/NbStronglyConnectedComponentsTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/graph/connectivity/NbStronglyConnectedComponentsTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.graph.connectivity;

--- a/solver/src/test/java/org/chocosolver/solver/constraints/graph/connectivity/ReifiedConnectivityTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/graph/connectivity/ReifiedConnectivityTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.graph.connectivity;

--- a/solver/src/test/java/org/chocosolver/solver/constraints/graph/connectivity/SizeMaxCCTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/graph/connectivity/SizeMaxCCTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.graph.connectivity;

--- a/solver/src/test/java/org/chocosolver/solver/constraints/graph/connectivity/SizeMinCCTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/graph/connectivity/SizeMinCCTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.graph.connectivity;

--- a/solver/src/test/java/org/chocosolver/solver/constraints/graph/cost/hcp/HCP_Utils.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/graph/cost/hcp/HCP_Utils.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.graph.cost.hcp;

--- a/solver/src/test/java/org/chocosolver/solver/constraints/graph/cost/hcp/HamiltonianCycleProblemTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/graph/cost/hcp/HamiltonianCycleProblemTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.graph.cost.hcp;

--- a/solver/src/test/java/org/chocosolver/solver/constraints/graph/cost/hcp/KnightTourProblem.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/graph/cost/hcp/KnightTourProblem.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.graph.cost.hcp;

--- a/solver/src/test/java/org/chocosolver/solver/constraints/graph/cost/trees/DCMST.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/graph/cost/trees/DCMST.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.graph.cost.trees;

--- a/solver/src/test/java/org/chocosolver/solver/constraints/graph/cost/trees/DcmtsTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/graph/cost/trees/DcmtsTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.graph.cost.trees;

--- a/solver/src/test/java/org/chocosolver/solver/constraints/graph/cost/tsp/TSP_Utils.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/graph/cost/tsp/TSP_Utils.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 /**

--- a/solver/src/test/java/org/chocosolver/solver/constraints/graph/cost/tsp/TSP_exact.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/graph/cost/tsp/TSP_exact.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.graph.cost.tsp;

--- a/solver/src/test/java/org/chocosolver/solver/constraints/graph/cost/tsp/TSP_lns.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/graph/cost/tsp/TSP_lns.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.graph.cost.tsp;

--- a/solver/src/test/java/org/chocosolver/solver/constraints/graph/cost/tsp/TspTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/graph/cost/tsp/TspTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 /**

--- a/solver/src/test/java/org/chocosolver/solver/constraints/graph/cycles/AcyclicTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/graph/cycles/AcyclicTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.graph.cycles;

--- a/solver/src/test/java/org/chocosolver/solver/constraints/graph/cycles/CycleTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/graph/cycles/CycleTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.graph.cycles;

--- a/solver/src/test/java/org/chocosolver/solver/constraints/graph/degree/DegreesTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/graph/degree/DegreesTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.graph.degree;

--- a/solver/src/test/java/org/chocosolver/solver/constraints/graph/degree/InDegreesTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/graph/degree/InDegreesTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.graph.degree;

--- a/solver/src/test/java/org/chocosolver/solver/constraints/graph/degree/OutDegreesTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/graph/degree/OutDegreesTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.graph.degree;

--- a/solver/src/test/java/org/chocosolver/solver/constraints/graph/inclusion/SubgraphTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/graph/inclusion/SubgraphTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.graph.inclusion;

--- a/solver/src/test/java/org/chocosolver/solver/constraints/graph/symmbreaking/SymmetryBreaking2Test.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/graph/symmbreaking/SymmetryBreaking2Test.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.graph.symmbreaking;

--- a/solver/src/test/java/org/chocosolver/solver/constraints/graph/symmbreaking/SymmetryBreaking3Test.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/graph/symmbreaking/SymmetryBreaking3Test.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.graph.symmbreaking;

--- a/solver/src/test/java/org/chocosolver/solver/constraints/graph/symmbreaking/SymmetryBreakingDirectedTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/graph/symmbreaking/SymmetryBreakingDirectedTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.graph.symmbreaking;

--- a/solver/src/test/java/org/chocosolver/solver/constraints/graph/symmbreaking/SymmetryBreakingTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/graph/symmbreaking/SymmetryBreakingTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.graph.symmbreaking;

--- a/solver/src/test/java/org/chocosolver/solver/constraints/graph/tree/DirectedTreeForestTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/graph/tree/DirectedTreeForestTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.graph.tree;

--- a/solver/src/test/java/org/chocosolver/solver/constraints/graph/tree/ForestTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/graph/tree/ForestTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.graph.tree;

--- a/solver/src/test/java/org/chocosolver/solver/constraints/graph/tree/ReachabilityTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/graph/tree/ReachabilityTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.graph.tree;

--- a/solver/src/test/java/org/chocosolver/solver/constraints/graph/tree/TreeTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/graph/tree/TreeTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.graph.tree;

--- a/solver/src/test/java/org/chocosolver/solver/constraints/nary/AllDiffPrecTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/nary/AllDiffPrecTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.nary;

--- a/solver/src/test/java/org/chocosolver/solver/constraints/nary/AllDifferentTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/nary/AllDifferentTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.nary;

--- a/solver/src/test/java/org/chocosolver/solver/constraints/nary/AmongTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/nary/AmongTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.nary;

--- a/solver/src/test/java/org/chocosolver/solver/constraints/nary/BinPackingTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/nary/BinPackingTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.nary;

--- a/solver/src/test/java/org/chocosolver/solver/constraints/nary/BitsIntChannelingTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/nary/BitsIntChannelingTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.nary;

--- a/solver/src/test/java/org/chocosolver/solver/constraints/nary/BoolsIntChannelingTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/nary/BoolsIntChannelingTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.nary;

--- a/solver/src/test/java/org/chocosolver/solver/constraints/nary/BottleneckTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/nary/BottleneckTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.nary;

--- a/solver/src/test/java/org/chocosolver/solver/constraints/nary/BoundGlobalCardinalityTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/nary/BoundGlobalCardinalityTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.nary;

--- a/solver/src/test/java/org/chocosolver/solver/constraints/nary/CNFTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/nary/CNFTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.nary;

--- a/solver/src/test/java/org/chocosolver/solver/constraints/nary/CircuitTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/nary/CircuitTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 /**

--- a/solver/src/test/java/org/chocosolver/solver/constraints/nary/ClauseChannelingTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/nary/ClauseChannelingTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.nary;

--- a/solver/src/test/java/org/chocosolver/solver/constraints/nary/CostRegularTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/nary/CostRegularTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.nary;

--- a/solver/src/test/java/org/chocosolver/solver/constraints/nary/CountTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/nary/CountTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.nary;

--- a/solver/src/test/java/org/chocosolver/solver/constraints/nary/CryptoTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/nary/CryptoTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.nary;

--- a/solver/src/test/java/org/chocosolver/solver/constraints/nary/CumulativeTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/nary/CumulativeTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.nary;

--- a/solver/src/test/java/org/chocosolver/solver/constraints/nary/DiffNTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/nary/DiffNTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.nary;

--- a/solver/src/test/java/org/chocosolver/solver/constraints/nary/IntValuePrecedeChainTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/nary/IntValuePrecedeChainTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.nary;

--- a/solver/src/test/java/org/chocosolver/solver/constraints/nary/InverseChannelingTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/nary/InverseChannelingTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.nary;

--- a/solver/src/test/java/org/chocosolver/solver/constraints/nary/KeysortingTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/nary/KeysortingTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.nary;

--- a/solver/src/test/java/org/chocosolver/solver/constraints/nary/KnapsackTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/nary/KnapsackTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.nary;

--- a/solver/src/test/java/org/chocosolver/solver/constraints/nary/LexChainTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/nary/LexChainTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.nary;

--- a/solver/src/test/java/org/chocosolver/solver/constraints/nary/LexTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/nary/LexTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.nary;

--- a/solver/src/test/java/org/chocosolver/solver/constraints/nary/MinMaxTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/nary/MinMaxTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.nary;

--- a/solver/src/test/java/org/chocosolver/solver/constraints/nary/MixedScalarTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/nary/MixedScalarTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.nary;

--- a/solver/src/test/java/org/chocosolver/solver/constraints/nary/MultiCostRegularTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/nary/MultiCostRegularTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.nary;

--- a/solver/src/test/java/org/chocosolver/solver/constraints/nary/NValueTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/nary/NValueTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 /**

--- a/solver/src/test/java/org/chocosolver/solver/constraints/nary/NetworkflowTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/nary/NetworkflowTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.nary;

--- a/solver/src/test/java/org/chocosolver/solver/constraints/nary/NogoodTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/nary/NogoodTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.nary;

--- a/solver/src/test/java/org/chocosolver/solver/constraints/nary/PathTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/nary/PathTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.nary;

--- a/solver/src/test/java/org/chocosolver/solver/constraints/nary/PropCondAllDiffTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/nary/PropCondAllDiffTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.nary;

--- a/solver/src/test/java/org/chocosolver/solver/constraints/nary/RegularTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/nary/RegularTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.nary;

--- a/solver/src/test/java/org/chocosolver/solver/constraints/nary/SatTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/nary/SatTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.nary;

--- a/solver/src/test/java/org/chocosolver/solver/constraints/nary/ScalarTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/nary/ScalarTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.nary;

--- a/solver/src/test/java/org/chocosolver/solver/constraints/nary/SortTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/nary/SortTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.nary;

--- a/solver/src/test/java/org/chocosolver/solver/constraints/nary/SubcircuitTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/nary/SubcircuitTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 /**

--- a/solver/src/test/java/org/chocosolver/solver/constraints/nary/SumTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/nary/SumTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.nary;

--- a/solver/src/test/java/org/chocosolver/solver/constraints/nary/TableTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/nary/TableTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 /**

--- a/solver/src/test/java/org/chocosolver/solver/constraints/nary/TestData.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/nary/TestData.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.nary;

--- a/solver/src/test/java/org/chocosolver/solver/constraints/nary/TreeTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/nary/TreeTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 /**

--- a/solver/src/test/java/org/chocosolver/solver/constraints/nary/knapsack/structure/FingerTreeTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/nary/knapsack/structure/FingerTreeTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.nary.knapsack.structure;

--- a/solver/src/test/java/org/chocosolver/solver/constraints/nary/lex/PropIncreasingTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/nary/lex/PropIncreasingTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.nary.lex;

--- a/solver/src/test/java/org/chocosolver/solver/constraints/nary/min_max/ArgmaxminTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/nary/min_max/ArgmaxminTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.nary.min_max;

--- a/solver/src/test/java/org/chocosolver/solver/constraints/nary/sat/PropSatTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/nary/sat/PropSatTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.nary.sat;

--- a/solver/src/test/java/org/chocosolver/solver/constraints/nary/sum/IntLinCombTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/nary/sum/IntLinCombTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.nary.sum;

--- a/solver/src/test/java/org/chocosolver/solver/constraints/real/RealBase.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/real/RealBase.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.real;

--- a/solver/src/test/java/org/chocosolver/solver/constraints/real/RealCubicTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/real/RealCubicTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.real;

--- a/solver/src/test/java/org/chocosolver/solver/constraints/real/RealExponentTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/real/RealExponentTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.real;

--- a/solver/src/test/java/org/chocosolver/solver/constraints/real/RealNegativePowerTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/real/RealNegativePowerTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.real;

--- a/solver/src/test/java/org/chocosolver/solver/constraints/real/RealSquareTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/real/RealSquareTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.real;

--- a/solver/src/test/java/org/chocosolver/solver/constraints/real/RealTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/real/RealTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.real;

--- a/solver/src/test/java/org/chocosolver/solver/constraints/real/RestTrigTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/real/RestTrigTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.real;

--- a/solver/src/test/java/org/chocosolver/solver/constraints/reification/IfThenElseTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/reification/IfThenElseTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.reification;

--- a/solver/src/test/java/org/chocosolver/solver/constraints/reification/ImplicationTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/reification/ImplicationTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.reification;

--- a/solver/src/test/java/org/chocosolver/solver/constraints/reification/PropConDisTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/reification/PropConDisTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.reification;

--- a/solver/src/test/java/org/chocosolver/solver/constraints/reification/ReifiedTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/reification/ReifiedTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.reification;

--- a/solver/src/test/java/org/chocosolver/solver/constraints/set/AllDifferentTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/set/AllDifferentTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.set;

--- a/solver/src/test/java/org/chocosolver/solver/constraints/set/AllDisjointTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/set/AllDisjointTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.set;

--- a/solver/src/test/java/org/chocosolver/solver/constraints/set/AtMost1EmptyTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/set/AtMost1EmptyTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.set;

--- a/solver/src/test/java/org/chocosolver/solver/constraints/set/BoolChannelTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/set/BoolChannelTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.set;

--- a/solver/src/test/java/org/chocosolver/solver/constraints/set/CardinalityTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/set/CardinalityTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.set;

--- a/solver/src/test/java/org/chocosolver/solver/constraints/set/ElementTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/set/ElementTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.set;

--- a/solver/src/test/java/org/chocosolver/solver/constraints/set/IntBoundedMemberTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/set/IntBoundedMemberTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.set;

--- a/solver/src/test/java/org/chocosolver/solver/constraints/set/IntChannelTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/set/IntChannelTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.set;

--- a/solver/src/test/java/org/chocosolver/solver/constraints/set/IntCstMemberTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/set/IntCstMemberTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.set;

--- a/solver/src/test/java/org/chocosolver/solver/constraints/set/IntEnumMemberSet.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/set/IntEnumMemberSet.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.set;

--- a/solver/src/test/java/org/chocosolver/solver/constraints/set/IntersectionTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/set/IntersectionTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.set;

--- a/solver/src/test/java/org/chocosolver/solver/constraints/set/InverseTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/set/InverseTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.set;

--- a/solver/src/test/java/org/chocosolver/solver/constraints/set/MaxElementTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/set/MaxElementTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.set;

--- a/solver/src/test/java/org/chocosolver/solver/constraints/set/MemberSetTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/set/MemberSetTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.set;

--- a/solver/src/test/java/org/chocosolver/solver/constraints/set/MinElementTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/set/MinElementTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.set;

--- a/solver/src/test/java/org/chocosolver/solver/constraints/set/NbEmptyTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/set/NbEmptyTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.set;

--- a/solver/src/test/java/org/chocosolver/solver/constraints/set/NotEmptyTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/set/NotEmptyTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.set;

--- a/solver/src/test/java/org/chocosolver/solver/constraints/set/NotMemberTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/set/NotMemberTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.set;

--- a/solver/src/test/java/org/chocosolver/solver/constraints/set/OffsetTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/set/OffsetTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.set;

--- a/solver/src/test/java/org/chocosolver/solver/constraints/set/SetCstrsTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/set/SetCstrsTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.set;

--- a/solver/src/test/java/org/chocosolver/solver/constraints/set/SortedSetIntsChannelTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/set/SortedSetIntsChannelTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.set;

--- a/solver/src/test/java/org/chocosolver/solver/constraints/set/SubsetEqTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/set/SubsetEqTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.set;

--- a/solver/src/test/java/org/chocosolver/solver/constraints/set/SumOfElementsTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/set/SumOfElementsTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.set;

--- a/solver/src/test/java/org/chocosolver/solver/constraints/set/SumTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/set/SumTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.set;

--- a/solver/src/test/java/org/chocosolver/solver/constraints/set/SymmetricTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/set/SymmetricTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.set;

--- a/solver/src/test/java/org/chocosolver/solver/constraints/set/UnionTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/set/UnionTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.set;

--- a/solver/src/test/java/org/chocosolver/solver/constraints/ternary/AbstractTernaryTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/ternary/AbstractTernaryTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.ternary;

--- a/solver/src/test/java/org/chocosolver/solver/constraints/ternary/DistanceEQTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/ternary/DistanceEQTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.ternary;

--- a/solver/src/test/java/org/chocosolver/solver/constraints/ternary/DistanceGETest.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/ternary/DistanceGETest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.ternary;

--- a/solver/src/test/java/org/chocosolver/solver/constraints/ternary/DistanceGTTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/ternary/DistanceGTTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.ternary;

--- a/solver/src/test/java/org/chocosolver/solver/constraints/ternary/DistanceLETest.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/ternary/DistanceLETest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.ternary;

--- a/solver/src/test/java/org/chocosolver/solver/constraints/ternary/DistanceLTTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/ternary/DistanceLTTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.ternary;

--- a/solver/src/test/java/org/chocosolver/solver/constraints/ternary/DivTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/ternary/DivTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.ternary;

--- a/solver/src/test/java/org/chocosolver/solver/constraints/ternary/MaxTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/ternary/MaxTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.ternary;

--- a/solver/src/test/java/org/chocosolver/solver/constraints/ternary/MinTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/ternary/MinTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.ternary;

--- a/solver/src/test/java/org/chocosolver/solver/constraints/ternary/ModXYZTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/ternary/ModXYZTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.ternary;

--- a/solver/src/test/java/org/chocosolver/solver/constraints/ternary/TimesTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/ternary/TimesTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.ternary;

--- a/solver/src/test/java/org/chocosolver/solver/constraints/unary/MemberTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/unary/MemberTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.unary;

--- a/solver/src/test/java/org/chocosolver/solver/constraints/unary/ModXTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/unary/ModXTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.unary;

--- a/solver/src/test/java/org/chocosolver/solver/constraints/unary/NotMemberTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/constraints/unary/NotMemberTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.constraints.unary;

--- a/solver/src/test/java/org/chocosolver/solver/expression/continuous/ExpressionTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/expression/continuous/ExpressionTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.expression.continuous;

--- a/solver/src/test/java/org/chocosolver/solver/expression/continuous/IbexTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/expression/continuous/IbexTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.expression.continuous;

--- a/solver/src/test/java/org/chocosolver/solver/expression/continuous/relational/IATest.java
+++ b/solver/src/test/java/org/chocosolver/solver/expression/continuous/relational/IATest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.expression.continuous.relational;

--- a/solver/src/test/java/org/chocosolver/solver/expression/continuous/relational/PropEquationTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/expression/continuous/relational/PropEquationTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.expression.continuous.relational;

--- a/solver/src/test/java/org/chocosolver/solver/expression/discrete/ExpressionTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/expression/discrete/ExpressionTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.expression.discrete;

--- a/solver/src/test/java/org/chocosolver/solver/lcg/LCGTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/lcg/LCGTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.lcg;

--- a/solver/src/test/java/org/chocosolver/solver/lcg/LitVarTests.java
+++ b/solver/src/test/java/org/chocosolver/solver/lcg/LitVarTests.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.lcg;

--- a/solver/src/test/java/org/chocosolver/solver/propagation/DeltaTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/propagation/DeltaTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.propagation;

--- a/solver/src/test/java/org/chocosolver/solver/propagation/PropEngineTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/propagation/PropEngineTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.propagation;

--- a/solver/src/test/java/org/chocosolver/solver/search/BlackBoxTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/search/BlackBoxTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.search;

--- a/solver/src/test/java/org/chocosolver/solver/search/MeasuresTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/search/MeasuresTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.search;

--- a/solver/src/test/java/org/chocosolver/solver/search/ObjectiveTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/search/ObjectiveTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.search;

--- a/solver/src/test/java/org/chocosolver/solver/search/ParetoTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/search/ParetoTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.search;

--- a/solver/src/test/java/org/chocosolver/solver/search/StrategyTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/search/StrategyTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.search;

--- a/solver/src/test/java/org/chocosolver/solver/search/TestMultiSequentialObjectives.java
+++ b/solver/src/test/java/org/chocosolver/solver/search/TestMultiSequentialObjectives.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.search;

--- a/solver/src/test/java/org/chocosolver/solver/search/loop/LNSTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/search/loop/LNSTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.search.loop;

--- a/solver/src/test/java/org/chocosolver/solver/search/loop/SolverTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/search/loop/SolverTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.search.loop;

--- a/solver/src/test/java/org/chocosolver/solver/search/loop/monitors/CPProfilerTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/search/loop/monitors/CPProfilerTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.search.loop.monitors;

--- a/solver/src/test/java/org/chocosolver/solver/search/loop/monitors/GephiNetworkTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/search/loop/monitors/GephiNetworkTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.search.loop.monitors;

--- a/solver/src/test/java/org/chocosolver/solver/search/restart/NoGoodOnSolutionTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/search/restart/NoGoodOnSolutionTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.search.restart;

--- a/solver/src/test/java/org/chocosolver/solver/search/restart/RestartTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/search/restart/RestartTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.search.restart;

--- a/solver/src/test/java/org/chocosolver/solver/search/strategy/decision/DecisionMakerTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/search/strategy/decision/DecisionMakerTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.search.strategy.decision;

--- a/solver/src/test/java/org/chocosolver/solver/search/strategy/decision/DecisionPathTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/search/strategy/decision/DecisionPathTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.search.strategy.decision;

--- a/solver/src/test/java/org/chocosolver/solver/search/strategy/selectors/values/IntDomainClosestTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/search/strategy/selectors/values/IntDomainClosestTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.search.strategy.selectors.values;

--- a/solver/src/test/java/org/chocosolver/solver/search/strategy/selectors/values/IntDomainMedianTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/search/strategy/selectors/values/IntDomainMedianTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.search.strategy.selectors.values;

--- a/solver/src/test/java/org/chocosolver/solver/search/strategy/selectors/values/IntDomainMiddleTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/search/strategy/selectors/values/IntDomainMiddleTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.search.strategy.selectors.values;

--- a/solver/src/test/java/org/chocosolver/solver/search/strategy/strategy/BranchingTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/search/strategy/strategy/BranchingTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.search.strategy.strategy;

--- a/solver/src/test/java/org/chocosolver/solver/search/strategy/strategy/ConflictOrderingSearchTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/search/strategy/strategy/ConflictOrderingSearchTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.search.strategy.strategy;

--- a/solver/src/test/java/org/chocosolver/solver/search/strategy/strategy/FindAndProveTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/search/strategy/strategy/FindAndProveTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.search.strategy.strategy;

--- a/solver/src/test/java/org/chocosolver/solver/search/strategy/strategy/RandomVarSelectorTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/search/strategy/strategy/RandomVarSelectorTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.search.strategy.strategy;

--- a/solver/src/test/java/org/chocosolver/solver/search/strategy/strategy/WarmStartTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/search/strategy/strategy/WarmStartTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.search.strategy.strategy;

--- a/solver/src/test/java/org/chocosolver/solver/variables/BoolNotViewTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/variables/BoolNotViewTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.variables;

--- a/solver/src/test/java/org/chocosolver/solver/variables/IntOffsetViewTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/variables/IntOffsetViewTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.variables;

--- a/solver/src/test/java/org/chocosolver/solver/variables/IntScaleViewTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/variables/IntScaleViewTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.variables;

--- a/solver/src/test/java/org/chocosolver/solver/variables/IteratorTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/variables/IteratorTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.variables;

--- a/solver/src/test/java/org/chocosolver/solver/variables/MaxViewTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/variables/MaxViewTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.variables;

--- a/solver/src/test/java/org/chocosolver/solver/variables/TaskTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/variables/TaskTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.variables;

--- a/solver/src/test/java/org/chocosolver/solver/variables/ViewMinusTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/variables/ViewMinusTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.variables;

--- a/solver/src/test/java/org/chocosolver/solver/variables/ViewSumXYTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/variables/ViewSumXYTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.variables;

--- a/solver/src/test/java/org/chocosolver/solver/variables/ViewsTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/variables/ViewsTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.variables;

--- a/solver/src/test/java/org/chocosolver/solver/variables/fast/BitsetIntVarImplTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/variables/fast/BitsetIntVarImplTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.variables.fast;

--- a/solver/src/test/java/org/chocosolver/solver/variables/fast/IntervalIntVarImplTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/variables/fast/IntervalIntVarImplTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.variables.fast;

--- a/solver/src/test/java/org/chocosolver/solver/variables/impl/AbstractGraphVarTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/variables/impl/AbstractGraphVarTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.variables.impl;

--- a/solver/src/test/java/org/chocosolver/solver/variables/impl/AbstractVariableTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/variables/impl/AbstractVariableTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.variables.impl;

--- a/solver/src/test/java/org/chocosolver/solver/variables/impl/BoolVarImplTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/variables/impl/BoolVarImplTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.variables.impl;

--- a/solver/src/test/java/org/chocosolver/solver/variables/impl/BoundedIntVarTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/variables/impl/BoundedIntVarTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.variables.impl;

--- a/solver/src/test/java/org/chocosolver/solver/variables/impl/DirectedGraphVarImplTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/variables/impl/DirectedGraphVarImplTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.variables.impl;

--- a/solver/src/test/java/org/chocosolver/solver/variables/impl/DirectedNodeInducedGraphVarImplTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/variables/impl/DirectedNodeInducedGraphVarImplTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.variables.impl;

--- a/solver/src/test/java/org/chocosolver/solver/variables/impl/EnumIntVarTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/variables/impl/EnumIntVarTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.variables.impl;

--- a/solver/src/test/java/org/chocosolver/solver/variables/impl/IntVarIntMinusViewTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/variables/impl/IntVarIntMinusViewTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.variables.impl;

--- a/solver/src/test/java/org/chocosolver/solver/variables/impl/IntVarOffSetViewTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/variables/impl/IntVarOffSetViewTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.variables.impl;

--- a/solver/src/test/java/org/chocosolver/solver/variables/impl/IntVarTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/variables/impl/IntVarTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.variables.impl;

--- a/solver/src/test/java/org/chocosolver/solver/variables/impl/SetVarImplTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/variables/impl/SetVarImplTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.variables.impl;

--- a/solver/src/test/java/org/chocosolver/solver/variables/impl/UndirectedGraphVarImplTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/variables/impl/UndirectedGraphVarImplTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.variables.impl;

--- a/solver/src/test/java/org/chocosolver/solver/variables/impl/UndirectedNodeInducedGraphVarImplTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/variables/impl/UndirectedNodeInducedGraphVarImplTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.variables.impl;

--- a/solver/src/test/java/org/chocosolver/solver/variables/view/BoolEqViewTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/variables/view/BoolEqViewTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.variables.view;

--- a/solver/src/test/java/org/chocosolver/solver/variables/view/BoolGeqViewTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/variables/view/BoolGeqViewTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.variables.view;

--- a/solver/src/test/java/org/chocosolver/solver/variables/view/BoolSetViewTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/variables/view/BoolSetViewTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.variables.view;

--- a/solver/src/test/java/org/chocosolver/solver/variables/view/graph/TestDirectedEdgeExcludedSubgraphView.java
+++ b/solver/src/test/java/org/chocosolver/solver/variables/view/graph/TestDirectedEdgeExcludedSubgraphView.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.variables.view.graph;

--- a/solver/src/test/java/org/chocosolver/solver/variables/view/graph/TestDirectedEdgeInducedSubgraphView.java
+++ b/solver/src/test/java/org/chocosolver/solver/variables/view/graph/TestDirectedEdgeInducedSubgraphView.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.variables.view.graph;

--- a/solver/src/test/java/org/chocosolver/solver/variables/view/graph/TestDirectedNodeExcludedSubgraphView.java
+++ b/solver/src/test/java/org/chocosolver/solver/variables/view/graph/TestDirectedNodeExcludedSubgraphView.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.variables.view.graph;

--- a/solver/src/test/java/org/chocosolver/solver/variables/view/graph/TestDirectedNodeInducedSubgraphView.java
+++ b/solver/src/test/java/org/chocosolver/solver/variables/view/graph/TestDirectedNodeInducedSubgraphView.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.variables.view.graph;

--- a/solver/src/test/java/org/chocosolver/solver/variables/view/graph/TestEdgeExcludedSubgraphView.java
+++ b/solver/src/test/java/org/chocosolver/solver/variables/view/graph/TestEdgeExcludedSubgraphView.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.variables.view.graph;

--- a/solver/src/test/java/org/chocosolver/solver/variables/view/graph/TestEdgeInducedSubgraphView.java
+++ b/solver/src/test/java/org/chocosolver/solver/variables/view/graph/TestEdgeInducedSubgraphView.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.variables.view.graph;

--- a/solver/src/test/java/org/chocosolver/solver/variables/view/graph/TestGraphUnionView.java
+++ b/solver/src/test/java/org/chocosolver/solver/variables/view/graph/TestGraphUnionView.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.variables.view.graph;

--- a/solver/src/test/java/org/chocosolver/solver/variables/view/graph/TestNodeExcludedSubgraphView.java
+++ b/solver/src/test/java/org/chocosolver/solver/variables/view/graph/TestNodeExcludedSubgraphView.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.variables.view.graph;

--- a/solver/src/test/java/org/chocosolver/solver/variables/view/graph/TestNodeInducedSubgraphView.java
+++ b/solver/src/test/java/org/chocosolver/solver/variables/view/graph/TestNodeInducedSubgraphView.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.variables.view.graph;

--- a/solver/src/test/java/org/chocosolver/solver/variables/view/integer/IntAffineViewTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/variables/view/integer/IntAffineViewTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.variables.view.integer;

--- a/solver/src/test/java/org/chocosolver/solver/variables/view/set/SetBoolsViewTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/variables/view/set/SetBoolsViewTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.variables.view.set;

--- a/solver/src/test/java/org/chocosolver/solver/variables/view/set/SetDifferenceViewTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/variables/view/set/SetDifferenceViewTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.variables.view.set;

--- a/solver/src/test/java/org/chocosolver/solver/variables/view/set/SetGraphNodeViewTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/variables/view/set/SetGraphNodeViewTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.variables.view.set;

--- a/solver/src/test/java/org/chocosolver/solver/variables/view/set/SetGraphPredecessorsViewTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/variables/view/set/SetGraphPredecessorsViewTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.variables.view.set;

--- a/solver/src/test/java/org/chocosolver/solver/variables/view/set/SetGraphSuccessorsViewTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/variables/view/set/SetGraphSuccessorsViewTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.variables.view.set;

--- a/solver/src/test/java/org/chocosolver/solver/variables/view/set/SetIntersectionViewTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/variables/view/set/SetIntersectionViewTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.variables.view.set;

--- a/solver/src/test/java/org/chocosolver/solver/variables/view/set/SetIntsViewTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/variables/view/set/SetIntsViewTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.variables.view.set;

--- a/solver/src/test/java/org/chocosolver/solver/variables/view/set/SetUnionViewTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/variables/view/set/SetUnionViewTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.solver.variables.view.set;

--- a/solver/src/test/java/org/chocosolver/util/CustomListener.java
+++ b/solver/src/test/java/org/chocosolver/util/CustomListener.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.util;

--- a/solver/src/test/java/org/chocosolver/util/ESatTest.java
+++ b/solver/src/test/java/org/chocosolver/util/ESatTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.util;

--- a/solver/src/test/java/org/chocosolver/util/MDDTest.java
+++ b/solver/src/test/java/org/chocosolver/util/MDDTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.util;

--- a/solver/src/test/java/org/chocosolver/util/ProblemMaker.java
+++ b/solver/src/test/java/org/chocosolver/util/ProblemMaker.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.util;

--- a/solver/src/test/java/org/chocosolver/util/bandit/PolicyTest.java
+++ b/solver/src/test/java/org/chocosolver/util/bandit/PolicyTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.util.bandit;

--- a/solver/src/test/java/org/chocosolver/util/objects/graphs/DirectedGraphTest.java
+++ b/solver/src/test/java/org/chocosolver/util/objects/graphs/DirectedGraphTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.util.objects.graphs;

--- a/solver/src/test/java/org/chocosolver/util/objects/graphs/UndirectedGraphTest.java
+++ b/solver/src/test/java/org/chocosolver/util/objects/graphs/UndirectedGraphTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.util.objects.graphs;

--- a/solver/src/test/java/org/chocosolver/util/objects/queues/CircularQueueTest.java
+++ b/solver/src/test/java/org/chocosolver/util/objects/queues/CircularQueueTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.util.objects.queues;

--- a/solver/src/test/java/org/chocosolver/util/objects/setDataStructures/backtrackable/BacktrackableSetTest.java
+++ b/solver/src/test/java/org/chocosolver/util/objects/setDataStructures/backtrackable/BacktrackableSetTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.util.objects.setDataStructures.backtrackable;

--- a/solver/src/test/java/org/chocosolver/util/objects/setDataStructures/backtrackable/BipartiteSetTest.java
+++ b/solver/src/test/java/org/chocosolver/util/objects/setDataStructures/backtrackable/BipartiteSetTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.util.objects.setDataStructures.backtrackable;

--- a/solver/src/test/java/org/chocosolver/util/objects/setDataStructures/backtrackable/BitSetTest.java
+++ b/solver/src/test/java/org/chocosolver/util/objects/setDataStructures/backtrackable/BitSetTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.util.objects.setDataStructures.backtrackable;

--- a/solver/src/test/java/org/chocosolver/util/objects/setDataStructures/backtrackable/ConstantSetsTest.java
+++ b/solver/src/test/java/org/chocosolver/util/objects/setDataStructures/backtrackable/ConstantSetsTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.util.objects.setDataStructures.backtrackable;

--- a/solver/src/test/java/org/chocosolver/util/objects/setDataStructures/backtrackable/LinkedListTest.java
+++ b/solver/src/test/java/org/chocosolver/util/objects/setDataStructures/backtrackable/LinkedListTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.util.objects.setDataStructures.backtrackable;

--- a/solver/src/test/java/org/chocosolver/util/objects/setDataStructures/backtrackable/SmallBipartiteTest.java
+++ b/solver/src/test/java/org/chocosolver/util/objects/setDataStructures/backtrackable/SmallBipartiteTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.util.objects.setDataStructures.backtrackable;

--- a/solver/src/test/java/org/chocosolver/util/objects/setDataStructures/backtrackable/SortedBitSetTest.java
+++ b/solver/src/test/java/org/chocosolver/util/objects/setDataStructures/backtrackable/SortedBitSetTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.util.objects.setDataStructures.backtrackable;

--- a/solver/src/test/java/org/chocosolver/util/objects/setDataStructures/backtrackable/StoredIntLinkedListTest.java
+++ b/solver/src/test/java/org/chocosolver/util/objects/setDataStructures/backtrackable/StoredIntLinkedListTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.util.objects.setDataStructures.backtrackable;

--- a/solver/src/test/java/org/chocosolver/util/objects/setDataStructures/iterable/IntIterableBitSetTest.java
+++ b/solver/src/test/java/org/chocosolver/util/objects/setDataStructures/iterable/IntIterableBitSetTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.util.objects.setDataStructures.iterable;

--- a/solver/src/test/java/org/chocosolver/util/objects/setDataStructures/iterable/IntIterableRangeSetTest.java
+++ b/solver/src/test/java/org/chocosolver/util/objects/setDataStructures/iterable/IntIterableRangeSetTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.util.objects.setDataStructures.iterable;

--- a/solver/src/test/java/org/chocosolver/util/objects/setDataStructures/nonbacktrackable/BipartiteSetTest.java
+++ b/solver/src/test/java/org/chocosolver/util/objects/setDataStructures/nonbacktrackable/BipartiteSetTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.util.objects.setDataStructures.nonbacktrackable;

--- a/solver/src/test/java/org/chocosolver/util/objects/setDataStructures/nonbacktrackable/BitSetTest.java
+++ b/solver/src/test/java/org/chocosolver/util/objects/setDataStructures/nonbacktrackable/BitSetTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.util.objects.setDataStructures.nonbacktrackable;

--- a/solver/src/test/java/org/chocosolver/util/objects/setDataStructures/nonbacktrackable/ConstantSetTest.java
+++ b/solver/src/test/java/org/chocosolver/util/objects/setDataStructures/nonbacktrackable/ConstantSetTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.util.objects.setDataStructures.nonbacktrackable;

--- a/solver/src/test/java/org/chocosolver/util/objects/setDataStructures/nonbacktrackable/IntervalSetTest.java
+++ b/solver/src/test/java/org/chocosolver/util/objects/setDataStructures/nonbacktrackable/IntervalSetTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.util.objects.setDataStructures.nonbacktrackable;

--- a/solver/src/test/java/org/chocosolver/util/objects/setDataStructures/nonbacktrackable/LinkedListTest.java
+++ b/solver/src/test/java/org/chocosolver/util/objects/setDataStructures/nonbacktrackable/LinkedListTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.util.objects.setDataStructures.nonbacktrackable;

--- a/solver/src/test/java/org/chocosolver/util/objects/setDataStructures/nonbacktrackable/RangeSetTest.java
+++ b/solver/src/test/java/org/chocosolver/util/objects/setDataStructures/nonbacktrackable/RangeSetTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.util.objects.setDataStructures.nonbacktrackable;

--- a/solver/src/test/java/org/chocosolver/util/objects/setDataStructures/nonbacktrackable/SetDifferenceTest.java
+++ b/solver/src/test/java/org/chocosolver/util/objects/setDataStructures/nonbacktrackable/SetDifferenceTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.util.objects.setDataStructures.nonbacktrackable;

--- a/solver/src/test/java/org/chocosolver/util/objects/setDataStructures/nonbacktrackable/SetDynamicFilterTest.java
+++ b/solver/src/test/java/org/chocosolver/util/objects/setDataStructures/nonbacktrackable/SetDynamicFilterTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.util.objects.setDataStructures.nonbacktrackable;

--- a/solver/src/test/java/org/chocosolver/util/objects/setDataStructures/nonbacktrackable/SetIntersectionTest.java
+++ b/solver/src/test/java/org/chocosolver/util/objects/setDataStructures/nonbacktrackable/SetIntersectionTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.util.objects.setDataStructures.nonbacktrackable;

--- a/solver/src/test/java/org/chocosolver/util/objects/setDataStructures/nonbacktrackable/SetTest.java
+++ b/solver/src/test/java/org/chocosolver/util/objects/setDataStructures/nonbacktrackable/SetTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.util.objects.setDataStructures.nonbacktrackable;

--- a/solver/src/test/java/org/chocosolver/util/objects/setDataStructures/nonbacktrackable/SetUnionTest.java
+++ b/solver/src/test/java/org/chocosolver/util/objects/setDataStructures/nonbacktrackable/SetUnionTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.util.objects.setDataStructures.nonbacktrackable;

--- a/solver/src/test/java/org/chocosolver/util/objects/setDataStructures/nonbacktrackable/SmallBipartiteTest.java
+++ b/solver/src/test/java/org/chocosolver/util/objects/setDataStructures/nonbacktrackable/SmallBipartiteTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.util.objects.setDataStructures.nonbacktrackable;

--- a/solver/src/test/java/org/chocosolver/util/tools/ArrayUtilsTest.java
+++ b/solver/src/test/java/org/chocosolver/util/tools/ArrayUtilsTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.util.tools;

--- a/solver/src/test/java/org/chocosolver/util/tools/MathUtilsTest.java
+++ b/solver/src/test/java/org/chocosolver/util/tools/MathUtilsTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.util.tools;

--- a/solver/src/test/java/org/chocosolver/util/tools/PreProcessingTest.java
+++ b/solver/src/test/java/org/chocosolver/util/tools/PreProcessingTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.util.tools;

--- a/solver/src/test/java/org/chocosolver/util/tools/RealUtilsTest.java
+++ b/solver/src/test/java/org/chocosolver/util/tools/RealUtilsTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.util.tools;

--- a/solver/src/test/java/org/chocosolver/util/tools/VariableUtilsTest.java
+++ b/solver/src/test/java/org/chocosolver/util/tools/VariableUtilsTest.java
@@ -1,10 +1,7 @@
 /*
  * This file is part of choco-solver, http://choco-solver.org/
- *
- * Copyright (c) 2026, IMT Atlantique. All rights reserved.
- *
- * Licensed under the BSD 4-clause license.
- *
+ * Copyright (c) 1999, IMT Atlantique.
+ * SPDX-License-Identifier: BSD-3-Clause.
  * See LICENSE file in the project root for full license information.
  */
 package org.chocosolver.util.tools;


### PR DESCRIPTION
Fixes #1169.

Changes proposed in this PR:
- move to BSD-3-Clause

The two files to look at are:
- /etc/header.txt
- LICENSE
 
I also declare the inception year (1999) in the pom.xml.

The other ones are just side effects of the modification.

@chocoteam/core-developer 
