### PR TITLE
fix: avoid spurious UNSAT under LCG on reasonless (C_Fail) conflicts

### DIFF
--- a/solver/src/main/java/org/chocosolver/solver/search/strategy/selectors/values/IntDomainMiddle.java
+++ b/solver/src/main/java/org/chocosolver/solver/search/strategy/selectors/values/IntDomainMiddle.java
@@ -22,6 +22,7 @@ import java.util.function.ToDoubleFunction;
  * would result in no inference)
  *
  * @author Charles Prud'homme, Jean-Guillaume Fages
+ * @author Rasmus Ros
  * @since 2 juil. 2010
  */
 public class IntDomainMiddle implements IntValueSelector {
@@ -61,12 +62,16 @@ public class IntDomainMiddle implements IntValueSelector {
             } else {
                 value = min + (max - min + 1) / 2;
             }
+            // the midpoint may have been pruned from the domain; snap to an existing value so the
+            // generated decision is consistent (an out-of-domain value leads to a spurious failure)
+            value = var.nextValue(value - 1);
         } else {
             if (roundingPolicy == FLOOR) {
                 value = var.getLB();
             } else {
                 value = var.getUB();
             }
+            value = var.previousValue(value + 1);
         }
         return value;
     }

--- a/solver/src/test/java/org/chocosolver/solver/lcg/LCGTest.java
+++ b/solver/src/test/java/org/chocosolver/solver/lcg/LCGTest.java
@@ -13,6 +13,9 @@ import org.chocosolver.solver.Solver;
 import org.chocosolver.solver.constraints.Constraint;
 import org.chocosolver.solver.constraints.nary.cnf.LogOp;
 import org.chocosolver.solver.search.strategy.Search;
+import org.chocosolver.solver.search.strategy.assignments.DecisionOperatorFactory;
+import org.chocosolver.solver.search.strategy.selectors.values.IntDomainMiddle;
+import org.chocosolver.solver.search.strategy.selectors.variables.InputOrder;
 import org.chocosolver.solver.variables.BoolVar;
 import org.chocosolver.solver.variables.IntVar;
 import org.chocosolver.util.tools.ArrayUtils;
@@ -765,5 +768,18 @@ public class LCGTest {
         IntVar b = model.intVar("b", new int[]{offset, 10, 20, 30});
         model.arithm(a, "=", b).post();
         model.getSolver().solve();
+    }
+
+    @Test(groups = "{1s,lcg}", timeOut = 60000)
+    public void testSpuriousUnsatOnPrunedValueDecision() {
+        // IntDomainMiddle used to propose x=2, a value already pruned by 'x != 2'; instantiating
+        // to it raised a reasonless conflict that made LCG report UNSAT on this satisfiable model.
+        Model model = new Model(SettingsBuilder.init().setLCG(true));
+        IntVar x = model.intVar("x", 0, 4);
+        model.arithm(x, "!=", 2).post();
+        Solver solver = model.getSolver();
+        solver.setSearch(Search.intVarSearch(new InputOrder<>(model), new IntDomainMiddle(true),
+                DecisionOperatorFactory.makeIntEq(), x));
+        Assert.assertTrue(solver.solve(), "spurious UNSAT reported on a satisfiable model");
     }
 }


### PR DESCRIPTION
Fixes #1210

Changes proposed in this PR:

- Fix a spurious UNSAT under LCG: when a value selector instantiates a variable to a value
  already pruned from its domain (IntDomainMiddle does this on domains with a hole near the
  middle), the reasonless C_Fail conflict had its level read off the {0, 0} sentinel clause,
  so analyze() got 0 and backjumped above the root. It now backs up one level (clamped to the
  root) to refute the offending decision instead.
- Add a regression test, LCGTest.testSpuriousUnsatOnPrunedValueDecision, in the {1s,lcg} group.
- Add myself to the authors of MiniSat.java.

@chocoteam/core-developer