### PR TITLE
Add a parameter to extract nogood from variables

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,7 @@ NEXT MILESTONE
 #### Constraints & LCG
 - Faster modulo constraints with bounded variables
 - Fix modulo constraint with negative values
+- Add `lcgExtractFromVariablesOnSolution` setting to control whether the solution-forbidding clause is built from variable assignments (true) or from the decision path (false, default)
 
 ### Deprecated API (to be removed in next release):
 

--- a/solver/src/main/java/org/chocosolver/solver/Settings.java
+++ b/solver/src/main/java/org/chocosolver/solver/Settings.java
@@ -92,6 +92,8 @@ public class Settings {
 
     private final int satCCMinMode;
 
+    private final boolean lcgExtractFromVariablesOnSolution;
+
     private final Supplier<IEnvironment> environmentSupplier;
 
     protected Settings(SettingsBuilder builder) {
@@ -125,6 +127,7 @@ public class Settings {
         this.reasonManager = builder.getReasonManager();
         this.sortLitsOnSolution = builder.sortLitsOnSolution();
         this.satCCMinMode = builder.getSatCCMinMode();
+        this.lcgExtractFromVariablesOnSolution = builder.lcgExtractFromVariablesOnSolution();
         this.environmentSupplier = builder.getEnvironmentSupplier();
         this.additionalSettings = new HashMap<>(builder.getAdditionalSettings());
     }
@@ -328,6 +331,14 @@ public class Settings {
      */
     public int getSatCCMinMode() {
         return this.satCCMinMode;
+    }
+
+    /**
+     * @return true if the clause generated on a solution is built from the current variable assignments,
+     * false if it is built from the decisions taken in the search tree (default is false).
+     */
+    public boolean lcgExtractFromVariablesOnSolution() {
+        return this.lcgExtractFromVariablesOnSolution;
     }
 
     /**

--- a/solver/src/main/java/org/chocosolver/solver/SettingsBuilder.java
+++ b/solver/src/main/java/org/chocosolver/solver/SettingsBuilder.java
@@ -248,6 +248,13 @@ public class SettingsBuilder {
                     "When set to 2, recursive minimization is applied (default is 0).")
     private int satCCMinMode = 0;
 
+    public static final String LCG_EXTRACT_FROM_VARIABLES_ON_SOLUTION = "lcgExtractFromVariablesOnSolution";
+    @Option(name = "--lcgExtractFromVariablesOnSolution",
+            aliases = {"--model.lcg.extractFromVariables", "-lcgefvos"},
+            usage = "when true, the clause generated on a solution is built from the current variable assignments. " +
+                    "when false (default), the clause is built from the decisions taken in the search tree.")
+    private boolean lcgExtractFromVariablesOnSolution = false;
+
     public static final String ENVIRONMENT_SUPPLIER = "environmentSupplier";
     private Supplier<IEnvironment> environmentSupplier = () -> new EnvironmentBuilder().fromFlat().build();
 
@@ -420,6 +427,9 @@ public class SettingsBuilder {
                     break;
                 case SAT_CC_MIN_MODE:
                     this.setSatCCMinMode(Integer.parseInt(value));
+                    break;
+                case LCG_EXTRACT_FROM_VARIABLES_ON_SOLUTION:
+                    this.setLcgExtractFromVariablesOnSolution(Boolean.parseBoolean(value));
                     break;
                 default:
                     this.set(key, value);
@@ -957,6 +967,26 @@ public class SettingsBuilder {
      */
     public int getSatCCMinMode() {
         return this.satCCMinMode;
+    }
+
+    /**
+     * Set whether the clause generated on a solution is built from the current variable assignments (true)
+     * or from the decisions taken in the search tree (false, default).
+     *
+     * @param lcgExtractFromVariablesOnSolution true to extract from variables, false to extract from decisions
+     * @return the current instance
+     */
+    public SettingsBuilder setLcgExtractFromVariablesOnSolution(boolean lcgExtractFromVariablesOnSolution) {
+        this.lcgExtractFromVariablesOnSolution = lcgExtractFromVariablesOnSolution;
+        return this;
+    }
+
+    /**
+     * @return true if the clause generated on a solution is built from the current variable assignments,
+     * false if it is built from the decisions taken in the search tree (default is false).
+     */
+    public boolean lcgExtractFromVariablesOnSolution() {
+        return this.lcgExtractFromVariablesOnSolution;
     }
 
     /**

--- a/solver/src/main/java/org/chocosolver/solver/search/loop/learn/LazyClauseGeneration.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/loop/learn/LazyClauseGeneration.java
@@ -69,6 +69,7 @@ public class LazyClauseGeneration implements Learn {
     private final long reduceBase;
     private final long reduceFactor;
     private int reductions = 0;
+    private boolean extractFromVariablesOnSolution;
     /**
      * A temporary storage for learnt clauses.
      */
@@ -83,6 +84,7 @@ public class LazyClauseGeneration implements Learn {
         this.reduceBase = solver.getModel().getSettings().getReduceLearntClausesBase();
         this.reduceFactor = solver.getModel().getSettings().getReduceLearntClausesFactor();
         this.nextReductionCall = reduceBase;
+        this.extractFromVariablesOnSolution = solver.getModel().getSettings().lcgExtractFromVariablesOnSolution();
     }
 
     @Override
@@ -137,8 +139,11 @@ public class LazyClauseGeneration implements Learn {
         assert mSat.confl == MiniSat.C_Undef;
         if (!mSolver.getObjectiveManager().isOptimization()) {
             learnt_clause.resetQuick();
-            extractFromVariables();
-            //extractFromDecisions();
+            if (extractFromVariablesOnSolution) {
+                extractFromVariables();
+            } else {
+                extractFromDecisions();
+            }
 
             mSat.confl = new ArrayClause(learnt_clause, false /*?*/);
             int backtrack_level = analyze(mSolver.getContradictionException().set(Cause.Sat, null, null), ON_SOLUTION);
@@ -161,7 +166,6 @@ public class LazyClauseGeneration implements Learn {
         }
     }
 
-    @SuppressWarnings("unused")
     private void extractFromDecisions() {
         //todo deal with LazyLit
         DecisionPath path = mSolver.getDecisionPath();

--- a/solver/src/main/java/org/chocosolver/solver/search/loop/learn/LazyClauseGeneration.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/loop/learn/LazyClauseGeneration.java
@@ -182,7 +182,12 @@ public class LazyClauseGeneration implements Learn {
                 IntVar var = dec.getDecisionVariable();
                 if (dec.getDecOp().equals(DecisionOperatorFactory.makeIntEq())) {
                     if (dec.hasNext() || dec.getArity() == 1) {
-                        learnt_clause.add(var.getLit(dec.getDecisionValue(), IntVar.LR_NE));
+                        if (var.hasEnumeratedDomain()) {
+                            learnt_clause.add(var.getLit(dec.getDecisionValue(), IntVar.LR_NE));
+                        } else {
+                            learnt_clause.add(var.getLit(dec.getDecisionValue() - 1, IntVar.LR_LE));
+                            learnt_clause.add(var.getLit(dec.getDecisionValue() + 1, IntVar.LR_GE));
+                        }
                     } else {
                         learnt_clause.add(var.getLit(dec.getDecisionValue(), IntVar.LR_EQ));
                     }
@@ -190,7 +195,12 @@ public class LazyClauseGeneration implements Learn {
                     if (dec.hasNext() || dec.getArity() == 1) {
                         learnt_clause.add(var.getLit(dec.getDecisionValue(), IntVar.LR_EQ));
                     } else {
-                        learnt_clause.add(var.getLit(dec.getDecisionValue(), IntVar.LR_NE));
+                        if (var.hasEnumeratedDomain()) {
+                            learnt_clause.add(var.getLit(dec.getDecisionValue(), IntVar.LR_NE));
+                        } else {
+                            learnt_clause.add(var.getLit(dec.getDecisionValue() - 1, IntVar.LR_LE));
+                            learnt_clause.add(var.getLit(dec.getDecisionValue() + 1, IntVar.LR_GE));
+                        }
                     }
                 } else if (dec.getDecOp().equals(DecisionOperatorFactory.makeIntSplit())) { // <=
                     if (dec.hasNext() || dec.getArity() == 1) {


### PR DESCRIPTION
Add `lcgExtractFromVariablesOnSolution` setting to control whether the solution-forbidding clause is built from variable assignments (true) or from the decision path (false, default)