### PR TITLE
Fix integer overflow when composing nested affine views

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,28 +9,10 @@ This file is dedicated to sum up the new features added and bugs fixed in Choco-
 
 ### Major features:
 
-#### Constraints & LCG
-- Improved `element` constraint: new propagator for bounded result variables and optimized handling of large arrays with repeated values
-- Improved `modulo` constraint: faster propagation for both binary and ternary cases; fixed handling of negative values in expressions and `mod` with negatives
-- Improved `div` constraint (`PropDivXYZ`): better filtering based on sign analysis of variables
-- LCG: added `extractFromVariables` setting to extract nogoods from variable domains (rather than decision path) on solution (#1193)
-- Fixed `PropModXY` incorrect filtering
-- Fixed `PropElementIn` propagator
-- Fixed `SparseBitSet.prevClearBit()` and unified its implementation with `nextClearBit()`
-
-#### Build, CI & Tooling
-- Migrated build and GitHub Actions CI to Java 17
-- Upgraded ANTLR from 4.9.3 to 4.13.2, TestNG from 7.5.1 to 7.12.0, and args4j from 2.33 to 2.37
-- Bumped jgrapht, sizeof, slf4j, and Maven plugin versions
-- Moved `slf4j-nop` to test scope to avoid classpath conflicts in applications depending on choco-solver
-- Centralized dependency versions in POM properties and cleaned up redundant POM configuration
-- Updated release scripts and changelog generation tooling
-
-### Other closed issues and pull requests:
-- #1193: Add a parameter to extract nogoods from variables on solution (LCG)
+#### Constraints
+- Fix PropModXY in case of negative mod
 
 #### Contributors to this release:
-- Arthur Godet <arth.godet@gmail.com>
 - Charles Prud'homme <charles.prudhomme@imt-atlantique.fr>
 - Jean-Guillaume Fages <jg.fages@cosling.com>
 


### PR DESCRIPTION
Fixes #1244.

`IViewFactory#intView` flattens a nested affine view by composing the coefficients in `int` arithmetic:

```java
int av = (view.p ? 1 : -1) * view.a * a;
int bv = a * view.b + b;
```

Either product can leave the `int` range even when every value the expression can take is small. In the reported case, `x` ranges over `[46341, 46342]` and the composed expression is at most `46341`, but flattening `(x - 46341) * 46341` computes `bv` as `46341 * -46341 = -2147488281`, which underflows and wraps to `+2147479015`. The view built from that is wrong in both directions: a valid solution is pruned and the model reported unsatisfiable, and an assignment that violates the posted constraint is returned as a solution.

Changes proposed in this PR:
- Compose the coefficients in `long` and keep the nested view when either does not fit in an `int`, falling back to the `new IntAffineView<>(var, a, b)` construction the non-flattening branch already used. No new view type is needed and views stay enabled.
- Add two regression tests to `IntAffineViewTest`, one per direction reported in the issue.
- Add myself to the authors of both modified classes, as CONTRIBUTING asks.

On scope: the issue also suggests guarding the scaled bounds of the base variable, in addition to the coefficients. I left that out. It only changes behaviour when `av` and `bv` both fit but `av * base` does not, and in that situation this patch and the current code take the same branch, so I could not write a test that distinguishes them. I would rather not add a condition with no regression test behind it. Worth noting if you do want it covered: `getLB()` and `getUB()` compute `(...) * a + b` as a single `int` expression, so an overflowing intermediate cancels there and the bound is still correct; `contains()` is the one that would suffer, because it does `value -= b` and then divides, and the division does not undo the wrap. Happy to add it if you would like it handled.

I did not touch `CHANGES.md`, since there is no unreleased section to add to.

Verified with a negative control: reverting only `IViewFactory.java` and keeping the tests fails exactly the two new tests out of 150 in the class, with `expected [true] but found [false]` for the pruned solution and `expected [46342] but found [46341]` for the invalid one. Restoring the fix passes all 150.

@chocoteam/core-developer
