### PR TITLE
Fix issue #1175

### DIFF
--- a/solver/src/main/java/org/chocosolver/util/objects/setDataStructures/bitset/Set_Std_BitSet.java
+++ b/solver/src/main/java/org/chocosolver/util/objects/setDataStructures/bitset/Set_Std_BitSet.java
@@ -29,7 +29,6 @@ public class Set_Std_BitSet extends AbstractSet implements ISet.WithOffset {
 	private final IStateInt card;	// enables to get the cardinality in O(1)
 	private final int offset;		// allow using negative numbers
 	private final S64BitSet values;
-	private final ISetIterator iter = newIterator();
 
 	//***********************************************************************************
 	// CONSTRUCTOR
@@ -120,8 +119,7 @@ public class Set_Std_BitSet extends AbstractSet implements ISet.WithOffset {
 
 	@Override
 	public ISetIterator iterator(){
-		iter.reset();
-		return iter;
+		return newIterator();
 	}
 
 	@Override

--- a/solver/src/main/java/org/chocosolver/util/objects/setDataStructures/constant/Set_CstInterval.java
+++ b/solver/src/main/java/org/chocosolver/util/objects/setDataStructures/constant/Set_CstInterval.java
@@ -24,7 +24,6 @@ public class Set_CstInterval implements ISet {
 
 	private final int lb;
     private final int ub;
-	private final ISetIterator iter = newIterator();
 
 	//***********************************************************************************
 	// CONSTRUCTORS
@@ -115,8 +114,7 @@ public class Set_CstInterval implements ISet {
 
 	@Override
 	public ISetIterator iterator(){
-		iter.reset();
-		return iter;
+		return newIterator();
 	}
 
 	@Override

--- a/solver/src/main/java/org/chocosolver/util/objects/setDataStructures/constant/Set_FixedArray.java
+++ b/solver/src/main/java/org/chocosolver/util/objects/setDataStructures/constant/Set_FixedArray.java
@@ -26,7 +26,6 @@ public class Set_FixedArray implements ISet {
 
 	protected final int size;
 	protected final int[] values;
-	protected ISetIterator iter = newIterator();
 
 	//***********************************************************************************
 	// CONSTRUCTOR
@@ -102,14 +101,13 @@ public class Set_FixedArray implements ISet {
 
 	@Override
 	public ISetIterator iterator(){
-		iter.reset();
-		return iter;
+		return newIterator();
 	}
 
 	@Override
 	public ISetIterator newIterator(){
 		return new ISetIterator() {
-			private int idx;
+			private int idx = 0;
 			@Override
 			public void reset() {
 				idx = 0;

--- a/solver/src/main/java/org/chocosolver/util/objects/setDataStructures/iterable/IntIterableRangeSet.java
+++ b/solver/src/main/java/org/chocosolver/util/objects/setDataStructures/iterable/IntIterableRangeSet.java
@@ -55,11 +55,6 @@ public class IntIterableRangeSet extends AbstractSet implements IntIterableSet {
     protected int CARDINALITY;
 
     /**
-     * Create an ISet iterator
-     */
-    private ISetIterator iter;
-
-    /**
      * Every public method must preserve these invariants.
      */
     private void checkInvariants() {
@@ -772,11 +767,7 @@ public class IntIterableRangeSet extends AbstractSet implements IntIterableSet {
 
     @Override
     public ISetIterator iterator() {
-        if (iter == null) {
-            iter = newIterator();
-        }
-        iter.reset();
-        return iter;
+        return newIterator();
     }
 
     /**

--- a/solver/src/test/java/org/chocosolver/util/objects/setDataStructures/iterable/ISetIteratorTest.java
+++ b/solver/src/test/java/org/chocosolver/util/objects/setDataStructures/iterable/ISetIteratorTest.java
@@ -1,0 +1,78 @@
+package org.chocosolver.util.objects.setDataStructures.iterable;
+
+import org.chocosolver.solver.Model;
+import org.chocosolver.util.objects.setDataStructures.ISet;
+import org.chocosolver.util.objects.setDataStructures.bitset.Set_BitSet;
+import org.chocosolver.util.objects.setDataStructures.bitset.Set_Std_BitSet;
+import org.chocosolver.util.objects.setDataStructures.constant.Set_CstInterval;
+import org.chocosolver.util.objects.setDataStructures.constant.Set_FixedArray;
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+public class ISetIteratorTest {
+    @DataProvider()
+    public Object[][] collect() {
+        Model model = new Model();
+
+        ISet set = new Set_BitSet(0);
+        set.add(1);
+        set.add(2);
+        set.add(3);
+        set.add(4);
+        ISet set2 = new Set_Std_BitSet(model.getEnvironment(), 0);
+        set2.add(1);
+        set2.add(2);
+        set2.add(3);
+        set2.add(4);
+        ISet set3 = new Set_CstInterval(1, 4);
+        ISet set4 = new Set_FixedArray(new int[]{1, 2, 3, 4});
+        ISet set5 = new IntIterableRangeSet(new int[]{1, 2, 3, 4});
+        ISet set6 = new Set_BitSet(0);
+        set6.add(2);
+        set6.add(3);
+        set6.add(5);
+        set6.add(6);
+        set6.add(11);
+        ISet set7 = new Set_Std_BitSet(model.getEnvironment(), 0);
+        set7.add(2);
+        set7.add(3);
+        set7.add(5);
+        set7.add(6);
+        set7.add(11);
+        ISet set8 = new Set_FixedArray(new int[]{2, 3, 5, 6, 11});
+        ISet set9 = new IntIterableRangeSet(new int[]{2, 3, 5, 6, 11});
+        return new Object[][]{
+                {set, "Set_BitSet", RESULT1},
+                {set2, "Set_Std_BitSet", RESULT1},
+                {set3, "Set_CstInterval", RESULT1},
+                {set4, "Set_FixedArray", RESULT1},
+                {set5, "IntIterableRangeSet", RESULT1},
+                {set6, "Set_BitSet", RESULT2},
+                {set7, "Set_Std_BitSet", RESULT2},
+                {set8, "Set_FixedArray", RESULT2},
+                {set9, "IntIterableRangeSet", RESULT2}
+        };
+    }
+
+    private static final String RESULT1 = "(1,1)(1,2)(1,3)(1,4)" +
+                                          "(2,1)(2,2)(2,3)(2,4)" +
+                                          "(3,1)(3,2)(3,3)(3,4)" +
+                                          "(4,1)(4,2)(4,3)(4,4)";
+    private static final String RESULT2 = "(2,2)(2,3)(2,5)(2,6)(2,11)" +
+                                          "(3,2)(3,3)(3,5)(3,6)(3,11)" +
+                                          "(5,2)(5,3)(5,5)(5,6)(5,11)" +
+                                          "(6,2)(6,3)(6,5)(6,6)(6,11)" +
+                                          "(11,2)(11,3)(11,5)(11,6)(11,11)";
+
+    @Test(groups = "1s", dataProvider = "collect")
+    public void testSetIterator(ISet set, String type, String result) {
+        StringBuilder sb = new StringBuilder();
+        for (int v : set) {
+            for (int w : set) {
+                sb.append(String.format("(%d,%d)", v, w));
+            }
+        }
+        Assert.assertEquals(sb.toString(), result);
+    }
+}


### PR DESCRIPTION
The changes in this Pull Request modify the implementations of `ISetIterator`.

On the one hand, it allows two things : 
- Imbricated for-each loop work correctly for `ISetIterator`
- `ISetIterator` now respects the contract of `Iterator` (which is the independency of iterators on a given `Iterable` object)

On the other hand, it changes the fundamental philosophy of reusable iterators (not relying too much on the Garbage Collector).

That being said, I didn't find any existing solution in Java to know if an `Iterator` is being used, which makes impossible to solve the problem of imbricated for-each loop with reusable iterators. Therefore, we have two possibilities : 
- Changing the implementations as done in this PR
- Refusing this PR and well document the fact that for-each loop would not work correctly if imbricated for ISetIterator (or that `newIterator()` function should be specifically used instead, but it breaks the ease of visibility offered by for-each loops)

Let note that many `ISetIterator` implementations rely on a unique integer (basically an index), which should not give too much work to the GC. Furthermore, it is very similar to the implementations of `Iterator<T>` of `List<T>` in the JDK (at least the implementation Eclipse Temurin), and therefore we can expect it is a hehaviour for which the JVM is well-trained/implemented and we should not have too much impact on performance (I found none significant on small examples, but it might be interesting to monitor performance on a diverse family of problems and instance sizes (such as XCSP or MiniZinc) to confirm it).